### PR TITLE
fix(gedcom): repair queueImport's broken job dispatch

### DIFF
--- a/app/Services/GedcomService.php
+++ b/app/Services/GedcomService.php
@@ -9,6 +9,7 @@ use App\Models\ImportJob;
 use FamilyTree365\LaravelGedcom\Utils\GedcomGenerator;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class GedcomService
@@ -108,7 +109,13 @@ class GedcomService
             'slug' => Str::uuid()->toString(),
         ]);
 
-        ImportGedcom::dispatch($path, $job->slug);
+        // ImportGedcom::__construct is (User $user, string $filePath, ?string $slug).
+        // The old dispatch passed ($path, $slug) — the relative path landed in the
+        // User slot (TypeError, every queued import died) and nothing was a User.
+        // Pass the authenticated user, the ABSOLUTE file path (handle() reads it
+        // with File::isFile/File::get, which need a real path, not the relative
+        // one $file->store() returns), and the slug.
+        ImportGedcom::dispatch(Auth::user(), Storage::disk('private')->path($path), $job->slug);
 
         return $job;
     }

--- a/tests/Feature/Services/GedcomQueueImportTest.php
+++ b/tests/Feature/Services/GedcomQueueImportTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Jobs\ImportGedcom;
+use App\Models\User;
+use App\Services\GedcomService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use ReflectionObject;
+use Tests\TestCase;
+
+/**
+ * queueImport dispatched ImportGedcom with the wrong arguments — ($path, $slug)
+ * against a (User, filePath, ?slug) constructor — so the relative path landed in
+ * the User slot (TypeError) and every queued GEDCOM import died before running.
+ */
+class GedcomQueueImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_queue_import_dispatches_the_job_with_a_user_and_absolute_path(): void
+    {
+        Storage::fake('private');
+        Bus::fake();
+
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $file = UploadedFile::fake()->createWithContent('tree.ged', "0 HEAD\n0 TRLR\n");
+
+        $job = (new GedcomService)->queueImport($file);
+
+        $this->assertDatabaseHas('importjobs', ['slug' => $job->slug, 'user_id' => $user->id]);
+
+        Bus::assertDispatched(ImportGedcom::class, function (ImportGedcom $dispatched) use ($user, $job): bool {
+            $ref = new ReflectionObject($dispatched);
+
+            $userProp = $ref->getProperty('user');
+            $userProp->setAccessible(true);
+            $filePathProp = $ref->getProperty('filePath');
+            $filePathProp->setAccessible(true);
+
+            $dispatchedUser = $userProp->getValue($dispatched);
+            $filePath = $filePathProp->getValue($dispatched);
+
+            // User is a real User (not the path string), the file path is an
+            // absolute, existing file (not the relative store() path), slug matches.
+            return $dispatchedUser instanceof User
+                && $dispatchedUser->is($user)
+                && is_string($filePath)
+                && is_file($filePath)
+                && $dispatched->slug === $job->slug;
+        });
+    }
+}


### PR DESCRIPTION
`GedcomService::queueImport()` dispatched the import job with the wrong arguments, so **every queued GEDCOM import died at construction** before doing any work.

```php
// job:  __construct(User $user, string $filePath, ?string $slug = null)
// was:  ImportGedcom::dispatch($path, $job->slug);
```

The relative file path landed in the `User` slot → `Argument #1 ($user) must be of type App\Models\User, string given`.

**Fix:** dispatch `(Auth::user(), Storage::disk('private')->path($path), $job->slug)` — correct order **and** the absolute path, since `handle()` reads the file with `File::isFile`/`File::get`, which need a real path (not the relative one `store()` returns).

**Test** dispatches through the real service (`Bus::fake`) and asserts the User slot holds a `User` and `filePath` is an existing absolute file. Mutation-checked: the old arg order fails it with the original `TypeError`.

Full suite **525 passed / 0 failed**; PHPStan + Pint gates clean.

(Flagged as discovered-not-fixed back in #1509; this closes it.)