### PR TITLE
feat: SCOPE batch — pedigree types, relationship calculator, tree privacy, search, media

### DIFF
--- a/app/Enums/MediaType.php
+++ b/app/Enums/MediaType.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Taxonomy for uploaded media objects (SCOPE §8). Distinguishes the kind of
+ * genealogical media so it can be filtered/displayed differently later.
+ */
+enum MediaType: string
+{
+    case PHOTO = 'photo';
+    case DOCUMENT = 'document';
+    case CERTIFICATE = 'certificate';
+    case CENSUS = 'census';
+    case SCAN = 'scan';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PHOTO => 'Photo',
+            self::DOCUMENT => 'Document',
+            self::CERTIFICATE => 'Certificate',
+            self::CENSUS => 'Census Record',
+            self::SCAN => 'Scan',
+        };
+    }
+
+    /**
+     * value => label map for a Filament Select ->options().
+     *
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        $options = [];
+        foreach (self::cases() as $case) {
+            $options[$case->value] = $case->label();
+        }
+
+        return $options;
+    }
+}

--- a/app/Enums/PedigreeType.php
+++ b/app/Enums/PedigreeType.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * GEDCOM FAMC.PEDI — a child's pedigree link to its child_in_family family.
+ * A null pedigree means the standard/unstated case, i.e. biological birth.
+ *
+ * Step-parent and guardianship are deliberately absent: they are not a child's
+ * FAMC link type but a person->person association (GEDCOM ASSO / PersonAsso).
+ */
+enum PedigreeType: string
+{
+    case BIRTH = 'birth';
+    case ADOPTED = 'adopted';
+    case FOSTER = 'foster';
+    case SEALING = 'sealing';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::BIRTH => 'Biological',
+            self::ADOPTED => 'Adopted',
+            self::FOSTER => 'Foster',
+            self::SEALING => 'Sealing (LDS)',
+        };
+    }
+
+    /**
+     * value => label map for a Filament Select ->options().
+     *
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        $options = [];
+        foreach (self::cases() as $case) {
+            $options[$case->value] = $case->label();
+        }
+
+        return $options;
+    }
+}

--- a/app/Filament/App/Pages/GlobalSearchPage.php
+++ b/app/Filament/App/Pages/GlobalSearchPage.php
@@ -26,66 +26,59 @@ class GlobalSearchPage extends Page
 
     public bool $searchGlobal = true;
 
-    public $results = [];
+    // Optional year-range filter (kept as strings so an empty input stays null).
+    public ?string $fromYear = null;
 
-    public int $currentPage = 1;
+    public ?string $toYear = null;
 
-    public int $lastPage = 1;
+    /** @var array{people: array, places: array, sources: array, events: array}|array */
+    public array $groups = [];
 
     public int $totalResults = 0;
 
     public function search(): void
     {
         if (in_array(trim($this->query), ['', '0'], true)) {
-            $this->results = [];
+            $this->groups = [];
             $this->totalResults = 0;
 
             return;
         }
 
-        $service = app(PersonSearchService::class);
+        $groups = app(PersonSearchService::class)->searchAll(
+            $this->query,
+            $this->yearOrNull($this->fromYear),
+            $this->yearOrNull($this->toYear),
+            $this->searchGlobal,
+        );
 
-        $paginator = $this->searchGlobal
-            ? $service->searchGlobal($this->query, 20, true, $this->currentPage)
-            : $service->searchOwnTeam($this->query, 20, $this->currentPage);
+        $this->groups = [
+            'people' => $groups['people']->all(),
+            'places' => $groups['places']->all(),
+            'sources' => $groups['sources']->all(),
+            'events' => $groups['events']->all(),
+        ];
+        $this->totalResults = collect($this->groups)->sum(fn (array $g): int => count($g));
+    }
 
-        $this->results = $paginator->items();
-        $this->currentPage = $paginator->currentPage();
-        $this->lastPage = $paginator->lastPage();
-        $this->totalResults = $paginator->total();
+    private function yearOrNull(?string $value): ?int
+    {
+        return $value === null || trim($value) === '' ? null : (int) $value;
     }
 
     public function updatedQuery(): void
     {
-        $this->currentPage = 1;
         if (strlen(trim($this->query)) >= 2) {
             $this->search();
         } else {
-            $this->results = [];
+            $this->groups = [];
             $this->totalResults = 0;
         }
     }
 
     public function updatedSearchGlobal(): void
     {
-        $this->currentPage = 1;
-        if (!in_array(trim($this->query), ['', '0'], true)) {
-            $this->search();
-        }
-    }
-
-    public function previousPage(): void
-    {
-        if ($this->currentPage > 1) {
-            $this->currentPage--;
-            $this->search();
-        }
-    }
-
-    public function nextPage(): void
-    {
-        if ($this->currentPage < $this->lastPage) {
-            $this->currentPage++;
+        if (! in_array(trim($this->query), ['', '0'], true)) {
             $this->search();
         }
     }

--- a/app/Filament/App/Pages/RelationshipCalculatorReport.php
+++ b/app/Filament/App/Pages/RelationshipCalculatorReport.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Pages;
+
+use App\Models\Person;
+use App\Modules\Core\Services\TreeService;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Schema;
+
+class RelationshipCalculatorReport extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    #[\Override]
+    protected string $view = 'filament.app.pages.relationship-calculator-report';
+
+    #[\Override]
+    protected static ?string $title = 'Relationship Calculator';
+
+    #[\Override]
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-users';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'Relationship Calculator';
+
+    #[\Override]
+    protected static string | \UnitEnum | null $navigationGroup = '📄 Reports';
+
+    public ?array $data = [];
+
+    public ?string $relationship = null;
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        $people = Person::query()
+            ->orderBy('surn')
+            ->orderBy('givn')
+            ->get()
+            ->mapWithKeys(fn (Person $p): array => [$p->id => $p->fullname()])
+            ->toArray();
+
+        return $schema
+            ->schema([
+                Select::make('person1_id')
+                    ->label('First person')
+                    ->options($people)
+                    ->searchable()
+                    ->required(),
+                Select::make('person2_id')
+                    ->label('Second person')
+                    ->options($people)
+                    ->searchable()
+                    ->required(),
+            ])
+            ->statePath('data');
+    }
+
+    public function calculate(): void
+    {
+        $data = $this->form->getState();
+
+        $person1 = Person::find($data['person1_id']);
+        $person2 = Person::find($data['person2_id']);
+
+        if (! $person1 || ! $person2) {
+            Notification::make()->title('Please select two people.')->danger()->send();
+
+            return;
+        }
+
+        $this->relationship = app(TreeService::class)->calculateRelationship($person1, $person2);
+    }
+}

--- a/app/Filament/App/Pages/TreePrivacy.php
+++ b/app/Filament/App/Pages/TreePrivacy.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Pages;
+
+use App\Models\Tree;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+
+class TreePrivacy extends Page
+{
+    #[\Override]
+    protected string $view = 'filament.app.pages.tree-privacy';
+
+    #[\Override]
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-lock-closed';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'Tree Privacy';
+
+    #[\Override]
+    protected static ?string $title = 'Tree Privacy';
+
+    #[\Override]
+    protected static string | \UnitEnum | null $navigationGroup = '📋 Research Management';
+
+    /**
+     * The current tenant's trees (BelongsToTenant scopes this to the active team).
+     *
+     * @return Collection<int, Tree>
+     */
+    public function trees(): Collection
+    {
+        return Tree::orderBy('name')->get();
+    }
+
+    /**
+     * Flip a tree between public and private.
+     */
+    public function toggle(int $treeId): void
+    {
+        // findOrFail stays inside the tenant scope, so a foreign team's id 404s.
+        $tree = Tree::findOrFail($treeId);
+        $tree->is_public = ! $tree->is_public;
+        $tree->save();
+
+        Notification::make()
+            ->title($tree->is_public ? 'Tree is now public' : 'Tree is now private')
+            ->success()
+            ->send();
+    }
+}

--- a/app/Filament/App/Resources/MediaObjectResource.php
+++ b/app/Filament/App/Resources/MediaObjectResource.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Filament\App\Resources;
 
 use Override;
+use App\Enums\MediaType;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Actions\EditAction;
@@ -47,6 +50,15 @@ class MediaObjectResource extends AppResource
     {
         return $schema
                 ->components([
+                    Select::make('media_type')
+                        ->options(MediaType::options())
+                        ->native(false),
+                    FileUpload::make('file_path')
+                        ->label('File')
+                        ->disk('private')
+                        ->directory('media-objects')
+                        ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/webp', 'application/pdf'])
+                        ->maxSize(10240),
                     TextInput::make('gid')
                         ->numeric(),
                     TextInput::make('group')
@@ -65,6 +77,9 @@ class MediaObjectResource extends AppResource
     {
         return $table
             ->columns([
+                TextColumn::make('media_type')
+                    ->badge()
+                    ->searchable(),
                 TextColumn::make('gid')
                     ->numeric()
                     ->sortable(),

--- a/app/Filament/App/Resources/PersonResource.php
+++ b/app/Filament/App/Resources/PersonResource.php
@@ -86,6 +86,11 @@ class PersonResource extends AppResource
                         DateTimePicker::make('deathday')->label('Date of Death'),
                         DateTimePicker::make('burial_day')->label('Burial Date'),
                         TextInput::make('child_in_family_id')->label('Child in Family ID'),
+                        Select::make('pedigree')
+                            ->options(\App\Enums\PedigreeType::options())
+                            ->label('Pedigree')
+                            ->placeholder('Biological')
+                            ->helperText('Link type to the child-in-family. Leave blank for biological.'),
                     ]),
 
                 Section::make('Contact Information')

--- a/app/Models/MediaObject.php
+++ b/app/Models/MediaObject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\MediaType;
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -11,6 +12,28 @@ class MediaObject extends \FamilyTree365\LaravelGedcom\Models\MediaObject
 {
     use HasFactory;
     use BelongsToTenant;
+
+    /**
+     * The vendor base hardcodes $fillable. Append our columns to whatever it
+     * declares (rather than redeclaring the full list) so vendor changes carry
+     * through instead of being silently masked.
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->mergeFillable(['media_type', 'file_path']);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'media_type' => MediaType::class,
+        ];
+    }
 
     /**
      * Files associated with this media object (from media_objects_file table).

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use App\Traits\ConnectionTrait;
 
+use App\Enums\PedigreeType;
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -42,6 +43,7 @@ class Person extends Model
         'surn',
         'sex',
         'child_in_family_id',
+        'pedigree',
         'description',
         'titl',
         'name',
@@ -183,6 +185,18 @@ class Person extends Model
     public function getSex(): string
     {
         return self::SEX_OPTIONS[$this->sex] ?? 'Unknown';
+    }
+
+    /** GEDCOM FAMC.PEDI ADOPTED. Null pedigree = biological, so not adopted. */
+    public function isAdopted(): bool
+    {
+        return $this->pedigree === PedigreeType::ADOPTED;
+    }
+
+    /** Human label for the child-family link type; null pedigree reads as biological. */
+    public function pedigreeLabel(): string
+    {
+        return ($this->pedigree ?? PedigreeType::BIRTH)->label();
     }
 
     public static function getList(): \Illuminate\Support\Collection
@@ -485,6 +499,7 @@ class Person extends Model
             'deathday' => 'datetime',
             'burial_day' => 'datetime',
             'chan' => 'datetime',
+            'pedigree' => PedigreeType::class,
         ];
     }
 }

--- a/app/Models/Tree.php
+++ b/app/Models/Tree.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\BelongsToTenant;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -23,7 +24,41 @@ class Tree extends Model
         'name',
         'description',
         'root_person_id',
+        'is_public',
     ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_public' => 'boolean',
+    ];
+
+    /**
+     * Private by default at the model level too, not only via the DB default —
+     * so a freshly-instantiated Tree reads as private before it round-trips.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'is_public' => false,
+    ];
+
+    /**
+     * Only trees the owner has opted to share publicly.
+     */
+    public function scopePublic(Builder $query): Builder
+    {
+        return $query->where('is_public', true);
+    }
+
+    /**
+     * Trees kept private (the default).
+     */
+    public function scopePrivate(Builder $query): Builder
+    {
+        return $query->where('is_public', false);
+    }
 
     /**
      * Get the user that owns the tree.

--- a/app/Modules/Core/Services/TreeService.php
+++ b/app/Modules/Core/Services/TreeService.php
@@ -95,13 +95,150 @@ class TreeService
     }
 
     /**
-     * Calculate relationship between two persons.
+     * Describe how $person1 is related to $person2 (e.g. "grandparent",
+     * "sibling", "1st cousin once removed"). Framing is person1-relative:
+     * calculateRelationship($grandpa, $grandchild) === 'grandparent'.
+     *
+     * Method: find the lowest common ancestor by intersecting each person's
+     * ancestor set (id => generations up), then read the relationship off the
+     * two generation distances d1, d2 to that ancestor.
      */
-    public function calculateRelationship(Person $person1, Person $person2): ?string
+    public function calculateRelationship(Person $person1, Person $person2): string
     {
-        // Implementation for relationship calculation
-        // This is a complex algorithm that would need detailed implementation
-        return null;
+        $a = $this->ancestorDistances($person1);
+        $b = $this->ancestorDistances($person2);
+
+        // Lowest common ancestor = the shared ancestor with the smallest
+        // combined generation distance.
+        $d1 = $d2 = null;
+        foreach (array_intersect_key($a, $b) as $id => $distA) {
+            if ($d1 === null || $distA + $b[$id] < $d1 + $d2) {
+                [$d1, $d2] = [$distA, $b[$id]];
+            }
+        }
+
+        if ($d1 === null) {
+            return 'no traceable relationship';
+        }
+
+        $min = min($d1, $d2);
+        $diff = abs($d1 - $d2);
+
+        // Direct line: one person is an ancestor of the other.
+        if ($min === 0) {
+            if ($diff === 0) {
+                return 'self';
+            }
+            $g = $diff; // generations apart
+            $up = $d2 === 0;   // person1 descends from person2
+            $stem = $up ? 'grandchild' : 'grandparent';
+            if ($g === 1) {
+                return $up ? 'child' : 'parent';
+            }
+
+            return str_repeat('great-', $g - 2).$stem;
+        }
+
+        // Siblings and the aunt/uncle <-> niece/nephew ladder.
+        if ($min === 1) {
+            if ($diff === 0) {
+                return 'sibling';
+            }
+            $g = max($d1, $d2); // >= 2
+
+            return $d1 < $d2
+                ? $this->collateralLabel($person1->sex, $g, true)   // person1 is the elder side
+                : $this->collateralLabel($person1->sex, $g, false); // person1 is the younger side
+        }
+
+        // Cousins: min-1 gives the degree, the generation gap gives "removed".
+        $label = $this->ordinal($min - 1).' cousin';
+
+        return $diff === 0 ? $label : $label.' '.$this->timesRemoved($diff);
+    }
+
+    /**
+     * Map every ancestor of $person (including $person at distance 0) to the
+     * minimum number of generations up. BFS up parents; cap and visited-set
+     * guard against runaway walks and cyclic (bad-data) trees.
+     *
+     * @return array<int,int> personId => generations
+     */
+    protected function ancestorDistances(Person $person, int $cap = 15): array
+    {
+        $distances = [];
+        $visited = [$person->id => true];
+        $queue = [[$person, 0]];
+
+        while ($queue !== []) {
+            [$current, $depth] = array_shift($queue);
+            $distances[$current->id] = $depth;
+
+            if ($depth >= $cap) {
+                continue; // ponytail: hard cap so bad data can't loop forever
+            }
+
+            $family = $current->childInFamily;
+            if (! $family) {
+                continue;
+            }
+
+            foreach ([$family->husband, $family->wife] as $parent) {
+                if ($parent && ! isset($visited[$parent->id])) {
+                    $visited[$parent->id] = true;
+                    $queue[] = [$parent, $depth + 1];
+                }
+            }
+        }
+
+        return $distances;
+    }
+
+    /**
+     * aunt/uncle (g=2), grand-aunt/uncle (g=3), great-grand-... for the elder
+     * side; niece/nephew mirror for the younger side. $sex picks the gendered
+     * term, falling back to the combined form when unknown.
+     */
+    protected function collateralLabel(?string $sex, int $g, bool $elder): string
+    {
+        if ($elder) {
+            $base = match ($sex) {
+                Person::GENDER_MALE => 'uncle',
+                Person::GENDER_FEMALE => 'aunt',
+                default => 'aunt/uncle',
+            };
+        } else {
+            $base = match ($sex) {
+                Person::GENDER_MALE => 'nephew',
+                Person::GENDER_FEMALE => 'niece',
+                default => 'niece/nephew',
+            };
+        }
+
+        return $g === 2 ? $base : str_repeat('great-', $g - 3).'grand-'.$base;
+    }
+
+    protected function ordinal(int $n): string
+    {
+        $suffix = match (true) {
+            in_array($n % 100, [11, 12, 13], true) => 'th',
+            $n % 10 === 1 => 'st',
+            $n % 10 === 2 => 'nd',
+            $n % 10 === 3 => 'rd',
+            default => 'th',
+        };
+
+        return $n.$suffix;
+    }
+
+    protected function timesRemoved(int $n): string
+    {
+        return match ($n) {
+            1 => 'once removed',
+            2 => 'twice removed',
+            3 => 'thrice removed',
+            default => $n.' times removed',
+        };
     }
 
     /**

--- a/app/Services/PersonSearchService.php
+++ b/app/Services/PersonSearchService.php
@@ -3,14 +3,25 @@
 namespace App\Services;
 
 use App\Models\Person;
+use App\Models\PersonEvent;
+use App\Models\Place;
+use App\Models\Source;
 use App\Models\Team;
+use Closure;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class PersonSearchService
 {
+    /** Run the phonetic fallback only when the exact/LIKE pass returns fewer than this. */
+    private const PHONETIC_THRESHOLD = 3;
+
+    /** Hard cap on same-first-letter rows the PHP soundex pass scans, so it can't explode. */
+    private const PHONETIC_SCAN_CAP = 200;
+
     /**
      * Search people within the current user's team only.
      * Living persons are included since this is the user's own data.
@@ -32,38 +43,189 @@ class PersonSearchService
      */
     public function searchGlobal(string $query, int $perPage = 20, bool $includeOwnTeam = true, int $page = 1): LengthAwarePaginator
     {
+        return $this->globalPersonQuery(
+            fn (Builder $q) => $this->applySearchConditions($q, $query),
+            $includeOwnTeam,
+        )
+            ->orderByDesc('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    /**
+     * Global search across every searchable entity type, returned as labelled
+     * result groups. People honour the same public-team privacy filter as
+     * searchGlobal(); places, sources and events are team-scoped by the
+     * BelongsToTenant global scope. An optional from/to year range narrows the
+     * person and event groups.
+     *
+     * @return array{people: Collection, places: Collection, sources: Collection, events: Collection}
+     */
+    public function searchAll(string $query, ?int $fromYear = null, ?int $toYear = null, bool $global = true, int $perGroup = 20): array
+    {
+        $term = trim($query);
+
+        if ($term === '' || $term === '0') {
+            return ['people' => new Collection, 'places' => new Collection, 'sources' => new Collection, 'events' => new Collection];
+        }
+
+        return [
+            'people' => $this->searchPeople($term, $fromYear, $toYear, $global, $perGroup),
+            'places' => $this->searchPlaces($term, $perGroup),
+            'sources' => $this->searchSources($term, $perGroup),
+            'events' => $this->searchEvents($term, $fromYear, $toYear, $perGroup),
+        ];
+    }
+
+    /**
+     * People group: exact/LIKE pass, with a bounded Soundex fallback when it
+     * returns little.
+     */
+    private function searchPeople(string $term, ?int $fromYear, ?int $toYear, bool $global, int $limit): Collection
+    {
+        $query = $this->buildPeopleQuery($global, fn (Builder $q) => $this->applySearchConditions($q, $term));
+        $this->applyPersonYearRange($query, $fromYear, $toYear);
+
+        $people = $query->orderByDesc('id')->limit($limit)->get();
+
+        if ($people->count() < self::PHONETIC_THRESHOLD) {
+            $people = $this->addPhoneticMatches($people, $term, $fromYear, $toYear, $global, $limit);
+        }
+
+        return $people;
+    }
+
+    /**
+     * Soundex near-miss fallback (e.g. "Smyth" → "Smith"). Bounded three ways:
+     * candidates must share the term's first letter (Soundex keeps it), stay
+     * inside the same privacy scope, and are capped at PHONETIC_SCAN_CAP rows
+     * before the PHP soundex() comparison; the merged result is capped at $limit.
+     */
+    private function addPhoneticMatches(Collection $exact, string $term, ?int $fromYear, ?int $toYear, bool $global, int $limit): Collection
+    {
+        $firstWord = preg_split('/\s+/', trim($term), -1, PREG_SPLIT_NO_EMPTY)[0] ?? '';
+
+        if ($firstWord === '') {
+            return $exact;
+        }
+
+        $code = soundex($firstWord);
+        $like = mb_substr($firstWord, 0, 1).'%';
+
+        $candidates = $this->buildPeopleQuery($global, function (Builder $q) use ($like): void {
+            $q->where('surn', 'LIKE', $like)->orWhere('givn', 'LIKE', $like);
+        });
+        $this->applyPersonYearRange($candidates, $fromYear, $toYear);
+
+        $matches = $candidates
+            ->limit(self::PHONETIC_SCAN_CAP)
+            ->get()
+            ->filter(fn (Person $p): bool => soundex((string) $p->surn) === $code || soundex((string) $p->givn) === $code);
+
+        return $exact->concat($matches)->unique('id')->take($limit)->values();
+    }
+
+    /**
+     * Places group — title/description.
+     */
+    private function searchPlaces(string $term, int $limit): Collection
+    {
+        $like = '%'.$term.'%';
+
+        return Place::query()
+            ->where(fn (Builder $q) => $q->where('title', 'LIKE', $like)->orWhere('description', 'LIKE', $like))
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * Sources group — name/title.
+     */
+    private function searchSources(string $term, int $limit): Collection
+    {
+        $like = '%'.$term.'%';
+
+        return Source::query()
+            ->where(fn (Builder $q) => $q->where('name', 'LIKE', $like)->orWhere('titl', 'LIKE', $like))
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * Events group — title/type, optionally narrowed by year range.
+     */
+    private function searchEvents(string $term, ?int $fromYear, ?int $toYear, int $limit): Collection
+    {
+        $like = '%'.$term.'%';
+
+        $query = PersonEvent::query()
+            ->where(fn (Builder $q) => $q->where('title', 'LIKE', $like)->orWhere('type', 'LIKE', $like));
+
+        if ($fromYear !== null) {
+            $query->where('year', '>=', $fromYear);
+        }
+        if ($toYear !== null) {
+            $query->where('year', '<=', $toYear);
+        }
+
+        return $query->orderByDesc('id')->limit($limit)->get();
+    }
+
+    /**
+     * Build the person query for either the own-team path (tenant-scoped) or the
+     * cross-team global path (privacy-filtered), applying $match as the search
+     * predicate. Shared by the exact and phonetic passes.
+     */
+    private function buildPeopleQuery(bool $global, Closure $match): Builder
+    {
+        return $global
+            ? $this->globalPersonQuery($match, true)
+            : Person::query()->where($match);
+    }
+
+    /**
+     * Cross-team person query: own team (all people) OR public teams
+     * (deceased/historical only). $match applies the search predicate inside
+     * each branch.
+     */
+    private function globalPersonQuery(Closure $match, bool $includeOwnTeam): Builder
+    {
         $currentTeamId = Auth::user()?->currentTeam?->id;
 
-        // Build query without the BelongsToTenant global scope
         return Person::withoutGlobalScope('team')
-            ->where(function (Builder $outer) use ($query, $currentTeamId, $includeOwnTeam): void {
-                // Own team — include all people (living + deceased)
+            ->where(function (Builder $outer) use ($match, $currentTeamId, $includeOwnTeam): void {
                 if ($includeOwnTeam && $currentTeamId) {
-                    $outer->where(function (Builder $own) use ($query, $currentTeamId): void {
-                        $own->where('people.team_id', $currentTeamId)
-                            ->where(function (Builder $q) use ($query): void {
-                                $this->applySearchConditions($q, $query);
-                            });
+                    $outer->where(function (Builder $own) use ($match, $currentTeamId): void {
+                        $own->where('people.team_id', $currentTeamId)->where($match);
                     });
                 }
 
-                // Public teams — deceased/historical persons only
                 $publicTeamIds = Team::where('is_public', true)
                     ->when($currentTeamId, fn ($q) => $q->where('id', '!=', $currentTeamId))
                     ->pluck('id');
 
                 if ($publicTeamIds->isNotEmpty()) {
-                    $outer->orWhere(function (Builder $pub) use ($query, $publicTeamIds): void {
+                    $outer->orWhere(function (Builder $pub) use ($match, $publicTeamIds): void {
                         $pub->whereIn('people.team_id', $publicTeamIds)
                             ->deceased()
-                            ->where(function (Builder $q) use ($query): void {
-                                $this->applySearchConditions($q, $query);
-                            });
+                            ->where($match);
                     });
                 }
-            })
-            ->orderByDesc('id')
-            ->paginate($perPage, ['*'], 'page', $page);
+            });
+    }
+
+    /**
+     * Narrow a person query to a birth-year range when either bound is given.
+     */
+    private function applyPersonYearRange(Builder $query, ?int $fromYear, ?int $toYear): void
+    {
+        if ($fromYear !== null) {
+            $query->where('people.birth_year', '>=', $fromYear);
+        }
+        if ($toYear !== null) {
+            $query->where('people.birth_year', '<=', $toYear);
+        }
     }
 
     /**

--- a/database/migrations/2026_07_16_000000_add_media_type_and_file_path_to_media_objects.php
+++ b/database/migrations/2026_07_16_000000_add_media_type_and_file_path_to_media_objects.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('media_objects', function (Blueprint $table): void {
+            if (!Schema::hasColumn('media_objects', 'media_type')) {
+                $table->string('media_type')->nullable();
+            }
+
+            if (!Schema::hasColumn('media_objects', 'file_path')) {
+                $table->string('file_path')->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('media_objects', function (Blueprint $table): void {
+            $table->dropColumn(['media_type', 'file_path']);
+        });
+    }
+};

--- a/database/migrations/2026_07_16_000001_add_pedigree_to_people_table.php
+++ b/database/migrations/2026_07_16_000001_add_pedigree_to_people_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * GEDCOM FAMC.PEDI: the child's link-type to its child_in_family_id family
+ * (birth / adopted / foster / sealing). Null = biological (the standard case).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('people', function (Blueprint $table): void {
+            if (!Schema::hasColumn('people', 'pedigree')) {
+                $table->string('pedigree')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('people', function (Blueprint $table): void {
+            if (Schema::hasColumn('people', 'pedigree')) {
+                $table->dropColumn('pedigree');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_16_150000_add_is_public_to_trees.php
+++ b/database/migrations/2026_07_16_150000_add_is_public_to_trees.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('trees', 'is_public')) {
+            Schema::table('trees', function (Blueprint $table): void {
+                // Private by default (SCOPE §20): a tree is only shared once its owner opts in.
+                $table->boolean('is_public')->default(false);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trees', function (Blueprint $table): void {
+            $table->dropColumn('is_public');
+        });
+    }
+};

--- a/resources/views/filament/app/pages/global-search-page.blade.php
+++ b/resources/views/filament/app/pages/global-search-page.blade.php
@@ -2,8 +2,8 @@
     <div class="space-y-6">
         {{-- Search Controls --}}
         <x-filament::section>
-            <x-slot name="heading">Search People</x-slot>
-            <x-slot name="description">Search across genealogy records. Living individuals (born less than 100 years ago with no death record) from other teams are excluded for privacy.</x-slot>
+            <x-slot name="heading">Global Search</x-slot>
+            <x-slot name="description">Search people, places, sources and events. Living individuals (born less than 100 years ago with no death record) from other teams are excluded for privacy.</x-slot>
 
             <div class="space-y-4">
                 <div class="flex gap-4 items-end">
@@ -13,8 +13,28 @@
                             type="text"
                             id="search-query"
                             wire:model.live.debounce.300ms="query"
-                            placeholder="Enter name, place, or description..."
+                            placeholder="Enter name, place, source or event..."
                             class="w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 shadow-sm focus:border-primary-500 focus:ring-primary-500"
+                        >
+                    </div>
+                    <div>
+                        <label for="from-year" class="block text-sm font-medium mb-1">From year</label>
+                        <input
+                            type="number"
+                            id="from-year"
+                            wire:model.blur="fromYear"
+                            placeholder="e.g. 1800"
+                            class="w-28 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 shadow-sm focus:border-primary-500 focus:ring-primary-500"
+                        >
+                    </div>
+                    <div>
+                        <label for="to-year" class="block text-sm font-medium mb-1">To year</label>
+                        <input
+                            type="number"
+                            id="to-year"
+                            wire:model.blur="toYear"
+                            placeholder="e.g. 1900"
+                            class="w-28 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 shadow-sm focus:border-primary-500 focus:ring-primary-500"
                         >
                     </div>
                     <button
@@ -42,93 +62,126 @@
 
         {{-- Results --}}
         @if($totalResults > 0)
-            <x-filament::section>
-                <x-slot name="heading">Results ({{ number_format($totalResults) }} found)</x-slot>
+            {{-- People --}}
+            @if(!empty($groups['people']))
+                <x-filament::section>
+                    <x-slot name="heading">People ({{ count($groups['people']) }})</x-slot>
 
-                <div class="divide-y divide-gray-200 dark:divide-gray-700">
-                    @foreach($results as $person)
-                        <div class="py-4 first:pt-0 last:pb-0">
-                            <div class="flex items-start gap-4">
-                                {{-- Avatar --}}
-                                <div class="flex-shrink-0">
-                                    <div class="w-12 h-12 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-lg font-bold text-gray-500">
-                                        {{ strtoupper(substr($person->givn ?? '?', 0, 1)) }}{{ strtoupper(substr($person->surn ?? '?', 0, 1)) }}
-                                    </div>
-                                </div>
-
-                                {{-- Info --}}
-                                <div class="flex-1 min-w-0">
-                                    <div class="flex items-center gap-2">
-                                        <h3 class="text-base font-semibold text-gray-900 dark:text-white truncate">
-                                            {{ $person->givn }} {{ $person->surn }}
-                                        </h3>
-                                        @if($person->sex === 'M')
-                                            <span class="text-blue-500 text-sm">♂</span>
-                                        @elseif($person->sex === 'F')
-                                            <span class="text-pink-500 text-sm">♀</span>
-                                        @endif
-
-                                        @if($person->team_id !== auth()->user()?->currentTeam?->id)
-                                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                                                Shared
-                                            </span>
-                                        @endif
+                    <div class="divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach($groups['people'] as $person)
+                            <div class="py-4 first:pt-0 last:pb-0">
+                                <div class="flex items-start gap-4">
+                                    {{-- Avatar --}}
+                                    <div class="flex-shrink-0">
+                                        <div class="w-12 h-12 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-lg font-bold text-gray-500">
+                                            {{ strtoupper(substr($person->givn ?? '?', 0, 1)) }}{{ strtoupper(substr($person->surn ?? '?', 0, 1)) }}
+                                        </div>
                                     </div>
 
-                                    <div class="mt-1 text-sm text-gray-600 dark:text-gray-400 space-x-4">
-                                        @if($person->birthday)
-                                            <span>b. {{ $person->birthday->format('Y') }}</span>
-                                        @elseif($person->birth_year)
-                                            <span>b. {{ $person->birth_year }}</span>
-                                        @endif
+                                    {{-- Info --}}
+                                    <div class="flex-1 min-w-0">
+                                        <div class="flex items-center gap-2">
+                                            <h3 class="text-base font-semibold text-gray-900 dark:text-white truncate">
+                                                {{ $person->givn }} {{ $person->surn }}
+                                            </h3>
+                                            @if($person->sex === 'M')
+                                                <span class="text-blue-500 text-sm">♂</span>
+                                            @elseif($person->sex === 'F')
+                                                <span class="text-pink-500 text-sm">♀</span>
+                                            @endif
 
-                                        @if($person->birthday_plac)
-                                            <span>📍 {{ $person->birthday_plac }}</span>
-                                        @endif
+                                            @if($person->team_id !== auth()->user()?->currentTeam?->id)
+                                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                                                    Shared
+                                                </span>
+                                            @endif
+                                        </div>
 
-                                        @if($person->deathday)
-                                            <span>d. {{ $person->deathday->format('Y') }}</span>
-                                        @elseif($person->death_year)
-                                            <span>d. {{ $person->death_year }}</span>
-                                        @endif
+                                        <div class="mt-1 text-sm text-gray-600 dark:text-gray-400 space-x-4">
+                                            @if($person->birthday)
+                                                <span>b. {{ $person->birthday->format('Y') }}</span>
+                                            @elseif($person->birth_year)
+                                                <span>b. {{ $person->birth_year }}</span>
+                                            @endif
 
-                                        @if($person->deathday_plac)
-                                            <span>📍 {{ $person->deathday_plac }}</span>
+                                            @if($person->birthday_plac)
+                                                <span>📍 {{ $person->birthday_plac }}</span>
+                                            @endif
+
+                                            @if($person->deathday)
+                                                <span>d. {{ $person->deathday->format('Y') }}</span>
+                                            @elseif($person->death_year)
+                                                <span>d. {{ $person->death_year }}</span>
+                                            @endif
+
+                                            @if($person->deathday_plac)
+                                                <span>📍 {{ $person->deathday_plac }}</span>
+                                            @endif
+                                        </div>
+
+                                        @if($person->description)
+                                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-500 truncate">{{ \Illuminate\Support\Str::limit($person->description, 120) }}</p>
                                         @endif
                                     </div>
-
-                                    @if($person->description)
-                                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-500 truncate">{{ \Illuminate\Support\Str::limit($person->description, 120) }}</p>
-                                    @endif
                                 </div>
                             </div>
-                        </div>
-                    @endforeach
-                </div>
-
-                {{-- Pagination --}}
-                @if($lastPage > 1)
-                    <div class="flex items-center justify-between pt-4 border-t dark:border-gray-700">
-                        <button
-                            wire:click="previousPage"
-                            @if($currentPage <= 1) disabled @endif
-                            class="px-4 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-800"
-                        >
-                            Previous
-                        </button>
-                        <span class="text-sm text-gray-600 dark:text-gray-400">
-                            Page {{ $currentPage }} of {{ $lastPage }}
-                        </span>
-                        <button
-                            wire:click="nextPage"
-                            @if($currentPage >= $lastPage) disabled @endif
-                            class="px-4 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-800"
-                        >
-                            Next
-                        </button>
+                        @endforeach
                     </div>
-                @endif
-            </x-filament::section>
+                </x-filament::section>
+            @endif
+
+            {{-- Places --}}
+            @if(!empty($groups['places']))
+                <x-filament::section>
+                    <x-slot name="heading">Places ({{ count($groups['places']) }})</x-slot>
+                    <div class="divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach($groups['places'] as $place)
+                            <div class="py-3 first:pt-0 last:pb-0">
+                                <h3 class="text-base font-semibold text-gray-900 dark:text-white">📍 {{ $place->title }}</h3>
+                                @if($place->description)
+                                    <p class="text-sm text-gray-500 dark:text-gray-400 truncate">{{ \Illuminate\Support\Str::limit($place->description, 120) }}</p>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                </x-filament::section>
+            @endif
+
+            {{-- Sources --}}
+            @if(!empty($groups['sources']))
+                <x-filament::section>
+                    <x-slot name="heading">Sources ({{ count($groups['sources']) }})</x-slot>
+                    <div class="divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach($groups['sources'] as $source)
+                            <div class="py-3 first:pt-0 last:pb-0">
+                                <h3 class="text-base font-semibold text-gray-900 dark:text-white">📄 {{ $source->name ?? $source->titl }}</h3>
+                                @if($source->titl && $source->name)
+                                    <p class="text-sm text-gray-500 dark:text-gray-400 truncate">{{ $source->titl }}</p>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                </x-filament::section>
+            @endif
+
+            {{-- Events --}}
+            @if(!empty($groups['events']))
+                <x-filament::section>
+                    <x-slot name="heading">Events ({{ count($groups['events']) }})</x-slot>
+                    <div class="divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach($groups['events'] as $event)
+                            <div class="py-3 first:pt-0 last:pb-0">
+                                <h3 class="text-base font-semibold text-gray-900 dark:text-white">📅 {{ $event->title ?: $event->type }}</h3>
+                                <div class="text-sm text-gray-500 dark:text-gray-400 space-x-4">
+                                    @if($event->type)<span>{{ $event->type }}</span>@endif
+                                    @if($event->year)<span>{{ $event->year }}</span>@endif
+                                    @if($event->plac)<span>📍 {{ $event->plac }}</span>@endif
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </x-filament::section>
+            @endif
         @elseif(!empty(trim($query)) && strlen(trim($query)) >= 2)
             <x-filament::section>
                 <div class="text-center py-8">
@@ -141,7 +194,7 @@
             <x-filament::section>
                 <div class="text-center py-8">
                     <div class="text-4xl mb-2">🌳</div>
-                    <p class="text-gray-500 dark:text-gray-400">Enter a name, place, or description to search genealogy records.</p>
+                    <p class="text-gray-500 dark:text-gray-400">Enter a name, place, source or event to search genealogy records.</p>
                     <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">Results from other public teams will exclude living individuals for privacy.</p>
                 </div>
             </x-filament::section>

--- a/resources/views/filament/app/pages/relationship-calculator-report.blade.php
+++ b/resources/views/filament/app/pages/relationship-calculator-report.blade.php
@@ -1,0 +1,28 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <x-slot name="heading">How are they related?</x-slot>
+        <x-slot name="description">Pick two people to see how the first is related to the second.</x-slot>
+
+        <form wire:submit="calculate">
+            {{ $this->form }}
+
+            <div class="mt-6">
+                <x-filament::button type="submit">
+                    Calculate
+                </x-filament::button>
+            </div>
+        </form>
+    </x-filament::section>
+
+    @if ($this->relationship !== null)
+        <x-filament::section class="mt-6">
+            <x-slot name="heading">Result</x-slot>
+            <p class="text-2xl font-bold text-primary-600 dark:text-primary-400">
+                {{ ucfirst($this->relationship) }}
+            </p>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                (first person's relationship to the second)
+            </p>
+        </x-filament::section>
+    @endif
+</x-filament-panels::page>

--- a/resources/views/filament/app/pages/tree-privacy.blade.php
+++ b/resources/views/filament/app/pages/tree-privacy.blade.php
@@ -1,0 +1,31 @@
+<x-filament-panels::page>
+    <div class="space-y-4">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+            Trees are private by default. Make one public to share it beyond your team.
+        </p>
+
+        @forelse ($this->trees() as $tree)
+            <div class="flex items-center justify-between bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+                <div>
+                    <h3 class="text-base font-semibold text-gray-900 dark:text-white">
+                        {{ $tree->name ?: 'Untitled tree' }}
+                    </h3>
+                    <span class="text-xs {{ $tree->is_public ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400' }}">
+                        {{ $tree->is_public ? 'Public' : 'Private' }}
+                    </span>
+                </div>
+
+                <x-filament::button
+                    wire:click="toggle({{ $tree->id }})"
+                    :color="$tree->is_public ? 'gray' : 'primary'"
+                >
+                    {{ $tree->is_public ? 'Make private' : 'Make public' }}
+                </x-filament::button>
+            </div>
+        @empty
+            <div class="text-gray-600 dark:text-gray-400">
+                No trees found.
+            </div>
+        @endforelse
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/Reports/RelationshipCalculatorTest.php
+++ b/tests/Feature/Reports/RelationshipCalculatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Reports;
+
+use App\Models\Family;
+use App\Models\Person;
+use App\Models\User;
+use App\Modules\Core\Services\TreeService;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RelationshipCalculatorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Person / Family are tenant-scoped (BelongsToTenant); reads no-op without
+     * an authed tenant context. Mirror DnaMatchingTenantScopeTest's setup.
+     */
+    private function actAsTenant(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+    }
+
+    public function test_relationships_are_computed_from_the_lowest_common_ancestor(): void
+    {
+        $this->actAsTenant();
+
+        // Grandparent -> {parent, auncle} -> {cousinA, cousinB}
+        $grandparent = Person::factory()->create();
+        $gpFamily = Family::factory()->create(['husband_id' => $grandparent->id, 'wife_id' => null]);
+
+        $parent = Person::factory()->create(['child_in_family_id' => $gpFamily->id]);
+        $auncle = Person::factory()->create(['child_in_family_id' => $gpFamily->id]);
+
+        $parentFamily = Family::factory()->create(['husband_id' => $parent->id, 'wife_id' => null]);
+        $auncleFamily = Family::factory()->create(['husband_id' => $auncle->id, 'wife_id' => null]);
+
+        $cousinA = Person::factory()->create(['child_in_family_id' => $parentFamily->id]);
+        $cousinB = Person::factory()->create(['child_in_family_id' => $auncleFamily->id]);
+
+        $service = app(TreeService::class);
+
+        $this->assertSame('sibling', $service->calculateRelationship($parent, $auncle));
+        $this->assertSame('parent', $service->calculateRelationship($parent, $cousinA));
+        $this->assertSame('grandparent', $service->calculateRelationship($grandparent, $cousinA));
+        $this->assertSame('1st cousin', $service->calculateRelationship($cousinA, $cousinB));
+
+        // Framing is person1-relative and unrelated trees are labelled as such.
+        $this->assertSame('grandchild', $service->calculateRelationship($cousinA, $grandparent));
+        $this->assertSame('self', $service->calculateRelationship($parent, $parent));
+        $this->assertSame(
+            'no traceable relationship',
+            $service->calculateRelationship($parent, Person::factory()->create()),
+        );
+    }
+}

--- a/tests/Feature/Search/GlobalSearchTest.php
+++ b/tests/Feature/Search/GlobalSearchTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Search;
+
+use App\Models\Person;
+use App\Models\PersonEvent;
+use App\Models\Place;
+use App\Models\Source;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\PersonSearchService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GlobalSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected PersonSearchService $service;
+
+    protected int $teamId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PersonSearchService;
+
+        // All searchable entities are tenant-scoped (BelongsToTenant), so a
+        // signed-in user with a current team is required.
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $user->id]);
+        $user->current_team_id = $team->id;
+        $user->save();
+        $this->actingAs($user);
+        $this->teamId = $team->id;
+    }
+
+    public function test_search_all_finds_person_by_name(): void
+    {
+        Person::factory()->create([
+            'givn' => 'Aloysius',
+            'surn' => 'Uniquesurname',
+            'team_id' => $this->teamId,
+        ]);
+
+        $groups = $this->service->searchAll('Uniquesurname');
+
+        $this->assertContains('Uniquesurname', $groups['people']->pluck('surn')->all());
+    }
+
+    public function test_search_all_finds_place_by_title(): void
+    {
+        Place::factory()->create(['title' => 'Transylvania']);
+
+        $groups = $this->service->searchAll('Transylvania');
+
+        $this->assertContains('Transylvania', $groups['places']->pluck('title')->all());
+    }
+
+    public function test_search_all_finds_source_by_name(): void
+    {
+        Source::factory()->create(['name' => 'DomesdayBook']);
+
+        $groups = $this->service->searchAll('DomesdayBook');
+
+        $this->assertContains('DomesdayBook', $groups['sources']->pluck('name')->all());
+    }
+
+    public function test_search_all_finds_event_by_title(): void
+    {
+        PersonEvent::factory()->create([
+            'title' => 'GreatCoronation',
+            'type' => 'coronation',
+        ]);
+
+        $groups = $this->service->searchAll('GreatCoronation');
+
+        $this->assertContains('GreatCoronation', $groups['events']->pluck('title')->all());
+    }
+
+    public function test_phonetic_fallback_finds_similar_surname(): void
+    {
+        // "Smyth" is not a literal match for "Smith", but they share Soundex S530.
+        Person::factory()->create([
+            'givn' => 'John',
+            'surn' => 'Smith',
+            'team_id' => $this->teamId,
+        ]);
+
+        $groups = $this->service->searchAll('Smyth');
+
+        $this->assertContains('Smith', $groups['people']->pluck('surn')->all());
+    }
+
+    public function test_year_filter_narrows_person_results(): void
+    {
+        Person::factory()->create([
+            'givn' => 'Early',
+            'surn' => 'Yeartest',
+            'birth_year' => 1850,
+            'team_id' => $this->teamId,
+        ]);
+        Person::factory()->create([
+            'givn' => 'Late',
+            'surn' => 'Yeartest',
+            'birth_year' => 1950,
+            'team_id' => $this->teamId,
+        ]);
+
+        $unfiltered = $this->service->searchAll('Yeartest');
+        $this->assertCount(2, $unfiltered['people']);
+
+        // Only the 1850 birth should survive a "to 1900" bound.
+        $filtered = $this->service->searchAll('Yeartest', null, 1900);
+        $this->assertCount(1, $filtered['people']);
+        $this->assertSame(1850, (int) $filtered['people']->first()->birth_year);
+    }
+}

--- a/tests/Feature/Trees/TreePrivacyTest.php
+++ b/tests/Feature/Trees/TreePrivacyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Trees;
+
+use App\Models\Tree;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Per-tree privacy (SCOPE §3/§20): trees are private by default and only
+ * surface publicly once the owner opts in. Tree is tenant-scoped via
+ * BelongsToTenant, so a tenant must be set for the global scope to behave.
+ */
+class TreePrivacyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actAsTenant(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+
+        return $user;
+    }
+
+    public function test_a_new_tree_is_private_by_default(): void
+    {
+        $this->actAsTenant();
+
+        $tree = Tree::factory()->create();
+
+        $this->assertFalse($tree->is_public, 'A newly created tree must default to private.');
+        $this->assertFalse($tree->fresh()->is_public, 'The private default must persist to the database.');
+    }
+
+    public function test_public_scope_returns_only_public_trees(): void
+    {
+        $this->actAsTenant();
+
+        $private = Tree::factory()->create(); // is_public defaults to false
+        $public = Tree::factory()->create(['is_public' => true]);
+
+        $ids = Tree::public()->pluck('id');
+
+        $this->assertTrue($ids->contains($public->id), 'Public tree must be returned by public() scope.');
+        $this->assertFalse($ids->contains($private->id), 'Private tree must NOT be returned by public() scope.');
+    }
+
+    public function test_toggling_visibility_persists(): void
+    {
+        $this->actAsTenant();
+
+        $tree = Tree::factory()->create();
+
+        $tree->is_public = true;
+        $tree->save();
+
+        $this->assertTrue($tree->fresh()->is_public, 'Flipping a tree to public must persist.');
+    }
+}

--- a/tests/Filament/Resources/MediaObjectResourceTest.php
+++ b/tests/Filament/Resources/MediaObjectResourceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Resources;
+
+use App\Enums\MediaType;
+use App\Filament\App\Resources\MediaObjectResource\Pages\CreateMediaObject;
+use App\Models\MediaObject;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class MediaObjectResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+
+        return $user;
+    }
+
+    public function test_create_page_mounts(): void
+    {
+        $this->actingUser();
+
+        Livewire::test(CreateMediaObject::class)->assertOk();
+    }
+
+    public function test_persists_media_type_and_file_path(): void
+    {
+        $this->actingUser();
+
+        $media = MediaObject::create([
+            'titl' => 'Birth Certificate',
+            'media_type' => MediaType::CERTIFICATE,
+            'file_path' => 'media-objects/birth.pdf',
+        ]);
+
+        $this->assertDatabaseHas('media_objects', [
+            'id' => $media->id,
+            'media_type' => 'certificate',
+            'file_path' => 'media-objects/birth.pdf',
+        ]);
+
+        $this->assertSame(MediaType::CERTIFICATE, $media->fresh()->media_type);
+    }
+}

--- a/tests/Unit/Models/PersonPedigreeTest.php
+++ b/tests/Unit/Models/PersonPedigreeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Enums\PedigreeType;
+use App\Models\Person;
+use Tests\TestCase;
+
+class PersonPedigreeTest extends TestCase
+{
+    public function test_pedigree_cast_round_trips_to_enum(): void
+    {
+        $person = new Person(['pedigree' => 'adopted']);
+
+        $this->assertSame(PedigreeType::ADOPTED, $person->pedigree);
+    }
+
+    public function test_is_adopted_true_only_for_adopted(): void
+    {
+        $this->assertTrue((new Person(['pedigree' => 'adopted']))->isAdopted());
+        $this->assertFalse((new Person(['pedigree' => 'foster']))->isAdopted());
+        $this->assertFalse((new Person(['pedigree' => 'birth']))->isAdopted());
+    }
+
+    public function test_null_pedigree_is_not_adopted_and_reads_biological(): void
+    {
+        $person = new Person;
+
+        $this->assertNull($person->pedigree);
+        $this->assertFalse($person->isAdopted());
+        $this->assertSame('Biological', $person->pedigreeLabel());
+    }
+}


### PR DESCRIPTION
Five more `SCOPE_TASKS.md` items via parallel agents on disjoint files, integrated + verified centrally. Full suite **490 passed / 0 failed**; the three migrations were run on real **MySQL**.

| Item | What |
|------|------|
| **C2** | `PedigreeType` enum (birth/adopted/foster/sealing) on the child link — covers biological/adoptive; step/guardianship flagged as needing the `PersonAsso` seam |
| **C10** | Relationship calculator implemented (was a `null` stub) — LCA + generation math → sibling/cousin-Nth-removed/etc., with a report page |
| **C3** | Per-tree `is_public`, **private by default** (model + DB), self-service toggle page |
| **N1** | Global search extended to places/sources/events + bounded Soundex phonetic fallback + year-range filter |
| **N3** | Media upload + type taxonomy (photo/document/certificate/census/scan); OCR/indexing deferred |

## Verification
Each ships a test that bites (enum cast + `isAdopted`, LCA relationship labels, default-private + scope + toggle, multi-entity + phonetic + year-filter search, media persist + mount). Guards intact: no `phpunit.xml`/config/FK weakened, no existing test deleted, disjoint files (no path touched by two agents).

## Integration fix I made centrally
PRIV's default-private test failed — the DB `default(false)` only applies on INSERT, so a freshly-created model read `is_public = null` in-memory. Added a model-level `$attributes = ['is_public' => false]` so private-by-default holds before the model round-trips (the correct fix, not relaxing the test).

## Honest limits flagged (not buried)
- Step-parent / guardianship need a person→person association table (`PersonAsso`), not a child-link flag.
- Relationship calculator punts half- vs full-sibling and gendered direct-line labels.
- New search tables lack FULLTEXT indexes (capped LIKE scan) — upgrade path noted.
- Media OCR / indexing / face-tagging deferred.
- Tree `is_public` has no live public read surface (`PublicPanelProvider` is dead code) — data model + toggle only.