### PR TITLE
feat: SCOPE P1 batch — tenancy audit, event types, GEDCOM validation, timelines, gender fix

### DIFF
--- a/app/Console/Commands/MatchKitsCommand.php
+++ b/app/Console/Commands/MatchKitsCommand.php
@@ -36,6 +36,11 @@ class MatchKitsCommand extends Command
             return;
         }
 
+        // Command runs unauthenticated, so BelongsToTenant can't auto-assign team_id.
+        // dna1 is the base kit (its user is the match owner), so key the row to that
+        // user's current team. Null if the owner has no current team (fail-closed).
+        $teamId = $dna1->user?->current_team_id;
+
         try {
             // Use advanced DNA matching service
             $matchResult = $this->advancedDnaMatchingService->performAdvancedMatching(
@@ -47,6 +52,7 @@ class MatchKitsCommand extends Command
 
             // Store the match result in database
             DnaMatching::create([
+                'team_id'            => $teamId,
                 'file1'              => $fileName1,
                 'file2'              => $fileName2,
                 'image'              => 'path/to/match/image.png', // Will be updated with actual visualization
@@ -66,6 +72,7 @@ class MatchKitsCommand extends Command
             $largestCmSegment = random_int(1, $totalSharedCm);
 
             DnaMatching::create([
+                'team_id'            => $teamId,
                 'file1'              => $fileName1,
                 'file2'              => $fileName2,
                 'image'              => 'path/to/match/image.png',

--- a/app/Enums/EventType.php
+++ b/app/Enums/EventType.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Enumerated genealogy event types.
+ *
+ * The backing value is the stored value: a GEDCOM 5.5.1 tag where one exists.
+ * In this app the event type is stored in the events' `title` column (see
+ * Event::getTitle() / PersonEvent::$gedcom_event_names / EventsService), not the
+ * `type` column, which is GEDCOM's free-text TYPE sub-qualifier.
+ *
+ * ponytail: military has no standard GEDCOM 5.5.1 event tag; `_MILT` is the
+ * de-facto custom tag genealogy tools use. Swap it if the import layer settles
+ * on a different one.
+ */
+enum EventType: string
+{
+    // Person-level events.
+    case Birth = 'BIRT';
+    case Baptism = 'BAPM';
+    case Death = 'DEAT';
+    case Burial = 'BURI';
+    case Immigration = 'IMMI';
+    case Census = 'CENS';
+    case Military = '_MILT';
+    case Occupation = 'OCCU';
+
+    // Family-level events.
+    case Marriage = 'MARR';
+    case Divorce = 'DIV';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Birth => 'Birth',
+            self::Baptism => 'Baptism',
+            self::Death => 'Death',
+            self::Burial => 'Burial',
+            self::Immigration => 'Immigration',
+            self::Census => 'Census',
+            self::Military => 'Military Service',
+            self::Occupation => 'Occupation',
+            self::Marriage => 'Marriage',
+            self::Divorce => 'Divorce',
+        };
+    }
+
+    /** Family-level events belong on FamilyEvent; everything else is person-level. */
+    public function isFamily(): bool
+    {
+        return in_array($this, [self::Marriage, self::Divorce], true);
+    }
+
+    /** @return list<self> */
+    public static function personCases(): array
+    {
+        return array_values(array_filter(self::cases(), fn (self $c): bool => ! $c->isFamily()));
+    }
+
+    /** @return list<self> */
+    public static function familyCases(): array
+    {
+        return array_values(array_filter(self::cases(), fn (self $c): bool => $c->isFamily()));
+    }
+
+    /**
+     * value => label map for a Filament Select ->options(). Pass a subset
+     * (e.g. self::personCases()) to scope it; defaults to every case.
+     *
+     * @param  list<self>|null  $cases
+     * @return array<string, string>
+     */
+    public static function options(?array $cases = null): array
+    {
+        $cases ??= self::cases();
+
+        $options = [];
+        foreach ($cases as $case) {
+            $options[$case->value] = $case->label();
+        }
+
+        return $options;
+    }
+
+    /** @return list<string> backing (stored) values */
+    public static function values(): array
+    {
+        return array_map(fn (self $c): string => $c->value, self::cases());
+    }
+}

--- a/app/Filament/App/Resources/FamilyEventResource.php
+++ b/app/Filament/App/Resources/FamilyEventResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\App\Resources;
 
 use Override;
+use App\Enums\EventType;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Tables\Columns\TextColumn;
@@ -53,8 +55,20 @@ class FamilyEventResource extends AppResource
                 Textarea::make('date')
                     ->maxLength(65535)
                     ->columnSpanFull(),
-                TextInput::make('title')
-                    ->maxLength(255),
+                // Event type is stored in `title` (see Event::getTitle / EventsService).
+                // family_events has no `type` column (commented out in its create migration),
+                // so `title` is the only type field. ponytail: constrained input, no enum cast.
+                Select::make('title')
+                    ->label('Event Type')
+                    // Preserve an off-list legacy title on edit (see PersonEventResource).
+                    ->options(function ($record): array {
+                        $options = EventType::options(EventType::familyCases());
+                        if ($record && $record->title && ! array_key_exists($record->title, $options)) {
+                            $options[$record->title] = $record->title;
+                        }
+                        return $options;
+                    })
+                    ->searchable(),
                 Textarea::make('description')
                     ->maxLength(65535)
                     ->columnSpanFull(),

--- a/app/Filament/App/Resources/PersonEventResource.php
+++ b/app/Filament/App/Resources/PersonEventResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\App\Resources;
 
 use Override;
+use App\Enums\EventType;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Tables\Columns\TextColumn;
@@ -76,8 +78,22 @@ class PersonEventResource extends AppResource
                     ->maxLength(255),
                 TextInput::make('person_id')
                     ->numeric(),
-                TextInput::make('title')
-                    ->maxLength(255),
+                // Event type is stored in `title` (see Event::getTitle / EventsService).
+                // ponytail: constrained Select, not a strict cast — legacy imports hold
+                // GEDCOM tags beyond these 10, and a backed-enum cast would ValueError on read.
+                Select::make('title')
+                    ->label('Event Type')
+                    // Merge the record's own value in when it isn't one of the 10 enum
+                    // types (legacy GEDCOM imports), so editing an existing event can't
+                    // silently blank a valid-but-off-list title on save.
+                    ->options(function ($record): array {
+                        $options = EventType::options(EventType::personCases());
+                        if ($record && $record->title && ! array_key_exists($record->title, $options)) {
+                            $options[$record->title] = $record->title;
+                        }
+                        return $options;
+                    })
+                    ->searchable(),
                 TextInput::make('date')
                     ->maxLength(255),
                 TextInput::make('description')

--- a/app/Filament/App/Resources/PersonResource.php
+++ b/app/Filament/App/Resources/PersonResource.php
@@ -72,10 +72,7 @@ class PersonResource extends AppResource
                         TextInput::make('appellative')->label('Appellative'),
                         TextInput::make('name')->label('Full Name'),
                         Select::make('sex')
-                            ->options([
-                                'M' => 'Male',
-                                'F' => 'Female',
-                            ])
+                            ->options(Person::SEX_OPTIONS)
                             ->label('Sex'),
                         TextInput::make('description')->label('Description')->columnSpanFull(),
                     ]),
@@ -139,10 +136,7 @@ class PersonResource extends AppResource
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('sex')
-                    ->options([
-                        'M' => 'Male',
-                        'F' => 'Female',
-                    ]),
+                    ->options(Person::SEX_OPTIONS),
             ])
             ->recordActions([
                 EditAction::make(),

--- a/app/Jobs/ImportGedcom.php
+++ b/app/Jobs/ImportGedcom.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Models\ImportJob;
 use App\Models\User;
+use App\Services\GedcomService;
 use Artisan;
 use Exception;
 use FamilyTree365\LaravelGedcom\Utils\GedcomParser;
@@ -54,6 +55,21 @@ class ImportGedcom implements ShouldQueue
             throw_unless(File::isFile($this->filePath), Exception::class, "{$this->filePath} does not exist.");
 
             $importJob->update(['progress' => 25]);
+
+            // Structural sanity check before the (heavy) vendor parser runs.
+            // Invalid input fails the job cleanly instead of letting the parser throw raw.
+            $validationErrors = (new GedcomService)->validateGedcom(File::get($this->filePath));
+            if ($validationErrors !== []) {
+                $message = 'Invalid GEDCOM file: ' . implode(' ', $validationErrors);
+                $importJob->update(['status' => 'failed', 'error_message' => $message]);
+                Log::error('ImportGedcom validation failed', [
+                    'file_path' => $this->filePath,
+                    'user_id' => $this->user->getKey(),
+                    'errors' => $validationErrors,
+                ]);
+
+                return 1;
+            }
 
             $parser = new GedcomParser;
             $team_id = $this->user->currentTeam?->id;

--- a/app/Livewire/TimelineComponent.php
+++ b/app/Livewire/TimelineComponent.php
@@ -2,7 +2,10 @@
 
 namespace App\Livewire;
 
+use App\Models\Family;
+use App\Models\FamilyEvent;
 use App\Models\Person;
+use App\Models\PersonEvent;
 use App\Services\HistoricalEventService;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -10,6 +13,8 @@ use Livewire\Component;
 class TimelineComponent extends Component
 {
     public ?int $personId = null;
+
+    public ?int $familyId = null;
 
     public array $events = [];
 
@@ -22,9 +27,10 @@ class TimelineComponent extends Component
         $this->historicalEventService = $historicalEventService;
     }
 
-    public function mount(?int $personId = null): void
+    public function mount(?int $personId = null, ?int $familyId = null): void
     {
         $this->personId = $personId;
+        $this->familyId = $familyId;
         $this->loadEvents();
     }
 
@@ -34,36 +40,72 @@ class TimelineComponent extends Component
      */
     public function loadEvents($start = null, $end = null): void
     {
+        // Keyed by item id so an event reached via more than one source dedups.
         $items = [];
+        $dates = [];
 
+        // Person mode (back-compat): a single person's own events.
         if ($this->personId) {
             $person = Person::with('events.place')->find($this->personId);
 
             if ($person) {
                 foreach ($person->events as $e) {
-                    // Ensure a parsable date exists
                     if (! $e->date) {
                         continue;
                     }
+                    $items['p_'.$e->id] = $this->personEventItem($e);
+                    $dates[] = (string) $e->date;
+                }
+            }
+        }
 
-                    $items[] = [
-                        'id' => 'p_'.$e->id,
-                        'title' => $e->title,
-                        'content' => $e->title,
-                        'start' => (string) $e->date,
+        // Family mode: every member's person-events + the family's own events.
+        if ($this->familyId) {
+            $family = Family::find($this->familyId);
+
+            if ($family) {
+                $memberIds = collect([$family->husband_id, $family->wife_id])
+                    ->merge(Person::where('child_in_family_id', $family->id)->pluck('id'))
+                    ->filter()
+                    ->unique();
+
+                foreach (Person::with('events.place')->whereIn('id', $memberIds)->get() as $member) {
+                    foreach ($member->events as $e) {
+                        if (! $e->date) {
+                            continue;
+                        }
+                        $items['p_'.$e->id] = $this->personEventItem($e);
+                        $dates[] = (string) $e->date;
+                    }
+                }
+
+                foreach (FamilyEvent::with('place')->where('family_id', $family->id)->get() as $fe) {
+                    if (! $fe->date) {
+                        continue;
+                    }
+                    $items['f_'.$fe->id] = [
+                        'id' => 'f_'.$fe->id,
+                        'title' => $fe->title,
+                        'content' => $fe->title,
+                        'start' => (string) $fe->date,
                         'group' => 'family',
                         'type' => 'family',
-                        'place' => $e->place?->name ?? null,
-                        'description' => $e->description ?? null,
+                        'place' => $fe->place?->name ?? null,
+                        'description' => $fe->description ?? null,
                     ];
+                    $dates[] = (string) $fe->date;
                 }
             }
         }
 
         // Determine period to query historical events
         if (! $start || ! $end) {
-            if (isset($person) && ($person->birthday || $person->deathday)) {
-                $start = $person->birthday ?? ($person->deathday ? now()->subYears(120)->toDateString() : now()->subYears(120)->toDateString());
+            if ($this->familyId && $dates) {
+                // Span the family's collected events.
+                $start = min($dates);
+                $end = max($dates);
+            } elseif (isset($person) && ($person->birthday || $person->deathday)) {
+                $start = $person->birthday ?? now()->subYears(120)->toDateString();
                 $end = $person->deathday ?? now()->toDateString();
             } else {
                 $start = now()->subYears(100)->toDateString();
@@ -78,7 +120,7 @@ class TimelineComponent extends Component
                 continue;
             }
 
-            $items[] = [
+            $items['h_'.$h->id] = [
                 'id' => 'h_'.$h->id,
                 'title' => $h->title,
                 'content' => $h->title,
@@ -92,10 +134,29 @@ class TimelineComponent extends Component
             ];
         }
 
+        $items = array_values($items);
+
         // Sort items by start date
         usort($items, fn(array $a, array $b) => strcmp($a['start'] ?? '', $b['start'] ?? ''));
 
         $this->events = $items;
+    }
+
+    /**
+     * Map a PersonEvent to the timeline item shape shared by person and family modes.
+     */
+    private function personEventItem(PersonEvent $e): array
+    {
+        return [
+            'id' => 'p_'.$e->id,
+            'title' => $e->title,
+            'content' => $e->title,
+            'start' => (string) $e->date,
+            'group' => 'family',
+            'type' => 'family',
+            'place' => $e->place?->name ?? null,
+            'description' => $e->description ?? null,
+        ];
     }
 
     /**
@@ -120,6 +181,7 @@ class TimelineComponent extends Component
         return view('livewire.timeline-component', [
             'events' => $this->events,
             'selectedEvent' => $this->selectedEvent,
+            'mode' => $this->familyId ? 'family' : 'person',
         ]);
     }
 }

--- a/app/Models/AISuggestedMatch.php
+++ b/app/Models/AISuggestedMatch.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Model;
-use App\Models\Team;
 
 class AISuggestedMatch extends Model
 {
+    use BelongsToTenant;
+
     #[\Override]
     protected $table = 'ai_suggested_matches';
 
@@ -28,11 +30,6 @@ class AISuggestedMatch extends Model
         'candidate_data' => 'array',
         'confidence' => 'float',
     ];
-
-    public function team()
-    {
-        return $this->belongsTo(Team::class);
-    }
 
     public function feedbacks()
     {

--- a/app/Models/DuplicateCheck.php
+++ b/app/Models/DuplicateCheck.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,9 +10,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class DuplicateCheck extends Model
 {
     use HasFactory;
+    use BelongsToTenant;
 
     #[\Override]
     protected $fillable = [
+        'team_id',
         'user_id',
         'results',
         'duplicates_found',

--- a/app/Models/DuplicateMatch.php
+++ b/app/Models/DuplicateMatch.php
@@ -2,13 +2,17 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class DuplicateMatch extends Model
 {
+    use BelongsToTenant;
+
     #[\Override]
     protected $fillable = [
+        'team_id',
         'primary_person_id',
         'duplicate_person_id',
         'confidence_score',

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -25,6 +25,16 @@ class Person extends Model
 
     public const GENDER_UNKNOWN = 'U';
 
+    /**
+     * Single source of truth for sex code => label. Add codes here (e.g. 'X' => 'Unspecified')
+     * to extend; forms, filters and getSex() all read from this map.
+     */
+    public const SEX_OPTIONS = [
+        self::GENDER_MALE => 'Male',
+        self::GENDER_FEMALE => 'Female',
+        self::GENDER_UNKNOWN => 'Unknown',
+    ];
+
     #[\Override]
     protected $fillable = [
         'gid',
@@ -172,11 +182,7 @@ class Person extends Model
 
     public function getSex(): string
     {
-        if ($this->sex === 'F') {
-            return 'Female';
-        }
-
-        return 'Male';
+        return self::SEX_OPTIONS[$this->sex] ?? 'Unknown';
     }
 
     public static function getList(): \Illuminate\Support\Collection

--- a/app/Models/SmartMatch.php
+++ b/app/Models/SmartMatch.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,9 +10,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class SmartMatch extends Model
 {
     use HasFactory;
+    use BelongsToTenant;
 
     #[\Override]
     protected $fillable = [
+        'team_id',
         'user_id',
         'person_id',
         'external_tree_id',

--- a/app/Models/Tree.php
+++ b/app/Models/Tree.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,12 +11,14 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Tree extends Model
 {
     use HasFactory;
+    use BelongsToTenant;
 
     /**
      * @var array
      */
     #[\Override]
     protected $fillable = [
+        'team_id',
         'user_id',
         'name',
         'description',

--- a/app/Services/DnaTriangulationService.php
+++ b/app/Services/DnaTriangulationService.php
@@ -294,8 +294,11 @@ class DnaTriangulationService
                         'analysis_date' => now(),
                     ]);
                 } else {
-                    // Create new record
+                    // Create new record. Triangulation runs unauthenticated (queue/
+                    // console), so BelongsToTenant can't auto-assign team_id; key the
+                    // row to the base kit owner's current team (null = fail-closed).
                     DnaMatching::create([
+                        'team_id' => $baseKit->user?->current_team_id,
                         'user_id' => $baseKit->user_id,
                         'match_id' => $match['user_id'],
                         'match_name' => $match['kit_name'],

--- a/app/Services/GedcomService.php
+++ b/app/Services/GedcomService.php
@@ -40,6 +40,62 @@ class GedcomService
         return $head === false ? $gedcom : substr($gedcom, $head);
     }
 
+    /**
+     * Structural sanity check for a GEDCOM document. Returns a list of
+     * human-readable errors; an empty array means the content clears the
+     * boundary checks.
+     *
+     * ponytail: envelope-only, NOT a full GEDCOM 5.5.1 validator. It confirms
+     * the file is non-empty, opens at "0 HEAD", carries a "0 TRLR" terminator,
+     * and that lines carry a numeric level + tag — enough to reject empty
+     * uploads, wrong file types and truncated files before the (heavy) vendor
+     * parser runs. Per-line linting stops at the first offending line (the
+     * boundary), not a full report. Upgrade to a spec validator only if malformed
+     * imports slip past the parser.
+     *
+     * @return list<string>
+     */
+    public function validateGedcom(string $content): array
+    {
+        // Strip a leading UTF-8 BOM and surrounding whitespace before inspecting.
+        $trimmed = ltrim($content, "\xEF\xBB\xBF \t\r\n");
+
+        if ($trimmed === '') {
+            return ['GEDCOM is empty.'];
+        }
+
+        $lines = preg_split('/\r\n|\r|\n/', $trimmed) ?: [];
+        $errors = [];
+
+        if (! str_starts_with($lines[0], '0 HEAD')) {
+            $errors[] = 'GEDCOM must begin with a "0 HEAD" record.';
+        }
+
+        $hasTrailer = false;
+        foreach ($lines as $line) {
+            if (rtrim($line) === '0 TRLR') {
+                $hasTrailer = true;
+                break;
+            }
+        }
+        if (! $hasTrailer) {
+            $errors[] = 'GEDCOM must contain a "0 TRLR" terminator.';
+        }
+
+        // Every non-blank line must be "<level> <tag-or-@xref@> ...".
+        foreach ($lines as $i => $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+            if (! preg_match('/^\d+\s+\S/', $line)) {
+                $errors[] = 'Line ' . ($i + 1) . ' is not a valid GEDCOM line: ' . Str::limit(trim($line), 40);
+                break;
+            }
+        }
+
+        return $errors;
+    }
+
     public function queueImport(UploadedFile $file, ?int $treeId = null): ImportJob
     {
         $path = $file->store('gedcom-form-imports', 'private');

--- a/database/migrations/2026_07_16_140000_add_team_id_to_smart_matches.php
+++ b/database/migrations/2026_07_16_140000_add_team_id_to_smart_matches.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('smart_matches', 'team_id')) {
+            Schema::table('smart_matches', function (Blueprint $table): void {
+                // nullable() MUST precede constrained() or the column ships NOT NULL (repo gotcha).
+                $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            });
+        }
+
+        // Backfill from the owning user's current team so existing rows stay
+        // visible once BelongsToTenant's scope goes live (null team_id matches no
+        // tenant). Correlated subquery runs on both MySQL and SQLite. Rows whose
+        // user has no current_team_id stay null (fail-closed).
+        DB::statement(
+            'UPDATE smart_matches SET team_id = '
+            .'(SELECT current_team_id FROM users WHERE users.id = smart_matches.user_id) '
+            .'WHERE team_id IS NULL'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('smart_matches', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('team_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_16_140001_add_team_id_to_duplicate_checks.php
+++ b/database/migrations/2026_07_16_140001_add_team_id_to_duplicate_checks.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('duplicate_checks', 'team_id')) {
+            Schema::table('duplicate_checks', function (Blueprint $table): void {
+                // nullable() MUST precede constrained() or the column ships NOT NULL (repo gotcha).
+                $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            });
+        }
+
+        // Backfill from the owning user's current team so existing rows stay
+        // visible once BelongsToTenant's scope goes live (null team_id matches no
+        // tenant). Correlated subquery runs on both MySQL and SQLite. Rows whose
+        // user has no current_team_id stay null (fail-closed).
+        DB::statement(
+            'UPDATE duplicate_checks SET team_id = '
+            .'(SELECT current_team_id FROM users WHERE users.id = duplicate_checks.user_id) '
+            .'WHERE team_id IS NULL'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('duplicate_checks', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('team_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_16_140002_add_team_id_to_duplicate_matches.php
+++ b/database/migrations/2026_07_16_140002_add_team_id_to_duplicate_matches.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('duplicate_matches', 'team_id')) {
+            Schema::table('duplicate_matches', function (Blueprint $table): void {
+                // nullable() MUST precede constrained() or the column ships NOT NULL (repo gotcha).
+                $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            });
+        }
+
+        // duplicate_matches has no user_id — its owner is the matched person, which
+        // already carries team_id. Backfill from the primary person's team so
+        // existing rows stay visible once BelongsToTenant's scope goes live.
+        // Correlated subquery runs on both MySQL and SQLite. Rows whose primary
+        // person has no team_id stay null (fail-closed).
+        DB::statement(
+            'UPDATE duplicate_matches SET team_id = '
+            .'(SELECT team_id FROM people WHERE people.id = duplicate_matches.primary_person_id) '
+            .'WHERE team_id IS NULL'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('duplicate_matches', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('team_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_16_140003_add_team_id_to_trees.php
+++ b/database/migrations/2026_07_16_140003_add_team_id_to_trees.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('trees', 'team_id')) {
+            Schema::table('trees', function (Blueprint $table): void {
+                // nullable() MUST precede constrained() or the column ships NOT NULL (repo gotcha).
+                $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            });
+        }
+
+        // Backfill from the owning user's current team so existing rows stay
+        // visible once BelongsToTenant's scope goes live (null team_id matches no
+        // tenant). Correlated subquery runs on both MySQL and SQLite. Rows whose
+        // user has no current_team_id stay null (fail-closed).
+        DB::statement(
+            'UPDATE trees SET team_id = '
+            .'(SELECT current_team_id FROM users WHERE users.id = trees.user_id) '
+            .'WHERE team_id IS NULL'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trees', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('team_id');
+        });
+    }
+};

--- a/resources/views/livewire/timeline-component.blade.php
+++ b/resources/views/livewire/timeline-component.blade.php
@@ -1,4 +1,3 @@
-```html
 <div>
     <!-- Include vis-timeline CSS + JS from CDN -->
     <link href="https://unpkg.com/vis-timeline@latest/styles/vis-timeline-graph2d.min.css" rel="stylesheet" />
@@ -54,7 +53,7 @@
             const container = document.getElementById('timeline');
 
             const groups = new vis.DataSet([
-                { id: 'family', content: 'Family events' },
+                { id: 'family', content: @json($mode === 'family' ? 'Family events' : 'Personal events') },
                 { id: 'historical', content: 'Historical events' },
             ]);
 

--- a/tests/Feature/Livewire/FamilyTimelineTest.php
+++ b/tests/Feature/Livewire/FamilyTimelineTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\TimelineComponent;
+use App\Models\Family;
+use App\Models\FamilyEvent;
+use App\Models\Person;
+use App\Models\PersonEvent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FamilyTimelineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_family_timeline_merges_member_and_family_events(): void
+    {
+        $husband = Person::factory()->create();
+        $wife = Person::factory()->create();
+
+        $family = Family::factory()->create([
+            'husband_id' => $husband->id,
+            'wife_id' => $wife->id,
+        ]);
+
+        // A member's own person-event and the family's own event.
+        $personEvent = PersonEvent::factory()->create([
+            'person_id' => $husband->id,
+            'title' => 'Husband Baptism',
+            'date' => '1901-05-01',
+        ]);
+
+        $familyEvent = FamilyEvent::factory()->create([
+            'family_id' => $family->id,
+            'title' => 'Wedding',
+            'date' => '1925-06-15',
+        ]);
+
+        $ids = array_column(
+            Livewire::test(TimelineComponent::class, ['familyId' => $family->id])->get('events'),
+            'id'
+        );
+
+        // Merged timeline carries the member's person-event AND the family event.
+        $this->assertContains('p_'.$personEvent->id, $ids);
+        $this->assertContains('f_'.$familyEvent->id, $ids);
+    }
+}

--- a/tests/Feature/Tenancy/GlobalScopeAuditTest.php
+++ b/tests/Feature/Tenancy/GlobalScopeAuditTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\DuplicateMatch;
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * DuplicateMatch (and SmartMatch) previously used neither BelongsToTenant nor a
+ * team_id column, so every team read every team's duplicate/smart matches. With
+ * the trait + team_id migration added, the global scope keys off the acting
+ * user's currentTeam. This proves a match created under team A is invisible
+ * under team B and visible again under A — the same harness the DNA scope test
+ * and the Filament mount tests use (User::withPersonalTeam + Filament::setTenant).
+ */
+class GlobalScopeAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_duplicate_match_is_scoped_to_the_current_team(): void
+    {
+        $userA = User::factory()->withPersonalTeam()->create();
+        $userB = User::factory()->withPersonalTeam()->create();
+
+        // Act as team A: the two people and the match all auto-assign team_id = A.
+        $this->actingAs($userA);
+        Filament::setTenant($userA->currentTeam);
+
+        $primary = Person::factory()->create();
+        $duplicate = Person::factory()->create();
+
+        $match = DuplicateMatch::create([
+            'primary_person_id' => $primary->id,
+            'duplicate_person_id' => $duplicate->id,
+            'confidence_score' => 0.9500,
+            'status' => 'pending',
+        ]);
+
+        $this->assertSame($userA->currentTeam->id, $match->team_id);
+        $this->assertTrue(DuplicateMatch::whereKey($match->id)->exists(), 'Match must be visible under its own team.');
+
+        // Not visible under team B.
+        $this->actingAs($userB);
+        Filament::setTenant($userB->currentTeam);
+        $this->assertFalse(DuplicateMatch::whereKey($match->id)->exists(), 'Match must NOT leak to another team.');
+        $this->assertNull(DuplicateMatch::find($match->id));
+
+        // Visible again once back on team A.
+        $this->actingAs($userA);
+        Filament::setTenant($userA->currentTeam);
+        $this->assertTrue(DuplicateMatch::whereKey($match->id)->exists());
+    }
+}

--- a/tests/Unit/Enums/EventTypeTest.php
+++ b/tests/Unit/Enums/EventTypeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\EventType;
+use PHPUnit\Framework\TestCase;
+
+class EventTypeTest extends TestCase
+{
+    /** The 10 SCOPE event types, each mapped to its stored value + label. */
+    public function test_it_covers_all_ten_scope_event_types(): void
+    {
+        $expected = [
+            'BIRT' => 'Birth',
+            'BAPM' => 'Baptism',
+            'MARR' => 'Marriage',
+            'DIV' => 'Divorce',
+            'DEAT' => 'Death',
+            'BURI' => 'Burial',
+            'IMMI' => 'Immigration',
+            'CENS' => 'Census',
+            '_MILT' => 'Military Service',
+            'OCCU' => 'Occupation',
+        ];
+
+        foreach ($expected as $value => $label) {
+            $case = EventType::tryFrom($value);
+            $this->assertNotNull($case, "Missing EventType case for stored value {$value}");
+            $this->assertSame($label, $case->label());
+        }
+    }
+
+    public function test_options_map_stored_values_to_labels(): void
+    {
+        $options = EventType::options();
+
+        $this->assertSame('Birth', $options['BIRT']);
+        $this->assertSame('Occupation', $options['OCCU']);
+        $this->assertCount(count(EventType::cases()), $options);
+    }
+
+    public function test_family_subset_is_marriage_and_divorce_only(): void
+    {
+        $familyValues = array_map(fn (EventType $c): string => $c->value, EventType::familyCases());
+        sort($familyValues);
+        $this->assertSame(['DIV', 'MARR'], $familyValues);
+
+        // Person subset is the complement; must exclude the family events, include births.
+        $personValues = array_map(fn (EventType $c): string => $c->value, EventType::personCases());
+        $this->assertNotContains('MARR', $personValues);
+        $this->assertNotContains('DIV', $personValues);
+        $this->assertContains('BIRT', $personValues);
+    }
+
+    public function test_values_returns_all_backing_values(): void
+    {
+        $this->assertCount(10, EventType::values());
+        $this->assertContains('OCCU', EventType::values());
+    }
+}

--- a/tests/Unit/Models/PersonSexTest.php
+++ b/tests/Unit/Models/PersonSexTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Person;
+use Tests\TestCase;
+
+class PersonSexTest extends TestCase
+{
+    public function test_get_sex_maps_male(): void
+    {
+        $this->assertSame('Male', (new Person(['sex' => 'M']))->getSex());
+    }
+
+    public function test_get_sex_maps_female(): void
+    {
+        // Bites the old bug: buggy getSex() returned 'Male' for 'F'.
+        $this->assertSame('Female', (new Person(['sex' => 'F']))->getSex());
+    }
+
+    public function test_get_sex_maps_unknown_code(): void
+    {
+        $this->assertSame('Unknown', (new Person(['sex' => 'U']))->getSex());
+    }
+
+    public function test_get_sex_defaults_unknown_when_unset(): void
+    {
+        // Bites the old bug: buggy getSex() returned 'Male' for null/unset.
+        $this->assertSame('Unknown', (new Person)->getSex());
+    }
+}

--- a/tests/Unit/Services/GedcomRoundTripTest.php
+++ b/tests/Unit/Services/GedcomRoundTripTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Models\Family;
+use App\Models\Person;
+use App\Services\GedcomService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GedcomRoundTripTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_exported_tree_passes_structural_validation(): void
+    {
+        // Small tree, no auth: the BelongsToTenant scope no-ops without a current team.
+        Person::factory()->count(2)->create();
+        Family::factory()->create(); // also creates a husband + wife Person
+
+        $service = new GedcomService;
+        $content = $service->generateGedcomContent();
+
+        // Export must round-trip through our own validator with zero errors.
+        $errors = $service->validateGedcom($content);
+        $this->assertSame([], $errors, 'validateGedcom errors: ' . implode(' | ', $errors));
+
+        // Envelope: a valid single-document GEDCOM opens at HEAD and closes at TRLR.
+        $this->assertStringStartsWith('0 HEAD', $content);
+        $this->assertStringEndsWith('0 TRLR', rtrim($content));
+
+        // ponytail: round-trip stops at export -> validate. Parsing the string back
+        // in needs the vendor GedcomParser to write to the DB from a file on disk
+        // (queue/file wiring), which is out of scope for a unit test. Follow-up if a
+        // full parse-back assertion is wanted.
+    }
+
+    public function test_validate_gedcom_rejects_malformed_input(): void
+    {
+        // Proves the validator actually bites — each case must yield >=1 error.
+        $service = new GedcomService;
+
+        $this->assertNotEmpty($service->validateGedcom(''), 'empty content');
+        $this->assertNotEmpty($service->validateGedcom("0 INDI @I1@\n0 TRLR"), 'missing HEAD');
+        $this->assertNotEmpty($service->validateGedcom("0 HEAD\n1 SOUR X"), 'missing TRLR');
+        $this->assertNotEmpty($service->validateGedcom('not gedcom at all'), 'not gedcom');
+    }
+}


### PR DESCRIPTION
Five independent P1 items from `SCOPE_TASKS.md`, dispatched as parallel agents on disjoint files, integrated + verified centrally. Full suite **460 passed / 0 failed**; the four tenancy migrations were run against real **MySQL**, not just SQLite.

Deliberately **not** in this batch: C2 (relationship types) and C7 (real DNA-engine rebuild) — they need design/external-integration depth, not a one-shot; C10 depends on C2.

## Security — F2 tenancy audit (completes F1)
The `BelongsToTenant` global scope only filters models whose table has `team_id`. Several were still globally readable across teams. Added the trait + a nullable `team_id`+FK migration + owner-based backfill to **SmartMatch, DuplicateCheck, DuplicateMatch, Tree**; added the trait to **AISuggestedMatch** (already had the column). Left **HistoricalEvent** global (cross-team reference data). Also closed the F1 write-path gap: `MatchKitsCommand` + `DnaTriangulationService` create `DnaMatching` rows unauthenticated, so `team_id` was landing null — now set explicitly from the base kit's owner. All fail-closed (null owner ⇒ invisible to every tenant).

⚠️ **Behavior change:** `Tree` is now tenant-scoped, so unauthenticated contexts (console/queue/seeders) read zero trees. That's correct isolation, but any cross-tenant `Tree` read must now carry a tenant context.

## Features / fixes
- **C1 event types** — new `EventType` enum (10 SCOPE types → GEDCOM tags); Person/Family event forms go free-text → constrained Select. The type is stored in `title` (not `type` — that column doesn't even exist on `family_events`), so the Select constrains `title`; no enum cast (legacy imports hold off-list tags); off-list legacy values are preserved on edit.
- **C5 gender bug** — `getSex()` returned "Male" for **female and unknown** (fall-through bug). Centralized `SEX_OPTIONS`; form Select + filter consume it; Unknown now selectable.
- **C8 GEDCOM validation** — `validateGedcom()` envelope check (HEAD/TRLR/line-shape) gates import, failing cleanly on garbage; export→validate round-trip test.
- **C11 family timelines** — `TimelineComponent` gains a `familyId` path merging members' events + `FamilyEvent`s + historical overlays. Also fixed a stray ` ```html ` fence that made the blade a **multiple-root** Livewire component (broken on every mount, person mode included — no test had ever mounted it).

## Verification
Each ships a test that bites (tenant isolation, enum coverage, the F→Male bug, GEDCOM validity, family-timeline merge). Guard integrity checked: no `phpunit.xml`/config/FK weakened, no existing test deleted, disjoint files (no path touched by two agents).

## Discovered, not fixed (flagged for follow-up)
- `GedcomService::queueImport()` dispatches `ImportGedcom::dispatch($path, $slug)` but the job constructor is `(User, string, ?string)` — args misaligned; import entrypoint looks broken independently.
- Cross-team DNA matches (two kits, two teams) can't be expressed by a single `team_id` — schema question.
- `family_events.type` column is absent; a leftover free-text `type` input writes to a non-column (pre-existing drift).