### PR TITLE
feat: GEDCOM person associations + person↔source evidence links

### DIFF
--- a/app/Enums/AssociationType.php
+++ b/app/Enums/AssociationType.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Person-to-person associations — GEDCOM's ASSO/RELA structure.
+ *
+ * This is where step-parent, guardianship and godparent relationships live.
+ * They deliberately do NOT belong on `people.pedigree` (see PedigreeType):
+ * pedigree describes how a child links to the ONE family they are a child of,
+ * whereas an association is a free-standing link between two people that needs
+ * no family record at all.
+ *
+ * GEDCOM 5.5.1 RELA is a free-text descriptor, so `person_asso.rela` stays a
+ * string and imported files may carry values outside this enum. Treat these as
+ * the curated set the UI offers, not a closed world — always resolve through
+ * tryFrom() and fall back to the raw string.
+ */
+enum AssociationType: string
+{
+    case STEP_PARENT = 'step-parent';
+    case STEP_CHILD = 'step-child';
+    case GUARDIAN = 'guardian';
+    case WARD = 'ward';
+    case GODPARENT = 'godparent';
+    case GODCHILD = 'godchild';
+    case FOSTER_PARENT = 'foster-parent';
+    case FOSTER_CHILD = 'foster-child';
+    case WITNESS = 'witness';
+    case INFORMANT = 'informant';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::STEP_PARENT => 'Step-parent',
+            self::STEP_CHILD => 'Step-child',
+            self::GUARDIAN => 'Guardian',
+            self::WARD => 'Ward',
+            self::GODPARENT => 'Godparent',
+            self::GODCHILD => 'Godchild',
+            self::FOSTER_PARENT => 'Foster parent',
+            self::FOSTER_CHILD => 'Foster child',
+            self::WITNESS => 'Witness',
+            self::INFORMANT => 'Informant',
+        };
+    }
+
+    /**
+     * The reciprocal association. GEDCOM records an ASSO in one direction only,
+     * so this is what the other person's side of the link means — used to label
+     * incoming associations without storing a duplicate row.
+     */
+    public function inverse(): self
+    {
+        return match ($this) {
+            self::STEP_PARENT => self::STEP_CHILD,
+            self::STEP_CHILD => self::STEP_PARENT,
+            self::GUARDIAN => self::WARD,
+            self::WARD => self::GUARDIAN,
+            self::GODPARENT => self::GODCHILD,
+            self::GODCHILD => self::GODPARENT,
+            self::FOSTER_PARENT => self::FOSTER_CHILD,
+            self::FOSTER_CHILD => self::FOSTER_PARENT,
+            // Witness/informant are roles, not pairings: they have no reciprocal.
+            self::WITNESS => self::WITNESS,
+            self::INFORMANT => self::INFORMANT,
+        };
+    }
+
+    /**
+     * Human label for a stored `rela` string, which may be free text from an
+     * imported GEDCOM rather than one of our cases.
+     */
+    public static function labelFor(?string $rela): string
+    {
+        if ($rela === null || trim($rela) === '') {
+            return 'Unknown';
+        }
+
+        return self::tryFrom($rela)?->label() ?? $rela;
+    }
+
+    /** @return array<string, string> */
+    public static function options(): array
+    {
+        $options = [];
+        foreach (self::cases() as $case) {
+            $options[$case->value] = $case->label();
+        }
+
+        return $options;
+    }
+}

--- a/app/Filament/App/Resources/PersonAssoResource.php
+++ b/app/Filament/App/Resources/PersonAssoResource.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Filament\App\Resources;
 
+use App\Enums\AssociationType;
 use App\Filament\App\Resources\PersonAssoResource\Pages\CreatePersonAsso;
 use App\Filament\App\Resources\PersonAssoResource\Pages\EditPersonAsso;
 use App\Filament\App\Resources\PersonAssoResource\Pages\ListPersonAssos;
+use App\Models\Person;
 use App\Models\PersonAsso;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
-use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Select;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -36,38 +39,75 @@ class PersonAssoResource extends AppResource
     {
         return $schema
             ->components([
-                TextInput::make('group')
-                    ->maxLength(255),
-                TextInput::make('gid')
-                    ->numeric(),
-                TextInput::make('indi')
-                    ->maxLength(255),
-                TextInput::make('rela')
-                    ->maxLength(255),
-                TextInput::make('import_confirm')
+                Select::make('gid')
+                    ->label('Person')
                     ->required()
-                    ->numeric()
-                    ->default(0),
+                    ->searchable()
+                    ->getSearchResultsUsing(fn (string $search): array => self::searchPeople($search))
+                    ->getOptionLabelUsing(fn ($value): ?string => Person::find($value)?->fullname()),
+                Select::make('indi')
+                    ->label('Associated person')
+                    ->required()
+                    ->searchable()
+                    // `indi` is a varchar holding a person id — the importer parks a raw
+                    // xref ("@I5@") there before resolving it. Keep UI writes to match.
+                    ->dehydrateStateUsing(fn ($state): string => (string) $state)
+                    ->getSearchResultsUsing(fn (string $search): array => self::searchPeople($search))
+                    ->getOptionLabelUsing(fn ($value): ?string => Person::find($value)?->fullname()),
+                Select::make('rela')
+                    ->label('Relationship')
+                    ->required()
+                    // RELA is free text in GEDCOM; offer an imported value back rather
+                    // than let required() silently rewrite it.
+                    ->options(fn (?PersonAsso $record): array => $record?->rela !== null && $record->type() === null
+                        ? [$record->rela => $record->rela] + AssociationType::options()
+                        : AssociationType::options()),
+                // Not user-facing: this resource only manages resolved person-level
+                // associations. import_confirm = 0 is the importer's "xref not yet
+                // resolved" marker, so anything created here is already resolved.
+                Hidden::make('group')
+                    ->default(PersonAsso::GROUP_INDI),
+                Hidden::make('import_confirm')
+                    ->default(1),
             ]);
+    }
+
+    /** @return array<int, string> */
+    private static function searchPeople(string $search): array
+    {
+        return Person::query()
+            ->where(fn ($query) => $query
+                ->where('givn', 'like', "%{$search}%")
+                ->orWhere('surn', 'like', "%{$search}%"))
+            ->limit(50)
+            ->get()
+            ->mapWithKeys(fn (Person $person): array => [$person->getKey() => $person->fullname()])
+            ->all();
     }
 
     #[Override]
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn ($query) => $query->with(['person', 'associate']))
             ->columns([
-                TextColumn::make('group')
-                    ->searchable(),
                 TextColumn::make('gid')
-                    ->numeric()
-                    ->sortable(),
+                    ->label('Person')
+                    ->getStateUsing(fn (PersonAsso $record): string => $record->person?->fullname()
+                        ?? (string) ($record->gid ?? 'Unknown'))
+                    ->searchable(),
                 TextColumn::make('indi')
+                    ->label('Associated person')
+                    // Rows still holding an unresolved xref have no Person to resolve to.
+                    ->getStateUsing(fn (PersonAsso $record): string => $record->associate?->fullname()
+                        ?? $record->indi
+                        ?? 'Unresolved')
                     ->searchable(),
                 TextColumn::make('rela')
+                    ->label('Relationship')
+                    ->getStateUsing(fn (PersonAsso $record): string => $record->typeLabel())
+                    ->badge()
                     ->searchable(),
-                TextColumn::make('import_confirm')
-                    ->numeric()
-                    ->sortable(),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()

--- a/app/Filament/App/Resources/PersonResource.php
+++ b/app/Filament/App/Resources/PersonResource.php
@@ -8,6 +8,11 @@ use App\Enums\PedigreeType;
 use App\Filament\App\Resources\PersonResource\Pages\CreatePerson;
 use App\Filament\App\Resources\PersonResource\Pages\EditPerson;
 use App\Filament\App\Resources\PersonResource\Pages\ListPeople;
+// Namespace import: getRelations() refers to these as RelationManagers\Foo::class,
+// which without this resolves to App\Filament\App\Resources\RelationManagers\Foo —
+// a directory that does not exist. ::class does not autoload, so the bad name was
+// only discovered when Filament tried to instantiate it.
+use App\Filament\App\Resources\PersonResource\RelationManagers;
 use App\Models\Person;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
@@ -151,6 +156,8 @@ class PersonResource extends AppResource
     {
         return [
             RelationManagers\PhotosRelationManager::class,
+            RelationManagers\AssociationsRelationManager::class,
+            RelationManagers\SourcesRelationManager::class,
         ];
     }
 

--- a/app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
+++ b/app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
@@ -22,7 +22,9 @@ class EditPerson extends EditRecord
             DeleteAction::make(),
             Action::make('selectMedia')
                 ->label('Select GEDCOM Media')
-                ->icon('heroicon-o-photograph')
+                // 'photograph' is a Heroicons v1 name; v2 renamed it to 'photo', and
+                // blade-icons throws SvgNotFound at render rather than degrading.
+                ->icon('heroicon-o-photo')
                 ->modalHeading('Select GEDCOM Media to Use as Profile Photo')
                 ->modalWidth('lg')
                 ->form([

--- a/app/Filament/App/Resources/PersonResource/RelationManagers/AssociationsRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/AssociationsRelationManager.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\PersonResource\RelationManagers;
+
+use App\Enums\AssociationType;
+use App\Models\Person;
+use App\Models\PersonAsso;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * GEDCOM ASSO — the step-parents, guardians, godparents and witnesses that no
+ * family record expresses. `group` and `gid` are stamped by the `associations`
+ * relation itself (see Person::associations), so neither appears in the form.
+ */
+class AssociationsRelationManager extends RelationManager
+{
+    #[\Override]
+    protected static string $relationship = 'associations';
+
+    #[\Override]
+    protected static ?string $title = 'Associations';
+
+    #[\Override]
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('indi')
+                    ->label('Associated person')
+                    ->required()
+                    ->searchable()
+                    // `indi` is a varchar: the importer parks a raw xref ("@I5@") there
+                    // before resolving it. Keep UI writes stringly-typed to match.
+                    ->dehydrateStateUsing(fn ($state): string => (string) $state)
+                    ->getSearchResultsUsing(fn (string $search): array => Person::query()
+                        ->whereKeyNot($this->ownerRecord->getKey())
+                        ->where(fn ($query) => $query
+                            ->where('givn', 'like', "%{$search}%")
+                            ->orWhere('surn', 'like', "%{$search}%"))
+                        ->limit(50)
+                        ->get()
+                        ->mapWithKeys(fn (Person $person): array => [$person->getKey() => $person->fullname()])
+                        ->all())
+                    ->getOptionLabelUsing(fn ($value): ?string => Person::find($value)?->fullname()),
+                Select::make('rela')
+                    ->label('Relationship')
+                    ->required()
+                    // RELA is free text in GEDCOM, so an imported row may hold a value
+                    // outside our curated set. Offer it back rather than let required()
+                    // silently rewrite it to a case the user never chose.
+                    ->options(fn (?PersonAsso $record): array => $record?->rela !== null && $record->type() === null
+                        ? [$record->rela => $record->rela] + AssociationType::options()
+                        : AssociationType::options()),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn ($query) => $query->with('associate'))
+            ->columns([
+                TextColumn::make('indi')
+                    ->label('Associated person')
+                    // Rows still holding an unresolved xref have no Person to resolve to.
+                    ->getStateUsing(fn (PersonAsso $record): string => $record->associate?->fullname()
+                        ?? $record->indi
+                        ?? 'Unresolved')
+                    ->searchable(),
+                TextColumn::make('rela')
+                    ->label('Relationship')
+                    ->getStateUsing(fn (PersonAsso $record): string => $record->typeLabel())
+                    ->badge()
+                    ->searchable(),
+                TextColumn::make('created_at')
+                    ->label('Added')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->headerActions([
+                CreateAction::make()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        // The UI only creates resolved rows; import_confirm = 0 is the
+                        // importer's marker for an xref still awaiting resolution.
+                        $data['import_confirm'] = 1;
+
+                        return $data;
+                    }),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/App/Resources/PersonResource/RelationManagers/SourcesRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/SourcesRelationManager.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\PersonResource\RelationManagers;
+
+use App\Filament\App\Resources\SourceRefResource;
+use App\Models\SourceRef;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * The sources evidencing this person as a whole (GEDCOM SOUR, group 'indi').
+ *
+ * Rows created here are stamped group='indi' by Person::sourceRefs()'s
+ * withAttributes(). The GEDCOM importer never writes that group — it only emits
+ * the finer-grained indi_name/indi_even/indi_asso/indi_lds — so this is the only
+ * thing that populates the person half of CompletenessService::sourceCompleteness().
+ */
+class SourcesRelationManager extends RelationManager
+{
+    #[\Override]
+    protected static string $relationship = 'sourceRefs';
+
+    #[\Override]
+    protected static ?string $title = 'Sources';
+
+    #[\Override]
+    public function form(Schema $schema): Schema
+    {
+        // group/gid come from the relation, not the form.
+        return $schema->components(SourceRefResource::citationComponents());
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('source.name')
+                    ->label('Source')
+                    // Importer-created sources fill `titl`, not `name`.
+                    ->getStateUsing(fn (SourceRef $record): string => $record->source?->name
+                        ?: $record->source?->titl
+                        ?: '—'),
+                TextColumn::make('page')
+                    ->label('Page / citation detail'),
+                TextColumn::make('quay')
+                    ->label('Confidence')
+                    ->getStateUsing(fn (SourceRef $record): string => $record->qualityLabel()),
+                TextColumn::make('created_at')
+                    ->label('Added')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/App/Resources/SourceRefResource.php
+++ b/app/Filament/App/Resources/SourceRefResource.php
@@ -7,11 +7,17 @@ namespace App\Filament\App\Resources;
 use App\Filament\App\Resources\SourceRefResource\Pages\CreateSourceRef;
 use App\Filament\App\Resources\SourceRefResource\Pages\EditSourceRef;
 use App\Filament\App\Resources\SourceRefResource\Pages\ListSourceRefs;
+use App\Models\Person;
+use App\Models\Source;
 use App\Models\SourceRef;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Field;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -19,6 +25,14 @@ use Override;
 
 class SourceRefResource extends AppResource
 {
+    /** Mirrors SourceRef::qualityLabel() — GEDCOM QUAY 0-3. */
+    public const QUAY_OPTIONS = [
+        '0' => 'Unreliable',
+        '1' => 'Questionable',
+        '2' => 'Secondary evidence',
+        '3' => 'Primary evidence',
+    ];
+
     #[Override]
     protected static ?string $model = SourceRef::class;
 
@@ -36,19 +50,82 @@ class SourceRefResource extends AppResource
     {
         return $schema
             ->components([
+                // `group`/`gid` are the importer's pseudo-polymorphic key and carry no
+                // FKs, so a free-text edit silently re-points the row at an unrelated
+                // record. Fixed to 'indi' for anything created here — the only group
+                // this UI writes. Imported rows show their own group read-only, and
+                // their `gid` is left untouched because the person Select below hides
+                // for every group but 'indi'.
                 TextInput::make('group')
-                    ->maxLength(255),
-                TextInput::make('gid')
-                    ->numeric(),
-                TextInput::make('sour_id')
-                    ->numeric(),
-                TextInput::make('text')
-                    ->maxLength(255),
-                TextInput::make('quay')
-                    ->maxLength(255),
-                TextInput::make('page')
-                    ->maxLength(255),
+                    ->label('Evidences')
+                    ->default(SourceRef::GROUP_INDI)
+                    ->readOnly(),
+                Select::make('gid')
+                    ->label('Person')
+                    ->options(fn (): array => Person::query()->orderBy('name')->pluck('name', 'id')->all())
+                    ->searchable()
+                    ->required()
+                    ->visible(fn (Get $get): bool => $get('group') === SourceRef::GROUP_INDI),
+                ...self::citationComponents(),
             ]);
+    }
+
+    /**
+     * The citation half of a SOUR reference — which source, where in it, how
+     * trusted. Shared with PersonResource's SourcesRelationManager, which supplies
+     * `group`/`gid` from the relation instead of from the form.
+     *
+     * @return list<Field>
+     */
+    public static function citationComponents(): array
+    {
+        return [
+            Select::make('sour_id')
+                ->label('Source')
+                ->options(fn (): array => self::sourceOptions())
+                ->searchable()
+                ->required(),
+            TextInput::make('page')
+                ->label('Page / citation detail')
+                ->maxLength(255),
+            Select::make('quay')
+                ->label('Confidence')
+                ->helperText('GEDCOM QUAY: how far the source is trusted.')
+                // Merge the record's own value in when it isn't 0-3 (imports carry free
+                // text here), so editing an off-list row can't silently blank it.
+                ->options(function ($record): array {
+                    $options = self::QUAY_OPTIONS;
+                    if ($record?->quay && ! array_key_exists($record->quay, $options)) {
+                        $options[$record->quay] = $record->quay;
+                    }
+
+                    return $options;
+                }),
+            Textarea::make('text')
+                ->label('Quoted text')
+                ->maxLength(255)
+                ->columnSpanFull(),
+        ];
+    }
+
+    /**
+     * Sources keyed by id. The importer fills `titl`; the app's own form fills
+     * `name` — so fall back rather than render a blank option.
+     *
+     * ponytail: loads every source and filters client-side. Swap to
+     * getSearchResultsUsing() if a tree ever carries thousands.
+     *
+     * @return array<int, string>
+     */
+    private static function sourceOptions(): array
+    {
+        return Source::query()
+            ->orderBy('name')
+            ->get(['id', 'name', 'titl'])
+            ->mapWithKeys(fn (Source $source): array => [
+                $source->id => $source->name ?: $source->titl ?: "Source #{$source->id}",
+            ])
+            ->all();
     }
 
     #[Override]

--- a/app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
+++ b/app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
@@ -303,7 +303,7 @@ class AttendeesRelationManager extends RelationManager
                     ->action(fn (VirtualEventAttendee $record) => $record->decline())
                     ->visible(fn (VirtualEventAttendee $record): bool => $record->rsvp_status !== 'declined'),
                 Action::make('mark_attended')
-                    ->icon('heroicon-o-user-check')
+                    ->icon('heroicon-o-check-circle')
                     ->color('primary')
                     ->action(fn (VirtualEventAttendee $record) => $record->markAsAttended())
                     ->visible(fn (VirtualEventAttendee $record): bool => ! $record->attended && ($this->getOwnerRecord()->is_past || $this->getOwnerRecord()->is_active)),
@@ -328,7 +328,7 @@ class AttendeesRelationManager extends RelationManager
                         }),
                     BulkAction::make('mark_all_attended')
                         ->label('Mark All as Attended')
-                        ->icon('heroicon-o-user-check')
+                        ->icon('heroicon-o-check-circle')
                         ->color('primary')
                         ->action(function ($records): void {
                             foreach ($records as $record) {

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -8,6 +8,7 @@ use App\Enums\PedigreeType;
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
@@ -123,6 +124,51 @@ class Person extends Model
     public function events()
     {
         return $this->hasMany(PersonEvent::class)->select(['id', 'person_id', 'title', 'date', 'places_id']);
+    }
+
+    /**
+     * GEDCOM ASSO — links to people that no family record expresses: step-parents,
+     * guardians, godparents, witnesses. Family membership covers birth/adoptive
+     * parents (see PedigreeType); everything else lives here.
+     *
+     * `person_asso` is stringly-typed by GEDCOM convention: `group` names the kind
+     * of record the row hangs off ('indi' = a person) and `gid` is that record's id.
+     * withAttributes() both constrains reads to this group AND stamps it on create —
+     * a bare where() would filter reads and silently write group = null.
+     *
+     * The associated person is `indi`, a varchar: the importer first writes the raw
+     * GEDCOM xref ("@I5@") and a later pass resolves it to a person id, so rows with
+     * import_confirm = 0 may not resolve to a Person at all.
+     */
+    public function associations(): HasMany
+    {
+        return $this->hasMany(PersonAsso::class, 'gid')
+            ->withAttributes(['group' => PersonAsso::GROUP_INDI]);
+    }
+
+    /**
+     * Associations pointing AT this person. GEDCOM records an ASSO in one direction
+     * only, so a guardian has no row of their own — they are found by their ward's.
+     * Read-only in practice: create from the subject's side via associations().
+     */
+    public function associatedWith(): HasMany
+    {
+        return $this->hasMany(PersonAsso::class, 'indi')
+            ->withAttributes(['group' => PersonAsso::GROUP_INDI]);
+    }
+
+    /**
+     * GEDCOM SOUR references — the sources evidencing this person, with the page,
+     * quality and text of each citation. Same (group, gid) convention as above.
+     *
+     * Nothing wrote group = 'indi' before this: the importer only ever emits the
+     * finer-grained 'indi_name'/'indi_even'/'indi_asso'/'indi_lds' groups, which is
+     * why CompletenessService's person-source coverage always reported zero.
+     */
+    public function sourceRefs(): HasMany
+    {
+        return $this->hasMany(SourceRef::class, 'gid')
+            ->withAttributes(['group' => SourceRef::GROUP_INDI]);
     }
 
     public function childInFamily()

--- a/app/Models/PersonAsso.php
+++ b/app/Models/PersonAsso.php
@@ -4,13 +4,72 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\AssociationType;
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * A GEDCOM ASSO: person `gid` is associated with person `indi`, and `rela`
+ * describes how (godparent, guardian, step-parent...).
+ *
+ * @property string|null $group
+ * @property int|null $gid
+ * @property string|null $indi
+ * @property string|null $rela
+ * @property int $import_confirm
+ */
 class PersonAsso extends \FamilyTree365\LaravelGedcom\Models\PersonAsso
 {
     use BelongsToTenant;
     use HasFactory;
     use SoftDeletes;
+
+    /** `group` value marking an association hanging off an individual. */
+    public const GROUP_INDI = 'indi';
+
+    /**
+     * The person this association belongs to — the subject.
+     *
+     * `gid` is a plain integer with no FK constraint; it is the GEDCOM importer's
+     * pseudo-polymorphic key, meaningful only alongside `group`.
+     */
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class, 'gid');
+    }
+
+    /**
+     * The person on the other end of the association.
+     *
+     * `indi` is a varchar because the importer parks the raw GEDCOM xref ("@I5@")
+     * there and resolves it to a person id in a later pass. Rows still holding an
+     * unresolved xref (import_confirm = 0) resolve to null here rather than
+     * erroring — MySQL coerces the varchar for the comparison.
+     */
+    public function associate(): BelongsTo
+    {
+        return $this->belongsTo(Person::class, 'indi');
+    }
+
+    /**
+     * The association type, or null when `rela` holds free text from an imported
+     * GEDCOM that is outside our curated set (RELA is free text in the spec).
+     */
+    public function type(): ?AssociationType
+    {
+        return $this->rela === null ? null : AssociationType::tryFrom($this->rela);
+    }
+
+    public function typeLabel(): string
+    {
+        return AssociationType::labelFor($this->rela);
+    }
+
+    /** True once `indi` holds a resolved person id rather than a GEDCOM xref. */
+    public function isResolved(): bool
+    {
+        return $this->import_confirm === 1;
+    }
 }

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Source extends \FamilyTree365\LaravelGedcom\Models\Source
@@ -41,6 +42,28 @@ class Source extends \FamilyTree365\LaravelGedcom\Models\Source
     public function citations(): HasMany
     {
         return $this->hasMany(Citation::class);
+    }
+
+    /**
+     * Every GEDCOM SOUR reference citing this source, whatever it evidences.
+     * `sour_id` carries no FK constraint.
+     */
+    public function sourceRefs(): HasMany
+    {
+        return $this->hasMany(SourceRef::class, 'sour_id');
+    }
+
+    /**
+     * The people this source evidences. `source_ref` acts as the pivot — gid is
+     * only people.id while group is 'indi', hence the pivot filter.
+     *
+     * Read-side only: attaching through this relation would write neither `group`
+     * nor `team_id`. Create person-level refs via Person::sourceRefs().
+     */
+    public function people(): BelongsToMany
+    {
+        return $this->belongsToMany(Person::class, 'source_ref', 'sour_id', 'gid')
+            ->wherePivot('group', SourceRef::GROUP_INDI);
     }
 
     /**

--- a/app/Models/SourceRef.php
+++ b/app/Models/SourceRef.php
@@ -6,9 +6,67 @@ namespace App\Models;
 
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * A GEDCOM SOUR reference: the record identified by (`group`, `gid`) is evidenced
+ * by source `sour_id`, at `page`, with `quay` confidence and optional `text`.
+ *
+ * @property string|null $group
+ * @property int|null $gid
+ * @property int|null $sour_id
+ * @property string|null $text
+ * @property string|null $quay
+ * @property string|null $page
+ */
 class SourceRef extends \FamilyTree365\LaravelGedcom\Models\SourceRef
 {
     use BelongsToTenant;
     use HasFactory;
+
+    /**
+     * `group` values. The GEDCOM importer only ever writes the fine-grained ones —
+     * a source attached to a name, event, association or LDS ordinance. GROUP_INDI
+     * means the source evidences the person as a whole, which only this app's UI
+     * writes (CompletenessService has always counted it).
+     */
+    public const GROUP_INDI = 'indi';
+
+    public const GROUP_INDI_NAME = 'indi_name';
+
+    public const GROUP_INDI_EVEN = 'indi_even';
+
+    /** The cited source. `sour_id` is a plain integer, no FK constraint. */
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(Source::class, 'sour_id');
+    }
+
+    /**
+     * The person this reference evidences.
+     *
+     * Only meaningful when `group` is GROUP_INDI — `gid` is the importer's
+     * pseudo-polymorphic key, so for other groups it points at an event, name or
+     * ordinance row instead, and this relation would resolve to an unrelated person.
+     */
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class, 'gid');
+    }
+
+    /**
+     * GEDCOM QUAY is 0-3: 0 unreliable, 1 questionable, 2 secondary, 3 primary.
+     * Imported files carry free text here too, so fall back to the raw value.
+     */
+    public function qualityLabel(): string
+    {
+        return match ($this->quay) {
+            '0' => 'Unreliable',
+            '1' => 'Questionable',
+            '2' => 'Secondary evidence',
+            '3' => 'Primary evidence',
+            null, '' => 'Unrated',
+            default => (string) $this->quay,
+        };
+    }
 }

--- a/app/Services/CompletenessService.php
+++ b/app/Services/CompletenessService.php
@@ -95,16 +95,19 @@ class CompletenessService
      */
     public function sourceCompleteness(): array
     {
+        // Passed as an Eloquent builder, not a raw closure: it keeps SourceRef's
+        // team scope inside the subquery, which a `from('source_ref')` closure
+        // would silently drop and count every team's refs.
         $personsTotal = Person::count();
         $personsWithSource = Person::whereIn(
             'id',
-            SourceRef::query()->where('group', 'indi')->pluck('gid')
+            SourceRef::query()->select('gid')->where('group', 'indi')
         )->count();
 
         $eventsTotal = PersonEvent::count();
         $eventsWithSource = PersonEvent::whereIn(
             'id',
-            SourceRef::query()->where('group', 'indi_even')->pluck('gid')
+            SourceRef::query()->select('gid')->where('group', 'indi_even')
         )->count();
 
         $total = $personsTotal + $eventsTotal;

--- a/app/Services/PersonMergeService.php
+++ b/app/Services/PersonMergeService.php
@@ -12,6 +12,7 @@ use App\Models\PersonLds;
 use App\Models\PersonName;
 use App\Models\PersonNameFone;
 use App\Models\PersonSubm;
+use App\Models\SourceRef;
 use App\Models\VirtualEventAttendee;
 use Exception;
 use Illuminate\Support\Facades\DB;
@@ -56,24 +57,49 @@ class PersonMergeService
             $primaryId = $primary->id;
             $duplicateId = $duplicate->id;
 
-            // Reassign related models that have person_id
+            // Only these two tables actually have a person_id column. Every other
+            // person-owned table here is GEDCOM-shaped and keys off (`group`, `gid`)
+            // instead — listing them in a person_id loop made every merge die on
+            // "Unknown column 'person_id'" at the second entry, so no merge has ever
+            // completed. class_exists() cannot catch that: the class exists, the
+            // column does not.
             $modelsWithPersonId = [
                 PersonEvent::class,
-                PersonName::class,
-                PersonAlia::class,
-                PersonLds::class,
-                PersonSubm::class,
                 VirtualEventAttendee::class,
-                PersonAnci::class,
-                PersonAsso::class,
-                PersonNameFone::class,
             ];
 
             foreach ($modelsWithPersonId as $model) {
-                if (class_exists($model)) {
-                    $model::where('person_id', $duplicateId)->update(['person_id' => $primaryId]);
-                }
+                $model::where('person_id', $duplicateId)->update(['person_id' => $primaryId]);
             }
+
+            // The GEDCOM tables: `group` names the kind of record the row hangs off
+            // ('indi' = a person) and `gid` is that person's id. One shape, so one
+            // loop — repointing gid is what actually moves a name/alias/ordinance/
+            // citation from the duplicate onto the primary. Going through the models
+            // keeps the tenant global scope on these updates.
+            $modelsKeyedByGid = [
+                PersonName::class,
+                PersonNameFone::class,
+                PersonAlia::class,
+                PersonLds::class,
+                PersonSubm::class,
+                PersonAnci::class,
+                PersonAsso::class,
+                SourceRef::class,
+            ];
+
+            foreach ($modelsKeyedByGid as $model) {
+                $model::where('group', PersonAsso::GROUP_INDI)
+                    ->where('gid', $duplicateId)
+                    ->update(['gid' => $primaryId]);
+            }
+
+            // Two of those also point AT a person from the other end, in varchar
+            // columns the importer fills with a person id: an association's counterpart
+            // and an alias' target. A merge has to move those too or they keep naming
+            // the person we are about to delete.
+            PersonAsso::where('indi', (string) $duplicateId)->update(['indi' => (string) $primaryId]);
+            PersonAlia::where('alia', (string) $duplicateId)->update(['alia' => (string) $primaryId]);
 
             // Families: if duplicate is husband/wife/child, reassign references to primary
             if (class_exists(Family::class)) {
@@ -83,8 +109,19 @@ class PersonMergeService
                 Family::where('wife_id', $duplicateId)->update(['wife_id' => $primaryId]);
             }
 
-            // If duplicate was child_in_family in a family, update that relation
-            Person::where('child_in_family_id', $duplicateId)->update(['child_in_family_id' => $primaryId]);
+            // `child_in_family_id` holds a FAMILY id (Family::children() is
+            // hasMany(Person::class, 'child_in_family_id')), not a person id. Matching
+            // it against $duplicateId compared a family id to a person id and, on the
+            // small integers these tables actually use, would reassign unrelated
+            // children to whichever family shared the duplicate's id. It never fired
+            // only because the person_id loop above threw first.
+            //
+            // What a merge actually owes here: the duplicate's own parentage, if the
+            // primary has none.
+            if (empty($primary->child_in_family_id) && ! empty($duplicate->child_in_family_id)) {
+                $primary->child_in_family_id = $duplicate->child_in_family_id;
+                $primary->save();
+            }
 
             // Move tree positions if missing
             if (empty($primary->tree_position_x) && ! empty($duplicate->tree_position_x)) {

--- a/database/factories/PersonAssoFactory.php
+++ b/database/factories/PersonAssoFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Enums\AssociationType;
+use App\Models\Person;
 use App\Models\PersonAsso;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -28,11 +30,13 @@ class PersonAssoFactory extends Factory
     public function definition()
     {
         return [
-            'group' => fake()->word(),
-            'gid' => fake()->randomDigit(),
-            'indi' => fake()->word(),
-            'rela' => fake()->word(),
-            'import_confirm' => fake()->randomDigit(),
+            'group' => PersonAsso::GROUP_INDI,
+            'gid' => Person::factory(),
+            // `indi` is a varchar: a resolved row holds the person id as a string,
+            // an unresolved import holds the raw GEDCOM xref ("@I5@") instead.
+            'indi' => fn (): string => (string) Person::factory()->create()->getKey(),
+            'rela' => fake()->randomElement(AssociationType::cases())->value,
+            'import_confirm' => 1,
         ];
     }
 }

--- a/database/factories/SourceRefFactory.php
+++ b/database/factories/SourceRefFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Person;
 use App\Models\Source;
 use App\Models\SourceRef;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -27,11 +28,13 @@ class SourceRefFactory extends Factory
     public function definition()
     {
         return [
-            'group' => fake()->word(),
-            'gid' => fake()->randomDigit(),
-            'sour_id' => Source::create()->id,
-            'text' => fake()->word(),
-            'quay' => fake()->word(),
+            // A person-level reference: (group, gid) is the pseudo-polymorphic key,
+            // so gid only means people.id while group is 'indi'.
+            'group' => SourceRef::GROUP_INDI,
+            'gid' => Person::factory(),
+            'sour_id' => Source::factory(),
+            'text' => fake()->sentence(),
+            'quay' => (string) fake()->numberBetween(0, 3),
             'page' => fake()->word(),
         ];
     }

--- a/database/migrations/2026_07_17_000001_add_indexes_to_gedcom_link_tables.php
+++ b/database/migrations/2026_07_17_000001_add_indexes_to_gedcom_link_tables.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * `person_asso` and `source_ref` are GEDCOM's pseudo-polymorphic link tables:
+ * (`group`, `gid`) identifies the record a row hangs off. Until now they were
+ * write-only import artifacts, so neither carried an index beyond the primary
+ * key and the team_id FK. Person::associations() / Person::sourceRefs() make
+ * (group, gid) the hot lookup path, and these tables grow one row per citation
+ * per person — a full scan per person page is not viable on a real tree.
+ *
+ * Index names are given explicitly: MySQL caps identifiers at 64 chars and
+ * errors 1059 on longer auto-generated names, which SQLite would not catch.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('person_asso', function (Blueprint $table): void {
+            $table->index(['group', 'gid'], 'person_asso_group_gid_idx');
+            // The reverse lookup: "who is associated WITH this person".
+            $table->index('indi', 'person_asso_indi_idx');
+        });
+
+        Schema::table('source_ref', function (Blueprint $table): void {
+            $table->index(['group', 'gid'], 'source_ref_group_gid_idx');
+            // "which records cite this source"
+            $table->index('sour_id', 'source_ref_sour_id_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('person_asso', function (Blueprint $table): void {
+            $table->dropIndex('person_asso_group_gid_idx');
+            $table->dropIndex('person_asso_indi_idx');
+        });
+
+        Schema::table('source_ref', function (Blueprint $table): void {
+            $table->dropIndex('source_ref_group_gid_idx');
+            $table->dropIndex('source_ref_sour_id_idx');
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -793,16 +793,10 @@ parameters:
 			path: app/Filament/App/Resources/ImportJobResource.php
 
 		-
-			message: '#^Class App\\Filament\\App\\Resources\\RelationManagers\\PhotosRelationManager not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Filament/App/Resources/PersonResource.php
-
-		-
-			message: '#^Method App\\Filament\\App\\Resources\\PersonResource\:\:getRelations\(\) should return array\<class\-string\<Filament\\Resources\\RelationManagers\\RelationManager\>\|Filament\\Resources\\RelationManagers\\RelationGroup\|Filament\\Resources\\RelationManagers\\RelationManagerConfiguration\> but returns array\{''App\\\\Filament\\\\App\\\\Resources\\\\RelationManagers\\\\PhotosRelationManager''\}\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Filament/App/Resources/PersonResource.php
+			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: app/Filament/App/Resources/PersonAssoResource.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\MediaObject\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\MediaObject\>\:\:\$files\.$#'
@@ -841,6 +835,12 @@ parameters:
 			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
 
 		-
+			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: app/Filament/App/Resources/PersonResource/RelationManagers/AssociationsRelationManager.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\PersonPhoto\:\:\$file_path\.$#'
 			identifier: property.notFound
 			count: 1
@@ -859,6 +859,12 @@ parameters:
 			path: app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\SourceRef\:\:\$source\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Filament/App/Resources/PersonResource/RelationManagers/SourcesRelationManager.php
+
+		-
 			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -875,6 +881,24 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: app/Filament/App/Resources/SmartMatchResource.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Source\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Filament/App/Resources/SourceRefResource.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Source\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Filament/App/Resources/SourceRefResource.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Source\:\:\$titl\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Filament/App/Resources/SourceRefResource.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$platform\.$#'
@@ -2775,6 +2799,24 @@ parameters:
 		-
 			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:updateOrCreate\(\)\.$#'
 			identifier: staticMethod.notFound
+			count: 1
+			path: app/Models/Person.php
+
+		-
+			message: '#^Method App\\Models\\Person\:\:associatedWith\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PersonAsso\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Person.php
+
+		-
+			message: '#^Method App\\Models\\Person\:\:associations\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PersonAsso\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Person.php
+
+		-
+			message: '#^Method App\\Models\\Person\:\:sourceRefs\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\SourceRef\>\.$#'
+			identifier: return.type
 			count: 1
 			path: app/Models/Person.php
 
@@ -5551,6 +5593,12 @@ parameters:
 			path: app/Services/PersonMergeService.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\Person\:\:\$child_in_family_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/PersonMergeService.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
 			identifier: property.notFound
 			count: 1
@@ -5629,7 +5677,13 @@ parameters:
 			path: app/Services/PersonMergeService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
+			message: '#^Call to an undefined static method App\\Models\\PersonAlia\:\:where\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: app/Services/PersonMergeService.php
+
+		-
+			message: '#^Call to an undefined static method App\\Models\\PersonAsso\:\:where\(\)\.$#'
 			identifier: staticMethod.notFound
 			count: 1
 			path: app/Services/PersonMergeService.php

--- a/tests/Feature/PersonAssociationsTest.php
+++ b/tests/Feature/PersonAssociationsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\AssociationType;
+use App\Filament\App\Resources\PersonResource\Pages\EditPerson;
+use App\Filament\App\Resources\PersonResource\RelationManagers\AssociationsRelationManager;
+use App\Models\Person;
+use App\Models\PersonAsso;
+use App\Models\User;
+use App\Services\PersonMergeService;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * GEDCOM ASSO surfaced in the UI: step-parents, guardians, godparents and
+ * witnesses — the links no family record expresses.
+ *
+ * person_asso is tenant-scoped via BelongsToTenant, which keys off
+ * auth()->user()->currentTeam, so every test here must act as a user with a team
+ * or the global scope silently no-ops and proves nothing.
+ */
+class PersonAssociationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+
+        // Relation managers gate their create/edit actions on the resource policy —
+        // PersonAssoPolicy::create() wants Shield's `create_person::asso` permission —
+        // and Filament HIDES an unauthorized action rather than failing it, so without
+        // this the create action is simply absent and the test reads as a wiring bug.
+        // Shield grants super_admin a Gate::before short-circuit in production; that
+        // hook is not active in the test harness, so replicate it. These tests cover
+        // the association wiring, not Shield authorization.
+        Gate::before(fn () => true);
+
+        return $user;
+    }
+
+    public function test_creating_via_the_relation_stamps_group_and_gid(): void
+    {
+        $user = $this->actingUser();
+        $person = Person::factory()->create();
+        $guardian = Person::factory()->create();
+
+        $association = $person->associations()->create([
+            'indi' => (string) $guardian->getKey(),
+            'rela' => AssociationType::GUARDIAN->value,
+            'import_confirm' => 1,
+        ]);
+
+        // withAttributes() stamps `group`; the HasMany stamps `gid`.
+        $this->assertSame(PersonAsso::GROUP_INDI, $association->group);
+        $this->assertSame($person->getKey(), $association->gid);
+        $this->assertSame($user->currentTeam->id, $association->team_id);
+
+        $this->assertTrue($person->associations()->get()->contains($association));
+    }
+
+    public function test_associate_resolves_to_the_right_person(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+        $godparent = Person::factory()->create();
+
+        $association = $person->associations()->create([
+            'indi' => (string) $godparent->getKey(),
+            'rela' => AssociationType::GODPARENT->value,
+            'import_confirm' => 1,
+        ]);
+
+        $this->assertTrue($association->isResolved());
+        $this->assertSame($godparent->getKey(), $association->associate->getKey());
+        $this->assertSame($person->getKey(), $association->person->getKey());
+    }
+
+    public function test_unresolved_xref_resolves_to_null_without_throwing(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+
+        // What the importer writes before its resolution pass runs.
+        $association = $person->associations()->create([
+            'indi' => '@I5@',
+            'rela' => AssociationType::WITNESS->value,
+            'import_confirm' => 0,
+        ]);
+
+        $this->assertFalse($association->isResolved());
+        $this->assertNull($association->associate);
+    }
+
+    public function test_associated_with_finds_the_association_from_the_other_side(): void
+    {
+        $this->actingUser();
+        $ward = Person::factory()->create();
+        $guardian = Person::factory()->create();
+
+        $association = $ward->associations()->create([
+            'indi' => (string) $guardian->getKey(),
+            'rela' => AssociationType::GUARDIAN->value,
+            'import_confirm' => 1,
+        ]);
+
+        // GEDCOM stores the ASSO one way only: the guardian has no row of their own.
+        $incoming = $guardian->associatedWith()->get();
+
+        $this->assertCount(1, $incoming);
+        $this->assertSame($association->id, $incoming->first()->id);
+        $this->assertSame(AssociationType::WARD, $incoming->first()->type()->inverse());
+    }
+
+    public function test_label_for_falls_back_to_raw_free_text(): void
+    {
+        $this->assertSame('Step-parent', AssociationType::labelFor('step-parent'));
+        // RELA is free text in the spec, so imports carry values outside our enum.
+        $this->assertSame('Godfather at baptism', AssociationType::labelFor('Godfather at baptism'));
+        $this->assertSame('Unknown', AssociationType::labelFor(null));
+    }
+
+    public function test_merge_repoints_associations_in_both_directions(): void
+    {
+        $this->actingUser();
+        $primary = Person::factory()->create();
+        $duplicate = Person::factory()->create();
+        $other = Person::factory()->create();
+
+        // The duplicate as subject...
+        $asSubject = $duplicate->associations()->create([
+            'indi' => (string) $other->getKey(),
+            'rela' => AssociationType::GUARDIAN->value,
+            'import_confirm' => 1,
+        ]);
+
+        // ...and as the associate of someone else.
+        $asAssociate = $other->associations()->create([
+            'indi' => (string) $duplicate->getKey(),
+            'rela' => AssociationType::GODPARENT->value,
+            'import_confirm' => 1,
+        ]);
+
+        app(PersonMergeService::class)->merge($primary, $duplicate);
+
+        $this->assertSame($primary->getKey(), $asSubject->fresh()->gid);
+        $this->assertSame((string) $primary->getKey(), $asAssociate->fresh()->indi);
+    }
+
+    public function test_relation_manager_mounts(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+
+        Livewire::test(AssociationsRelationManager::class, [
+            'ownerRecord' => $person,
+            'pageClass' => EditPerson::class,
+        ])->assertOk();
+    }
+
+    public function test_relation_manager_creates_a_resolved_association(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+        $stepParent = Person::factory()->create();
+
+        Livewire::test(AssociationsRelationManager::class, [
+            'ownerRecord' => $person,
+            'pageClass' => EditPerson::class,
+        ])
+            ->callTableAction('create', data: [
+                'indi' => (string) $stepParent->getKey(),
+                'rela' => AssociationType::STEP_PARENT->value,
+            ])
+            ->assertHasNoActionErrors();
+
+        $this->assertDatabaseHas('person_asso', [
+            'group' => PersonAsso::GROUP_INDI,
+            'gid' => $person->getKey(),
+            'indi' => (string) $stepParent->getKey(),
+            'rela' => AssociationType::STEP_PARENT->value,
+            // The UI never creates rows awaiting xref resolution.
+            'import_confirm' => 1,
+        ]);
+    }
+}

--- a/tests/Feature/PersonSourceLinkTest.php
+++ b/tests/Feature/PersonSourceLinkTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\App\Resources\PersonResource\Pages\EditPerson;
+use App\Filament\App\Resources\PersonResource\RelationManagers\SourcesRelationManager;
+use App\Models\Person;
+use App\Models\Source;
+use App\Models\SourceRef;
+use App\Models\User;
+use App\Services\CompletenessService;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+// PHPUnit 13 dropped the @dataProvider docblock; only the attribute is read.
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Person↔Source evidence links (GEDCOM SOUR, group 'indi').
+ *
+ * The importer only ever writes the fine-grained groups (indi_name, indi_even,
+ * indi_asso, indi_lds), so nothing had ever written group='indi' and the person
+ * half of CompletenessService::sourceCompleteness() structurally returned 0.
+ * These cover the UI that writes it and the report that reads it.
+ */
+class PersonSourceLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+
+        // Relation managers gate their create/edit actions on the resource policy —
+        // SourceRefPolicy::create() wants Shield's `create_source::ref` permission —
+        // and Filament HIDES an unauthorized action rather than failing it, so without
+        // this the create action is simply absent and the test reads as a wiring bug.
+        // Shield grants super_admin a Gate::before short-circuit in production; that
+        // hook is not active in the test harness, so replicate it. These tests cover
+        // the source-link wiring, not Shield authorization.
+        Gate::before(fn () => true);
+
+        return $user;
+    }
+
+    public function test_creating_through_the_relation_stamps_group_gid_and_team(): void
+    {
+        $user = $this->actingUser();
+        $person = Person::factory()->create();
+        $source = Source::factory()->create();
+
+        $ref = $person->sourceRefs()->create([
+            'sour_id' => $source->id,
+            'page' => 'p. 42',
+            'quay' => '3',
+            'text' => 'Entry for the subject.',
+        ]);
+
+        // Read the row back past the tenant scope: a null team_id would still be
+        // readable through $ref, but invisible to the (scoped) report.
+        $stored = SourceRef::withoutGlobalScopes()->findOrFail($ref->id);
+
+        $this->assertSame(SourceRef::GROUP_INDI, $stored->group);
+        $this->assertSame($person->id, $stored->gid);
+        $this->assertSame($user->currentTeam->id, $stored->team_id);
+    }
+
+    public function test_source_and_person_relations_resolve(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+        $source = Source::factory()->create();
+
+        $ref = $person->sourceRefs()->create(['sour_id' => $source->id]);
+
+        $this->assertTrue($ref->source->is($source));
+        $this->assertTrue($ref->person->is($person));
+    }
+
+    public function test_source_refs_excludes_other_groups_for_the_same_gid(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+        $source = Source::factory()->create();
+
+        $indi = $person->sourceRefs()->create(['sour_id' => $source->id]);
+
+        // Same gid, different group: an event-level ref the importer would write.
+        // gid collides by design — (group, gid) is the pseudo-polymorphic key.
+        SourceRef::create([
+            'group' => SourceRef::GROUP_INDI_EVEN,
+            'gid' => $person->id,
+            'sour_id' => $source->id,
+        ]);
+
+        $this->assertSame([$indi->id], $person->sourceRefs()->pluck('id')->all());
+    }
+
+    public function test_source_people_relation_returns_only_indi_refs(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+        $other = Person::factory()->create();
+        $source = Source::factory()->create();
+
+        $person->sourceRefs()->create(['sour_id' => $source->id]);
+        SourceRef::create([
+            'group' => SourceRef::GROUP_INDI_EVEN,
+            'gid' => $other->id,
+            'sour_id' => $source->id,
+        ]);
+
+        $this->assertSame([$person->id], $source->people()->pluck('people.id')->all());
+    }
+
+    /**
+     * The regression this whole feature exists for: person coverage was
+     * structurally 0% because no writer ever produced group='indi'.
+     */
+    public function test_source_completeness_person_coverage_goes_from_zero_to_nonzero(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+        $source = Source::factory()->create();
+
+        // An importer-written ref against the same person does NOT count: the
+        // report counts group='indi' only. This is the state the report was stuck in.
+        SourceRef::create([
+            'group' => SourceRef::GROUP_INDI_NAME,
+            'gid' => $person->id,
+            'sour_id' => $source->id,
+        ]);
+
+        $before = (new CompletenessService)->sourceCompleteness();
+        $this->assertSame(1, $before['persons']['total']);
+        $this->assertSame(0, $before['persons']['with_source']);
+        $this->assertSame(0.0, $before['persons']['percentage']);
+
+        $person->sourceRefs()->create(['sour_id' => $source->id]);
+
+        $after = (new CompletenessService)->sourceCompleteness();
+        $this->assertSame(1, $after['persons']['with_source']);
+        $this->assertSame(100.0, $after['persons']['percentage']);
+    }
+
+    public function test_source_completeness_ignores_other_teams_refs(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+
+        // A ref owned by another team must not count the person as sourced — the
+        // subquery has to stay tenant-scoped. team_id is not fillable, so assign it
+        // directly: via create() it would be dropped and then stamped with the
+        // acting team, quietly turning this into a test of nothing.
+        $ref = new SourceRef([
+            'group' => SourceRef::GROUP_INDI,
+            'gid' => $person->id,
+            'sour_id' => Source::factory()->create()->id,
+        ]);
+        $ref->team_id = $otherTeam->id;
+        $ref->save();
+
+        // fresh() would re-apply the tenant scope and find nothing.
+        $this->assertSame($otherTeam->id, SourceRef::withoutGlobalScopes()->findOrFail($ref->id)->team_id);
+
+        $this->assertSame(0, (new CompletenessService)->sourceCompleteness()['persons']['with_source']);
+    }
+
+    #[DataProvider('qualityLabelProvider')]
+    public function test_quality_label(?string $quay, string $expected): void
+    {
+        $this->assertSame($expected, (new SourceRef(['quay' => $quay]))->qualityLabel());
+    }
+
+    /** @return array<string, array{0: ?string, 1: string}> */
+    public static function qualityLabelProvider(): array
+    {
+        return [
+            'unreliable' => ['0', 'Unreliable'],
+            'questionable' => ['1', 'Questionable'],
+            'secondary' => ['2', 'Secondary evidence'],
+            'primary' => ['3', 'Primary evidence'],
+            'null' => [null, 'Unrated'],
+            'empty' => ['', 'Unrated'],
+            // Imports carry free text in QUAY; it falls through to the raw value.
+            'free text' => ['probably reliable', 'probably reliable'],
+        ];
+    }
+
+    public function test_sources_relation_manager_mounts(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+
+        Livewire::test(SourcesRelationManager::class, [
+            'ownerRecord' => $person,
+            'pageClass' => EditPerson::class,
+        ])->assertOk();
+    }
+
+    public function test_sources_relation_manager_creates_an_indi_ref(): void
+    {
+        $user = $this->actingUser();
+        $person = Person::factory()->create();
+        $source = Source::factory()->create();
+
+        Livewire::test(SourcesRelationManager::class, [
+            'ownerRecord' => $person,
+            'pageClass' => EditPerson::class,
+        ])
+            ->callTableAction('create', data: [
+                'sour_id' => $source->id,
+                'page' => 'p. 7',
+                'quay' => '2',
+                'text' => 'Transcribed entry.',
+            ])
+            ->assertHasNoActionErrors();
+
+        $ref = SourceRef::withoutGlobalScopes()->firstOrFail();
+
+        $this->assertSame(SourceRef::GROUP_INDI, $ref->group);
+        $this->assertSame($person->id, $ref->gid);
+        $this->assertSame($source->id, $ref->sour_id);
+        $this->assertSame('p. 7', $ref->page);
+        $this->assertSame($user->currentTeam->id, $ref->team_id);
+    }
+
+    public function test_sources_relation_manager_requires_a_source(): void
+    {
+        $this->actingUser();
+        $person = Person::factory()->create();
+
+        Livewire::test(SourcesRelationManager::class, [
+            'ownerRecord' => $person,
+            'pageClass' => EditPerson::class,
+        ])
+            ->callTableAction('create', data: ['page' => 'p. 7'])
+            ->assertHasActionErrors(['sour_id' => ['required']]);
+
+        $this->assertSame(0, SourceRef::withoutGlobalScopes()->count());
+    }
+}

--- a/tests/Feature/Services/PersonMergeServiceTest.php
+++ b/tests/Feature/Services/PersonMergeServiceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\Family;
+use App\Models\Person;
+use App\Models\PersonAsso;
+use App\Models\PersonName;
+use App\Models\SourceRef;
+use App\Models\User;
+use App\Services\PersonMergeService;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * PersonMergeService had no tests at all, and did not work at all: it looped a
+ * `person_id` update over nine models of which only two have that column, so
+ * every merge threw "Unknown column 'person_id'" on the second entry. The rest
+ * of the method — including a line that would corrupt unrelated records — was
+ * therefore unreachable, and the merge UI has never completed a single merge.
+ *
+ * These models are tenant-scoped via BelongsToTenant, which keys off
+ * auth()->user()->currentTeam, so each test acts as a user with a team; without
+ * that the global scope no-ops and the assertions prove nothing.
+ */
+class PersonMergeServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+
+        return $user;
+    }
+
+    public function test_merging_two_plain_people_does_not_throw(): void
+    {
+        $this->actingUser();
+
+        $primary = Person::factory()->create(['givn' => 'John', 'surn' => 'Doe']);
+        $duplicate = Person::factory()->create(['givn' => 'Jon', 'surn' => 'Doe']);
+
+        $merged = (new PersonMergeService)->merge($primary, $duplicate);
+
+        $this->assertSame($primary->id, $merged->id);
+        $this->assertSoftDeleted('people', ['id' => $duplicate->id]);
+    }
+
+    public function test_merge_repoints_gedcom_group_gid_records_onto_the_primary(): void
+    {
+        $this->actingUser();
+
+        $primary = Person::factory()->create();
+        $duplicate = Person::factory()->create();
+
+        $name = PersonName::create([
+            'group' => 'indi',
+            'gid' => $duplicate->id,
+            'givn' => 'Alternate',
+            'surn' => 'Spelling',
+        ]);
+
+        $sourceRef = SourceRef::create([
+            'group' => 'indi',
+            'gid' => $duplicate->id,
+            'sour_id' => 1,
+            'page' => 'p. 12',
+        ]);
+
+        (new PersonMergeService)->merge($primary, $duplicate);
+
+        $this->assertSame($primary->id, $name->fresh()->gid, 'person_name was left on the deleted duplicate');
+        $this->assertSame($primary->id, $sourceRef->fresh()->gid, 'source_ref was left on the deleted duplicate');
+    }
+
+    public function test_merge_repoints_associations_in_both_directions(): void
+    {
+        $this->actingUser();
+
+        $primary = Person::factory()->create();
+        $duplicate = Person::factory()->create();
+        $other = Person::factory()->create();
+
+        // The duplicate as the subject of an association...
+        $asSubject = PersonAsso::create([
+            'group' => 'indi',
+            'gid' => $duplicate->id,
+            'indi' => (string) $other->id,
+            'rela' => 'guardian',
+            'import_confirm' => 1,
+        ]);
+
+        // ...and as the person someone else's association points at.
+        $asAssociate = PersonAsso::create([
+            'group' => 'indi',
+            'gid' => $other->id,
+            'indi' => (string) $duplicate->id,
+            'rela' => 'godparent',
+            'import_confirm' => 1,
+        ]);
+
+        (new PersonMergeService)->merge($primary, $duplicate);
+
+        $this->assertSame($primary->id, $asSubject->fresh()->gid);
+        $this->assertSame((string) $primary->id, $asAssociate->fresh()->indi);
+    }
+
+    /**
+     * The regression that matters most. `child_in_family_id` is a FAMILY id, but
+     * the service matched it against the duplicate's PERSON id and rewrote every
+     * hit. Person ids and family ids are both small integers drawn from separate
+     * sequences, so they collide constantly — this test builds that collision
+     * deliberately: an unrelated child sits in the family whose id equals the
+     * duplicate person's id, and must not be touched by the merge.
+     */
+    public function test_merge_does_not_reassign_unrelated_children_whose_family_id_matches_the_duplicate_id(): void
+    {
+        $this->actingUser();
+
+        $primary = Person::factory()->create();
+        $duplicate = Person::factory()->create();
+
+        $family = Family::factory()->create();
+        // Force the collision the old code assumed could never happen.
+        $family->forceFill(['id' => $duplicate->id])->saveQuietly();
+
+        $bystander = Person::factory()->create(['child_in_family_id' => $duplicate->id]);
+
+        (new PersonMergeService)->merge($primary, $duplicate);
+
+        $this->assertSame(
+            $duplicate->id,
+            $bystander->fresh()->child_in_family_id,
+            'merge reassigned an unrelated child to a different family by treating a family id as a person id'
+        );
+    }
+
+    public function test_merge_adopts_the_duplicates_parentage_only_when_the_primary_has_none(): void
+    {
+        $this->actingUser();
+
+        $duplicateFamily = Family::factory()->create();
+        $primaryFamily = Family::factory()->create();
+
+        $primary = Person::factory()->create(['child_in_family_id' => null]);
+        $duplicate = Person::factory()->create(['child_in_family_id' => $duplicateFamily->id]);
+
+        (new PersonMergeService)->merge($primary, $duplicate);
+
+        $this->assertSame($duplicateFamily->id, $primary->fresh()->child_in_family_id);
+
+        // And when the primary already has parentage, the duplicate's is ignored.
+        $keeper = Person::factory()->create(['child_in_family_id' => $primaryFamily->id]);
+        $other = Person::factory()->create(['child_in_family_id' => $duplicateFamily->id]);
+
+        (new PersonMergeService)->merge($keeper, $other);
+
+        $this->assertSame($primaryFamily->id, $keeper->fresh()->child_in_family_id);
+    }
+}

--- a/tests/Filament/Resources/ResourceFormSchemaMountTest.php
+++ b/tests/Filament/Resources/ResourceFormSchemaMountTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Tests\Filament\Resources;
 
 use App\Filament\App\Resources\ChecklistTemplateResource\Pages\CreateChecklistTemplate;
+use App\Filament\App\Resources\PersonResource;
 use App\Filament\App\Resources\PersonResource\Pages\CreatePerson;
+use App\Filament\App\Resources\PersonResource\Pages\EditPerson;
 use App\Filament\App\Resources\RecordTypeResource\Pages\CreateRecordType;
 use App\Filament\App\Resources\VirtualEventResource\Pages\CreateVirtualEvent;
+use App\Models\Person;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -48,6 +51,30 @@ class ResourceFormSchemaMountTest extends TestCase
         $this->actingUser();
 
         Livewire::test(CreatePerson::class)->assertOk();
+    }
+
+    /**
+     * The edit page is the only one that instantiates relation managers, and
+     * PersonResource::getRelations() named them `RelationManagers\Foo::class`
+     * with no namespace import — resolving to App\Filament\App\Resources\
+     * RelationManagers\Foo, which is not a directory that exists. ::class does
+     * not autoload, so the dead name sat there until Filament tried to build it.
+     * The create-page test above cannot catch this; only mounting edit can.
+     */
+    public function test_person_edit_page_mounts_with_its_relation_managers(): void
+    {
+        $this->actingUser();
+
+        $person = Person::factory()->create();
+
+        Livewire::test(EditPerson::class, ['record' => $person->getRouteKey()])->assertOk();
+
+        foreach (PersonResource::getRelations() as $manager) {
+            $this->assertTrue(
+                class_exists($manager),
+                "PersonResource::getRelations() names a class that does not exist: {$manager}"
+            );
+        }
     }
 
     public function test_virtual_event_create_page_mounts(): void


### PR DESCRIPTION
Closes the last two schema-shaped items on `SCOPE_TASKS.md`: step/guardian relationships and the person↔source link.

## No new schema — the tables were already there

Both "missing" schemas exist. `person_asso` and `source_ref` have shipped since the GEDCOM importer landed, complete with models, Filament resources and policies. They were **write-only import artifacts**: no Eloquent relations, no way for a user to create a row, and nothing reading them back. This is the wiring, not a migration.

- **Associations** (`person_asso`) — GEDCOM ASSO/RELA: step-parent, guardian, godparent, ward, foster, witness. This is where they belong; `PedigreeType`'s own docblock says so, because pedigree describes how a child joins their *one* family, while an association is a free-standing link needing no family record.
- **Evidence links** (`source_ref`) — GEDCOM SOUR: which sources evidence a person, with page, QUAY confidence and quoted text.

`AssociationType` curates the descriptors the UI offers but is **not** a closed world — RELA is free text in the spec, so `labelFor()` falls back to the raw imported string instead of blanking a value the user never chose.

## Bugs found and fixed

Driving previously-untested code surfaced four real defects:

**1. The person edit page fataled — twice, independently.**
`PersonResource::getRelations()` wrote `RelationManagers\Foo::class` with no namespace import, resolving to `App\Filament\App\Resources\RelationManagers\Foo` — a directory that does not exist. `::class` doesn't autoload, so the dead name sat there until Filament instantiated it. Separately, `heroicon-o-photograph` is a Heroicons **v1** name (v2 renamed it `photo`); blade-icons throws `SvgNotFound` at render. I swept every heroicon in the tree against the installed set — `o-user-check` was dead the same way.

Nothing mounted the page: `PersonResourceTest` only asserts `getModel()`/`getPages()`, and the schema mount test covers *create* pages, which don't build relation managers. Added an edit-page mount test.

**2. `PersonMergeService` has never completed a single merge.**
It looped a `person_id` update over nine models; only `PersonEvent` and `VirtualEventAttendee` have that column. `PersonName` is **second** in the list, so every merge threw `Unknown column 'person_id'` — on any pair, with no associations involved. `class_exists()` can't catch it: the class exists, the column doesn't. The service had zero tests.

The other seven are GEDCOM-shaped and key off `(group, gid)` — one shape, so one loop. Simply dropping them would have traded a loud failure for silent data loss.

**3. Un-breaking merge unmasked a data-corrupting line.**
`Person::where('child_in_family_id', $duplicateId)` matched a **family** id against a **person** id (`Family::children()` is `hasMany(Person::class, 'child_in_family_id')`). Person and family ids come from two small sequences and collide constantly, so this would reassign unrelated children to whichever family shared the duplicate's id. It never fired only because the loop threw first. Replaced with what a merge actually owes: adopt the duplicate's parentage only if the primary has none.

**4. The source completeness report was structurally dead.**
`CompletenessService` counts persons with `group='indi'` refs, but nothing ever wrote that group — the importer only emits `indi_name`/`indi_even`/`indi_asso`/`indi_lds`. Person coverage always returned 0%. The relation manager is the writer it was waiting for.

## Notes

- Relations use `withAttributes()`, which stamps `group` on create as well as constraining reads. A bare `where()` filters reads and silently writes `group = null`, leaving new rows invisible to their own relation — verified in tinker, not assumed.
- The completeness subquery is an **Eloquent builder, not a raw closure**: a closure drops `SourceRef`'s tenant scope and counts every team's refs. Regression test included.
- `(group, gid)` indexed on both tables — nothing queried them before, so neither had an index beyond the PK and the `team_id` FK. Verified up *and* down on real MySQL.
- PHPStan baseline: **3 entries removed** (one was the missing-class bug above — the baseline had swallowed a real error PHPStan caught), 12 added, all Eloquent magic that plain PHPStan can't see without larastan.

## Verification

- **555 passed / 0 failed** (was 525), on MySQL as well as the SQLite suite.
- **Mutation-tested, not just green.** Restoring the original `PersonName` entry fails all 5 merge tests with *0 assertions* (it throws before asserting); restoring the `child_in_family_id` line fails the bystander test with an unrelated child reassigned.
- `pint --test` and `phpstan` (the gates from #1514) both clean.