### PR TITLE
chore(phpstan): add larastan, shrink baseline 1568→615, fix 3 live fatals

### DIFF
--- a/app/Filament/App/Widgets/PedigreeChartWidget.php
+++ b/app/Filament/App/Widgets/PedigreeChartWidget.php
@@ -15,7 +15,10 @@ class PedigreeChartWidget extends Widget
     public function getData(): array
     {
         return [
-            'people' => Person::with('parents')->get(),
+            // parents() is a helper that walks childInFamily->husband/wife, not a
+            // relation — with('parents') threw "Collection::addEagerConstraints does
+            // not exist" on every render. Eager-load what it actually reads.
+            'people' => Person::with(['childInFamily.husband', 'childInFamily.wife'])->get(),
         ];
     }
 

--- a/app/Models/MediaObject.php
+++ b/app/Models/MediaObject.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Enums\MediaType;
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class MediaObject extends \FamilyTree365\LaravelGedcom\Models\MediaObject
 {
@@ -38,7 +39,7 @@ class MediaObject extends \FamilyTree365\LaravelGedcom\Models\MediaObject
     /**
      * Files associated with this media object (from media_objects_file table).
      */
-    public function files()
+    public function files(): HasMany
     {
         return $this->hasMany(MediaObjeectFile::class, 'gid', 'id')->where('group', 'obje');
     }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -8,6 +8,7 @@ use App\Enums\PedigreeType;
 use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
@@ -121,7 +122,7 @@ class Person extends Model
     //    //     error_log('Person-'.($this->connection).'-'.\Session::get('conn').'-'.\Session::get('db'));
     //     }
 
-    public function events()
+    public function events(): HasMany
     {
         return $this->hasMany(PersonEvent::class)->select(['id', 'person_id', 'title', 'date', 'places_id']);
     }
@@ -171,17 +172,17 @@ class Person extends Model
             ->withAttributes(['group' => SourceRef::GROUP_INDI]);
     }
 
-    public function childInFamily()
+    public function childInFamily(): BelongsTo
     {
         return $this->belongsTo(Family::class, 'child_in_family_id')->select(['id', 'husband_id', 'wife_id']);
     }
 
-    public function familiesAsHusband()
+    public function familiesAsHusband(): HasMany
     {
         return $this->hasMany(Family::class, 'husband_id');
     }
 
-    public function familiesAsWife()
+    public function familiesAsWife(): HasMany
     {
         return $this->hasMany(Family::class, 'wife_id');
     }

--- a/app/Services/DuplicateCheckerService.php
+++ b/app/Services/DuplicateCheckerService.php
@@ -25,10 +25,12 @@ class DuplicateCheckerService
         ]);
 
         try {
-            // Get all people for this user's team
-            $people = Person::whereHas('user', function ($query) use ($user): void {
-                $query->where('current_team_id', $user->current_team_id);
-            })->get();
+            // Get all people for this user's team. Person has no `user` relation —
+            // people are owned by a team, not a user, and there is no user_id column —
+            // so whereHas('user') threw and every duplicate check died here. Filter on
+            // team_id directly; explicit rather than leaning on BelongsToTenant, which
+            // no-ops when this runs unauthenticated (queue/console).
+            $people = Person::where('team_id', $user->current_team_id)->get();
 
             $duplicates = $this->findDuplicates($people);
 

--- a/app/Services/FamilyMatchingService.php
+++ b/app/Services/FamilyMatchingService.php
@@ -80,13 +80,14 @@ class FamilyMatchingService
      */
     protected function getUserFamilySurnames(User $user): array
     {
-        // Get persons associated with user's teams
-        $surnames = Person::whereHas('gedcom', function ($query) use ($user): void {
-            $query->whereIn('team_id', $user->allTeams()->pluck('id'));
-        })
-            ->whereNotNull('surname')
+        // Persons in the user's teams. Person has no `gedcom` relation, so
+        // whereHas('gedcom') threw and this returned no surnames — it never
+        // matched anyone. team_id is on people itself, so no hop is needed.
+        // The column is `surn` (GEDCOM SURN); `surname` does not exist.
+        $surnames = Person::whereIn('team_id', $user->allTeams()->pluck('id'))
+            ->whereNotNull('surn')
             ->distinct()
-            ->pluck('surname')
+            ->pluck('surn')
             ->toArray();
 
         return array_filter($surnames);

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b264fd9185c8b45e85949028c617f2be",
+    "content-hash": "1c6b1311d2d7bdf72e058af627e390d9",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -14017,6 +14017,137 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
             "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "iamcal/sql-parser",
+            "version": "v0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/610392f38de49a44dab08dc1659960a29874c4b8",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
+            },
+            "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
+            "name": "larastan/larastan",
+            "version": "v3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/2970f83398154178a739609c244577267c7ee8eb",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.7.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/database": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.2.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "laravel/framework": "^11.44.2 || ^12.7.2 || ^13",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
+                "phpmyadmin/sql-parser": "Install to enable Larastan's optional phpMyAdmin-based SQL parser automatically"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-28T08:00:58+00:00"
         },
         {
             "name": "laravel/pint",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,99 +1,15 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUser.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUser.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:forceCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUser.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUser.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUserWithTeams.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUserWithTeams.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:forceCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUserWithTeams.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Fortify/CreateNewUserWithTeams.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$email\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Fortify/UpdateUserProfileInformation.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Fortify/UpdateUserProfileInformation.php
-
-		-
 			message: '#^Method App\\Actions\\Jetstream\\CreateTeam\:\:create\(\) should return App\\Models\\Team but returns Illuminate\\Database\\Eloquent\\Model\.$#'
 			identifier: return.type
 			count: 1
 			path: app/Actions/Jetstream/CreateTeam.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$ownedTeams\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Actions/Jetstream/DeleteUserWithTeams.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$tokens\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Jetstream/DeleteUserWithTeams.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Team\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Jetstream/InviteTeamMember.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Team\:\:\$owner\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Jetstream/RemoveTeamMember.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 3
 			path: app/Actions/Jetstream/RemoveTeamMember.php
 
 		-
@@ -101,54 +17,6 @@ parameters:
 			identifier: property.notFound
 			count: 1
 			path: app/Actions/Socialstream/CreateConnectedAccount.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserFromProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserFromProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:forceCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserFromProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserFromProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserWithTeamsFromProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserWithTeamsFromProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:forceCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserWithTeamsFromProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserWithTeamsFromProvider.php
 
 		-
 			message: '#^Access to an undefined property Laravel\\Socialite\\Contracts\\User\:\:\$email\.$#'
@@ -169,148 +37,10 @@ parameters:
 			path: app/Actions/Socialstream/UpdateConnectedAccount.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$current_team_id\.$#'
+			identifier: property.notFound
 			count: 1
-			path: app/Console/Commands/BulkImportDnaCommand.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
 			path: app/Console/Commands/MatchKitsCommand.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DnaMatching\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Console/Commands/MatchKitsCommand.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:chunk\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Console/Commands/ProcessLargeScaleDnaCommand.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Console/Commands/ProcessLargeScaleDnaCommand.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Console/Commands/ProcessLargeScaleDnaCommand.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Console/Commands/TriangulateDnaCommand.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$badge_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$icon\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$key\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$points\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$level\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$total_points\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/AchievementUnlocked.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Events/UserLeveledUp.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/UserLeveledUp.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$total_points\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Events/UserLeveledUp.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/Admin/Pages/CreateTeam.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Filament/Admin/Resources/ModuleResource/Pages/ListModules.php
-
-		-
-			message: '#^Call to static method forget\(\) on an unknown class Cache\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Filament/Admin/Resources/ModuleResource/Pages/ListModules.php
 
 		-
 			message: '#^Cannot access property \$enabled on Illuminate\\Database\\Eloquent\\Model\|int\|string\.$#'
@@ -325,22 +55,10 @@ parameters:
 			path: app/Filament/Admin/Resources/ModuleResource/Pages/ViewModule.php
 
 		-
-			message: '#^Anonymous function should return Illuminate\\Database\\Eloquent\\Builder but returns Illuminate\\Database\\Query\\Builder\.$#'
+			message: '#^Method App\\Filament\\Admin\\Resources\\Users\\UserResource\:\:getNavigationBadge\(\) should return string\|null but returns int\<0, max\>\.$#'
 			identifier: return.type
-			count: 2
-			path: app/Filament/Admin/Resources/Users/Tables/UsersTable.php
-
-		-
-			message: '#^Call to an undefined static method Illuminate\\Database\\Eloquent\\Model\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 1
 			path: app/Filament/Admin/Resources/Users/UserResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/CreateTeam.php
 
 		-
 			message: '#^Access to an undefined property App\\Filament\\App\\Pages\\DnaTriangulationPage\:\:\$form\.$#'
@@ -349,106 +67,10 @@ parameters:
 			path: app/Filament/App/Pages/DnaTriangulationPage.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/DnaTriangulationPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/DnaTriangulationPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Filesystem\\Filesystem\:\:temporaryUrl\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/GedcomExportPage.php
-
-		-
-			message: '#^Property App\\Filament\\App\\Pages\\PersonalAccessTokensPage\:\:\$user \(App\\Models\\User\) does not accept Illuminate\\Contracts\\Auth\\Authenticatable\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/Filament/App/Pages/PersonalAccessTokensPage.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Contracts\\Auth\\Authenticatable\:\:\$premium_started_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Pages/PremiumDashboardPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:hasExpiredTrial\(\)\.$#'
+			message: '#^Call to an undefined method Laravel\\Cashier\\Subscription\:\:cancelled\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: app/Filament/App/Pages/PremiumDashboardPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:isPremium\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Filament/App/Pages/PremiumDashboardPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:onPremiumTrial\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/PremiumDashboardPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:subscription\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Filament/App/Pages/PremiumDashboardPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:trialDaysRemaining\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/PremiumDashboardPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Filament/App/Pages/PremiumDashboardPage.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Conversation\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Filament/App/Pages/PrivateMessagingPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Conversation\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/PrivateMessagingPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Conversation\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/PrivateMessagingPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Message\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/PrivateMessagingPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Message\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/PrivateMessagingPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/PrivateMessagingPage.php
 
 		-
 			message: '#^Access to an undefined property App\\Filament\\App\\Pages\\RelationshipCalculatorReport\:\:\$form\.$#'
@@ -457,93 +79,9 @@ parameters:
 			path: app/Filament/App/Pages/RelationshipCalculatorReport.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
+			message: '#^Access to an undefined property Laravel\\Cashier\\Checkout\:\:\$url\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Filament/App/Pages/RelationshipCalculatorReport.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Filament/App/Pages/RelationshipCalculatorReport.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/ResearchDashboardPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserChecklist\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/ResearchDashboardPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:fresh\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/SubscriptionPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:hasExpiredTrial\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Filament/App/Pages/SubscriptionPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:isPremium\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Filament/App/Pages/SubscriptionPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: app/Filament/App/Pages/SubscriptionPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Support\\Optional\:\:toFormattedDateString\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/SubscriptionPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Tree\:\:findOrFail\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/TreePrivacy.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Tree\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/TreePrivacy.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:hasExpiredTrial\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/TrialExpiredPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:isPremium\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/TrialExpiredPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:newSubscription\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/TrialExpiredPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 4
 			path: app/Filament/App/Pages/TrialExpiredPage.php
 
 		-
@@ -571,21 +109,9 @@ parameters:
 			path: app/Filament/App/Pages/TwoFactorAuthenticationPage.php
 
 		-
-			message: '#^Property App\\Filament\\App\\Pages\\TwoFactorAuthenticationPage\:\:\$user \(App\\Models\\User\) does not accept Illuminate\\Contracts\\Auth\\Authenticatable\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/Filament/App/Pages/TwoFactorAuthenticationPage.php
-
-		-
 			message: '#^Access to an undefined property App\\Filament\\App\\Pages\\UpdatePasswordPage\:\:\$form\.$#'
 			identifier: property.notFound
 			count: 2
-			path: app/Filament/App/Pages/UpdatePasswordPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:forceFill\(\)\.$#'
-			identifier: method.notFound
-			count: 1
 			path: app/Filament/App/Pages/UpdatePasswordPage.php
 
 		-
@@ -595,46 +121,10 @@ parameters:
 			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Contracts\\Auth\\Authenticatable\:\:\$email\.$#'
-			identifier: property.notFound
+			message: '#^Method App\\Filament\\App\\Pages\\UserChecklistsPage\:\:getNavigationBadge\(\) should return string\|null but returns int\<1, max\>\|null\.$#'
+			identifier: return.type
 			count: 1
-			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Contracts\\Auth\\Authenticatable\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:forceFill\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 2
 			path: app/Filament/App/Pages/UserChecklistsPage.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserChecklist\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Filament/App/Pages/UserChecklistsPage.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/AddrResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: app/Filament/App/Resources/AppResource.php
 
 		-
 			message: '#^Attribute class App\\Filament\\App\\Resources\\Override does not exist\.$#'
@@ -643,56 +133,8 @@ parameters:
 			path: app/Filament/App/Resources/AuthorResource.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChanResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ChecklistTemplate\:\:\$created_by\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$checklist_template_id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ChecklistTemplate\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ChecklistTemplate\:\:\$is_default\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ChecklistTemplate\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ChecklistTemplate\:\:\$templateItems\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
-			message: '#^Call to an undefined static method Illuminate\\Database\\Eloquent\\Model\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 1
 			path: app/Filament/App/Resources/ChecklistTemplateResource.php
 
@@ -703,10 +145,10 @@ parameters:
 			path: app/Filament/App/Resources/ChecklistTemplateResource.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Method App\\Filament\\App\\Resources\\ChecklistTemplateResource\:\:getNavigationBadge\(\) should return string\|null but returns int\<0, max\>\.$#'
+			identifier: return.type
 			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource/Pages/CreateChecklistTemplate.php
+			path: app/Filament/App/Resources/ChecklistTemplateResource.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
@@ -727,79 +169,19 @@ parameters:
 			path: app/Filament/App/Resources/ChecklistTemplateResource/RelationManagers/TemplateItemsRelationManager.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/DnaMatchingResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: app/Filament/App/Resources/DnaResource.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/DnaResource/Pages/CreateDna.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:isPremium\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/DuplicateCheckResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/DuplicateCheckResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/GedcomResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Filament/App/Resources/GedcomResource.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$filename\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Filament/App/Resources/GedcomResource/Pages/CreateGedcom.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Gedcom\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/GedcomResource/Pages/CreateGedcom.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ImportJob\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/GedcomResource/Pages/CreateGedcom.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:fullname\(\)\.$#'
 			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/ImportJobResource.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 2
 			path: app/Filament/App/Resources/PersonAssoResource.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\MediaObject\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\MediaObject\>\:\:\$files\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$medi\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
@@ -817,40 +199,16 @@ parameters:
 			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Filesystem\\Filesystem\:\:url\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\MediaObject\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
-
-		-
 			message: '#^Using nullsafe property access "\?\-\>medi" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
 			identifier: nullsafe.neverNull
 			count: 1
 			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:fullname\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: app/Filament/App/Resources/PersonResource/RelationManagers/AssociationsRelationManager.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonPhoto\:\:\$file_path\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonPhoto\:\:\$is_analyzed\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
@@ -859,64 +217,16 @@ parameters:
 			path: app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\SourceRef\:\:\$source\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: app/Filament/App/Resources/PersonResource/RelationManagers/SourcesRelationManager.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/ResearchSpaceResource/Pages/CreateResearchSpace.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:isPremium\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/SmartMatchResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/SmartMatchResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Source\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Filament/App/Resources/SourceRefResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Source\:\:\$name\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$titl\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Filament/App/Resources/SourceRefResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Source\:\:\$titl\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/SourceRefResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$platform\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/VirtualEventResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/VirtualEventResource.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Resources/VirtualEventResource.php
+			path: app/Filament/App/Resources/PersonResource/RelationManagers/SourcesRelationManager.php
 
 		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\:\:past\(\)\.$#'
@@ -997,12 +307,6 @@ parameters:
 			path: app/Filament/App/Resources/VirtualEventResource/Pages/ListVirtualEvents.php
 
 		-
-			message: '#^Call to an undefined static method Illuminate\\Database\\Eloquent\\Model\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/VirtualEventResource/Pages/ListVirtualEvents.php
-
-		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:canJoin\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -1019,18 +323,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: app/Filament/App/Resources/VirtualEventResource/Pages/ViewVirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$attended\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$rsvp_status\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
@@ -1063,69 +355,21 @@ parameters:
 			path: app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
+			message: '#^Called ''pluck'' on Laravel collection, but could have been retrieved as a query\.$#'
+			identifier: larastan.noUnnecessaryCollectionCall
+			count: 4
 			path: app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\VirtualEventAttendee\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Widgets/FamilyStatsWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Widgets/FamilyStatsWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Widgets/FamilyStatsWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Widgets/FamilyStatsWidget.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$childInFamily\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Filament/App/Widgets/FamilyTreeOverviewWidget.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
 			identifier: property.notFound
-			count: 2
-			path: app/Filament/App/Widgets/FamilyTreeOverviewWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 1
-			path: app/Filament/App/Widgets/FamilyTreeOverviewWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
 			path: app/Filament/App/Widgets/FamilyTreeOverviewWidget.php
 
 		-
@@ -1141,76 +385,10 @@ parameters:
 			path: app/Filament/App/Widgets/PedigreeChartWidget.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Widgets/RecentActivityWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Widgets/RecentActivityWidget.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Contracts\\Auth\\Authenticatable\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Filament/Resources/GedcomResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\AISuggestedMatch\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/AIMatchController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\AISuggestedMatch\:\:\$team_id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/AIMatchController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/DnaController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/DnaController.php
-
-		-
 			message: '#^Call to an undefined method App\\Models\\Family\:\:familyEvents\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: app/Http/Controllers/Api/FamilyController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/FamilyController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/FamilyController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ImportJob\:\:\$error_message\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/Api/ImportController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ImportJob\:\:\$progress\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/Api/ImportController.php
 
 		-
 			message: '#^Call to an undefined method App\\Services\\DnaImportService\:\:queueImport\(\)\.$#'
@@ -1219,52 +397,16 @@ parameters:
 			path: app/Http/Controllers/Api/ImportController.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\MediaObject\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/MediaController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\MediaObject\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/MediaController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Note\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/NoteController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Note\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/NoteController.php
-
-		-
 			message: '#^Call to an undefined method App\\Models\\Person\:\:personEvents\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: app/Http/Controllers/Api/PersonController.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/PersonController.php
-
-		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 2
 			path: app/Http/Controllers/Api/PersonController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Place\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/PlaceController.php
 
 		-
 			message: '#^If condition is always true\.$#'
@@ -1273,80 +415,14 @@ parameters:
 			path: app/Http/Controllers/Api/PlaceController.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Source\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/SourceController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Source\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/SourceController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:forceCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/TeamController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Tree\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Http/Controllers/Api/TreeController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Tree\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/TreeController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Tree\:\:latest\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/Api/TreeController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Http/Controllers/FanChartController.php
-
-		-
-			message: '#^Method App\\Http\\Controllers\\FanChartController\:\:show\(\) should return Illuminate\\View\\View but returns Illuminate\\Contracts\\View\\View\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Http/Controllers/FanChartController.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Http\\Request\:\:\$email\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Http/Controllers/TeamInvitationController.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Http\\Request\:\:\$team_id\.$#'
-			identifier: property.notFound
+			message: '#^Call to an undefined method App\\Models\\Team\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Team\>\:\:members\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: app/Http/Controllers/TeamInvitationController.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Http\\Request\:\:\$token\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/TeamInvitationController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:findOrFail\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Http/Controllers/TeamInvitationController.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:firstOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Call to an undefined method App\\Models\\User\:\:invitations\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: app/Http/Controllers/TeamInvitationController.php
 
@@ -1361,24 +437,6 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: app/Http/Controllers/TeamInvitationController.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:canUploadDna\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Http/Middleware/PremiumFeatureMiddleware.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Authenticatable\:\:isPremium\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Http/Middleware/PremiumFeatureMiddleware.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Http/Middleware/TeamsPermission.php
 
 		-
 			message: '#^Access to an undefined property App\\Http\\Resources\\PersonResource\:\:\$birthday\.$#'
@@ -1441,120 +499,6 @@ parameters:
 			path: app/Http/Resources/PersonResource.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Http/Responses/Auth/LoginResponse.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Http/Responses/Auth/RegisterResponse.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$analysis_date\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$chromosome_breakdown\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$confidence_level\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$detailed_report\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$file1\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$file2\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$image\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$largest_cm_segment\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$match_id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$match_name\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$match_quality_score\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$predicted_relationship\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$shared_segments_count\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$total_shared_cm\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DnaMatching\:\:\$user_id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Jobs/DnaMatching.php
-
-		-
 			message: '#^Using nullsafe property access "\?\-\>name" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
 			identifier: nullsafe.neverNull
 			count: 2
@@ -1567,112 +511,28 @@ parameters:
 			path: app/Jobs/ExportGrampsXml.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$currentTeam\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Jobs/ImportGedcom.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\ImportJob\:\:firstOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Jobs/ImportGedcom.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ImportJob\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Jobs/ImportGedcom.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 3
-			path: app/Jobs/ImportGedcom.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$currentTeam\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Jobs/ImportGrampsXml.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\ImportJob\:\:firstOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Jobs/ImportGrampsXml.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ImportJob\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Jobs/ImportGrampsXml.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 3
-			path: app/Jobs/ImportGrampsXml.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:notify\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: app/Jobs/RunRecordMatchingJob.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Jobs/RunRecordMatchingJob.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereIn\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:notify\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: app/Jobs/ScanForDuplicatePersons.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Jobs/ScanForDuplicatePersons.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/AchievementUnlockedListener.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$key\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/AchievementUnlockedListener.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/AchievementUnlockedListener.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$points\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/AchievementUnlockedListener.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Listeners/AchievementUnlockedListener.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/AchievementUnlockedListener.php
 
 		-
 			message: '#^Call to function method_exists\(\) with App\\Models\\User and ''assignRole'' will always evaluate to true\.$#'
@@ -1681,76 +541,16 @@ parameters:
 			path: app/Listeners/AssignDefaultRole.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Listeners/SwitchTeam.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/UserLeveledUpListener.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/UserLeveledUpListener.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$total_points\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Listeners/UserLeveledUpListener.php
-
-		-
 			message: '#^Access to an undefined property App\\Livewire\\DabovilleReport\:\:\$form\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Livewire/DabovilleReport.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Support\\Optional\:\:\$date\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Livewire/DeVilliersReport.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Called ''pluck'' on Laravel collection, but could have been retrieved as a query\.$#'
+			identifier: larastan.noUnnecessaryCollectionCall
 			count: 1
-			path: app/Livewire/DeVilliersReport.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Livewire/DescendantChartComponent.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:first\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/DescendantChartComponent.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/DescendantChartComponent.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:first\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/DescendantChartWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/DescendantChartWidget.php
+			path: app/Livewire/DabovilleReport.php
 
 		-
 			message: '#^Offset ''children'' on array\{family_id\: mixed, spouse\: array\{id\: mixed, name\: mixed, givn\: mixed, surn\: mixed, sex\: mixed, birth_date\: mixed, death_date\: mixed, birth_year\: mixed, \.\.\.\}\|null, children\: list\<non\-empty\-array\>\} in isset\(\) always exists and is not nullable\.$#'
@@ -1771,27 +571,15 @@ parameters:
 			path: app/Livewire/DevillierReport.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\DocumentTranscription\:\:\$id\.$#'
-			identifier: property.notFound
+			message: '#^Called ''pluck'' on Laravel collection, but could have been retrieved as a query\.$#'
+			identifier: larastan.noUnnecessaryCollectionCall
 			count: 1
-			path: app/Livewire/DocumentTranscriptionComponent.php
+			path: app/Livewire/DevillierReport.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Contracts\\Auth\\Authenticatable\:\:\$latestTeam\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 4
-			path: app/Livewire/DocumentTranscriptionComponent.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DocumentTranscription\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Livewire/DocumentTranscriptionComponent.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DocumentTranscription\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
+			count: 8
 			path: app/Livewire/DocumentTranscriptionComponent.php
 
 		-
@@ -1799,12 +587,6 @@ parameters:
 			identifier: nullsafe.neverNull
 			count: 4
 			path: app/Livewire/DocumentTranscriptionComponent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/FacialRecognitionReview.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$bounding_box\.$#'
@@ -1821,7 +603,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 3
 			path: app/Livewire/FacialRecognitionReview.php
 
 		-
@@ -1843,111 +625,39 @@ parameters:
 			path: app/Livewire/FacialRecognitionReview.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Livewire/FacialRecognitionReview.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Livewire/FacialRecognitionReview.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PhotoTag\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Livewire/FacialRecognitionReview.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$child_in_family_id\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$unlocked_at\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Livewire/FamilyTreeBuilder.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsHusband\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/FamilyTreeBuilder.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsWife\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/FamilyTreeBuilder.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/FamilyTreeBuilder.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/FamilyTreeBuilder.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Livewire/FamilyTreeBuilder.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:first\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/FanChart.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: app/Livewire/GamificationDashboard.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Achievement\:\:active\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 1
 			path: app/Livewire/GamificationDashboard.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Support\\Optional\:\:\$date\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Livewire/HenryReport.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
+			message: '#^Anonymous function should return Illuminate\\Support\\Collection\<int, array\{achievement\: mixed, unlocked\: true, unlocked_at\: mixed, progress\: Illuminate\\Database\\Eloquent\\Model\|null, progress_percentage\: mixed\}\> but returns Illuminate\\Support\\Collection\<int, array\{achievement\: mixed, unlocked\: true, unlocked_at\: mixed, progress\: Illuminate\\Database\\Eloquent\\Model\|null, progress_percentage\: mixed\}\>\.$#'
+			identifier: return.type
 			count: 1
-			path: app/Livewire/PedigreeChart.php
+			path: app/Livewire/GamificationDashboard.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/PedigreeChart.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/PedigreeChart.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/PedigreeChart.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Support\\Optional\:\:format\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:getProgressPercentage\(\)\.$#'
 			identifier: method.notFound
-			count: 2
+			count: 1
+			path: app/Livewire/GamificationDashboard.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany\:\:incomplete\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Livewire/GamificationDashboard.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Livewire/PedigreeChart.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
+			identifier: property.notFound
+			count: 1
 			path: app/Livewire/PedigreeChart.php
 
 		-
@@ -1957,63 +667,33 @@ parameters:
 			path: app/Livewire/PedigreeChart.php
 
 		-
-			message: '#^Using nullsafe method call on non\-nullable type Illuminate\\Support\\Optional\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 2
-			path: app/Livewire/PedigreeChart.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:first\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/PedigreeChartWidget.php
-
-		-
 			message: '#^Static access to instance property App\\Livewire\\PedigreeChartWidget\:\:\$view\.$#'
 			identifier: property.staticAccess
 			count: 1
 			path: app/Livewire/PedigreeChartWidget.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\UserChecklist\:\:\$completed_at\.$#'
+			message: '#^Access to an undefined property App\\Models\\Family\:\:\$progress_percentage\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Livewire/ResearchProgressWidget.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property App\\Models\\Person\:\:\$progress_percentage\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Livewire/ResearchProgressWidget.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserChecklist\>\:\:active\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Livewire/ResearchProgressWidget.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserChecklist\>\:\:completed\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: app/Livewire/ResearchProgressWidget.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserChecklist\>\:\:overdue\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property App\\Models\\UserChecklist\:\:\$completed_count\.$#'
+			identifier: property.notFound
 			count: 2
 			path: app/Livewire/ResearchProgressWidget.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/ResearchProgressWidget.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
+			message: '#^Access to an undefined property App\\Models\\UserChecklist\:\:\$total_count\.$#'
+			identifier: property.notFound
+			count: 2
 			path: app/Livewire/ResearchProgressWidget.php
 
 		-
@@ -2023,134 +703,20 @@ parameters:
 			path: app/Livewire/ResearchProgressWidget.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\ResearchSpace\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Livewire/ResearchSpace/CollaboratorBoard.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ResearchSpace\:\:\$settings\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Livewire/ResearchSpace/CollaboratorBoard.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Livewire/ResearchSpace/CollaboratorBoard.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\SocialConnectionPrivacy\:\:\$allow_contact_from_matches\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\SocialConnectionPrivacy\:\:\$allow_family_discovery\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\SocialConnectionPrivacy\:\:\$share_tree_with_matches\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\SocialConnectionPrivacy\:\:\$show_profile_to_matches\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Contracts\\Auth\\Authenticatable\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ConnectedAccount\:\:findOrFail\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ConnectedAccount\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\SocialFamilyConnection\:\:findOrFail\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\SocialFamilyConnection\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Method App\\Livewire\\SocialConnections\:\:render\(\) should return Illuminate\\View\\View but returns Illuminate\\Contracts\\View\\View\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Livewire/SocialConnections.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\FamilyEvent\:\:\$date\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/TimelineComponent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\FamilyEvent\:\:\$id\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$date\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Livewire/TimelineComponent.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 2
 			path: app/Livewire/TimelineComponent.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/TimelineComponent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$events\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/TimelineComponent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$date\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/TimelineComponent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/TimelineComponent.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/TimelineComponent.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Relation ''place'' is not found in App\\Models\\FamilyEvent model\.$#'
+			identifier: larastan.relationExistence
 			count: 1
 			path: app/Livewire/TimelineComponent.php
 
@@ -2161,92 +727,8 @@ parameters:
 			path: app/Livewire/TimelineComponent.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\ChecklistTemplate\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\ChecklistTemplate\>\:\:\$description\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ChecklistTemplate\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\ChecklistTemplate\>\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ChecklistTemplate\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserChecklist\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserChecklist\:\:findOrFail\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserChecklist\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserChecklistItem\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserChecklistItem\:\:findOrFail\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Livewire/UserChecklistManager.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/VirtualEventRsvp.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Livewire/VirtualEventRsvp.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\VirtualEventAttendee\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Livewire/VirtualEventRsvp.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/AISuggestedMatch.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/AISuggestedMatch.php
 
@@ -2257,56 +739,20 @@ parameters:
 			path: app/Models/AISuggestedMatch.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$badge_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Achievement.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$icon\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Achievement.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Achievement.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$points\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Achievement.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/Achievement.php
-
-		-
 			message: '#^Method App\\Models\\Achievement\:\:getProgressFor\(\) should return App\\Models\\UserProgress\|null but returns Illuminate\\Database\\Eloquent\\Model\|null\.$#'
 			identifier: return.type
 			count: 1
 			path: app/Models/Achievement.php
 
 		-
-			message: '#^PHPDoc type array of property App\\Models\\Activation\:\:\$fillable is not covariant with PHPDoc type array\<int, string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
+			message: '#^PHPDoc type array of property App\\Models\\Activation\:\:\$fillable is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
 			identifier: property.phpDocType
 			count: 1
 			path: app/Models/Activation.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Addr.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Addr.php
 
@@ -2317,14 +763,8 @@ parameters:
 			path: app/Models/Addr.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Author.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Author.php
 
@@ -2347,31 +787,19 @@ parameters:
 			path: app/Models/BatchData.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/BatchData.php
-
-		-
 			message: '#^Call to function unset\(\) contains undefined variable \$value\.$#'
 			identifier: unset.variable
 			count: 1
 			path: app/Models/BatchData.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Chan.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Chan.php
-
-		-
-			message: '#^PHPDoc type array of property App\\Models\\Chan\:\:\$fillable is not covariant with PHPDoc type array\<int, string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
+			message: '#^PHPDoc type array of property App\\Models\\Chan\:\:\$fillable is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
 			identifier: property.phpDocType
 			count: 1
 			path: app/Models/Chan.php
@@ -2383,20 +811,8 @@ parameters:
 			path: app/Models/Chan.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/ChecklistTemplate.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/ChecklistTemplate.php
-
-		-
-			message: '#^Method App\\Models\\ChecklistTemplate\:\:templateItems\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Query\\Builder\.$#'
-			identifier: return.type
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/ChecklistTemplate.php
 
@@ -2407,14 +823,8 @@ parameters:
 			path: app/Models/ChecklistTemplate.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Citation.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Citation.php
 
@@ -2425,7 +835,7 @@ parameters:
 			path: app/Models/Citation.php
 
 		-
-			message: '#^PHPDoc type array of property App\\Models\\ConnectedAccount\:\:\$fillable is not covariant with PHPDoc type array\<int, string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
+			message: '#^PHPDoc type array of property App\\Models\\ConnectedAccount\:\:\$fillable is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
 			identifier: property.phpDocType
 			count: 1
 			path: app/Models/ConnectedAccount.php
@@ -2437,26 +847,8 @@ parameters:
 			path: app/Models/Conversation.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$consent_given\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
-			path: app/Models/Dna.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$consent_given_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Dna.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Dna.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/Dna.php
 
@@ -2467,14 +859,8 @@ parameters:
 			path: app/Models/Dna.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/DnaMatching.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/DnaMatching.php
 
@@ -2485,26 +871,8 @@ parameters:
 			path: app/Models/DnaMatching.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\DocumentTranscription\:\:\$raw_transcription\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Models/DocumentTranscription.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateCheck\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Models/DuplicateCheck.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/DuplicateCheck.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/DuplicateCheck.php
 
@@ -2515,38 +883,8 @@ parameters:
 			path: app/Models/DuplicateCheck.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$reviewed_at\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Models/DuplicateMatch.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$reviewed_by\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/DuplicateMatch.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/DuplicateMatch.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/DuplicateMatch.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/DuplicateMatch.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/DuplicateMatch.php
 
@@ -2557,14 +895,8 @@ parameters:
 			path: app/Models/DuplicateMatch.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/FaceEncoding.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/FaceEncoding.php
 
@@ -2575,20 +907,8 @@ parameters:
 			path: app/Models/FaceEncoding.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Family\:\:\$research_progress\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Models/Family.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Family.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/Family.php
 
@@ -2617,20 +937,14 @@ parameters:
 			path: app/Models/Family.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/FamilyEvent.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/FamilySlgs.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/FamilySlgs.php
 
@@ -2641,14 +955,8 @@ parameters:
 			path: app/Models/FamilySlgs.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/ImportJob.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/ImportJob.php
 
@@ -2659,14 +967,8 @@ parameters:
 			path: app/Models/ImportJob.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/MediaObject.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/MediaObject.php
 
@@ -2677,14 +979,8 @@ parameters:
 			path: app/Models/MediaObject.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Note.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Note.php
 
@@ -2695,128 +991,32 @@ parameters:
 			path: app/Models/Note.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birth_year\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Models/Person.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$childInFamily\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 1
 			path: app/Models/Person.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Models/Person.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsHusband\.$#'
-			identifier: property.notFound
+			message: '#^Cannot call method greaterThan\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: app/Models/Person.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsWife\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$givn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 8
-			path: app/Models/Person.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$pedigree\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$research_progress\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$surn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Filesystem\\Filesystem\:\:url\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:get\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:withBasicInfo\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Models/Person.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:updateOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Method App\\Models\\Person\:\:associatedWith\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PersonAsso\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Method App\\Models\\Person\:\:associations\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PersonAsso\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/Person.php
-
-		-
-			message: '#^Method App\\Models\\Person\:\:sourceRefs\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\SourceRef\>\.$#'
-			identifier: return.type
+			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\PedigreeType\:\:ADOPTED will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: app/Models/Person.php
 
@@ -2827,14 +1027,8 @@ parameters:
 			path: app/Models/Person.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonAlia.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonAlia.php
 
@@ -2845,14 +1039,8 @@ parameters:
 			path: app/Models/PersonAlia.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonAnci.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonAnci.php
 
@@ -2863,14 +1051,8 @@ parameters:
 			path: app/Models/PersonAnci.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonAsso.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonAsso.php
 
@@ -2881,20 +1063,14 @@ parameters:
 			path: app/Models/PersonAsso.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonEvent.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonLds.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonLds.php
 
@@ -2905,14 +1081,8 @@ parameters:
 			path: app/Models/PersonLds.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonName.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonName.php
 
@@ -2923,14 +1093,8 @@ parameters:
 			path: app/Models/PersonName.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonNameFone.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonNameFone.php
 
@@ -2941,14 +1105,8 @@ parameters:
 			path: app/Models/PersonNameFone.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonNameRomn.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonNameRomn.php
 
@@ -2959,32 +1117,8 @@ parameters:
 			path: app/Models/PersonNameRomn.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\PersonPhoto\:\:\$file_path\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Models/PersonPhoto.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonPhoto.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonPhoto.php
-
-		-
-			message: '#^Method App\\Models\\PersonPhoto\:\:confirmedTags\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PhotoTag\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/PersonPhoto.php
-
-		-
-			message: '#^Method App\\Models\\PersonPhoto\:\:pendingTags\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PhotoTag\>\.$#'
-			identifier: return.type
 			count: 1
 			path: app/Models/PersonPhoto.php
 
@@ -2995,14 +1129,8 @@ parameters:
 			path: app/Models/PersonPhoto.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PersonSubm.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/PersonSubm.php
 
@@ -3013,20 +1141,8 @@ parameters:
 			path: app/Models/PersonSubm.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\PhotoTag\:\:\$status\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 3
-			path: app/Models/PhotoTag.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/PhotoTag.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/PhotoTag.php
 
@@ -3037,14 +1153,8 @@ parameters:
 			path: app/Models/PhotoTag.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Place.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Place.php
 
@@ -3055,14 +1165,8 @@ parameters:
 			path: app/Models/Place.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Publication.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Publication.php
 
@@ -3073,20 +1177,8 @@ parameters:
 			path: app/Models/Publication.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\RecordType\:\:\$category\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 4
-			path: app/Models/RecordType.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Refn.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/Refn.php
 
@@ -3097,14 +1189,8 @@ parameters:
 			path: app/Models/Refn.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Repository.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Repository.php
 
@@ -3115,14 +1201,8 @@ parameters:
 			path: app/Models/Repository.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/ResearchSpace.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/ResearchSpace.php
 
@@ -3133,26 +1213,8 @@ parameters:
 			path: app/Models/ResearchSpace.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\SmartMatch\:\:\$confidence_score\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
-			path: app/Models/SmartMatch.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\SmartMatch\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Models/SmartMatch.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/SmartMatch.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Models/SmartMatch.php
 
@@ -3163,32 +1225,32 @@ parameters:
 			path: app/Models/SmartMatch.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\SocialConnectionPrivacy\:\:\$blocked_users\.$#'
-			identifier: property.notFound
-			count: 2
+			message: '#^Property App\\Models\\SocialConnectionPrivacy\:\:\$blocked_users \(string\|null\) does not accept array\.$#'
+			identifier: assign.propertyType
+			count: 1
 			path: app/Models/SocialConnectionPrivacy.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\SocialFamilyConnection\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Models/SocialFamilyConnection.php
+			message: '#^Property App\\Models\\SocialConnectionPrivacy\:\:\$blocked_users \(string\|null\) does not accept array\<int, int\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Models/SocialConnectionPrivacy.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Source\:\:\$recordType\.$#'
+			message: '#^Strict comparison using \!\=\= between \*NEVER\* and int will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Models/SocialConnectionPrivacy.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$category\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Models/Source.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Source.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Source.php
 
@@ -3199,14 +1261,8 @@ parameters:
 			path: app/Models/Source.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/SourceData.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/SourceData.php
 
@@ -3217,14 +1273,8 @@ parameters:
 			path: app/Models/SourceData.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/SourceDataEven.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/SourceDataEven.php
 
@@ -3235,14 +1285,8 @@ parameters:
 			path: app/Models/SourceDataEven.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/SourceRef.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/SourceRef.php
 
@@ -3253,14 +1297,8 @@ parameters:
 			path: app/Models/SourceRef.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/SourceRefEven.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/SourceRefEven.php
 
@@ -3271,14 +1309,8 @@ parameters:
 			path: app/Models/SourceRefEven.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/SourceRepo.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/SourceRepo.php
 
@@ -3289,14 +1321,8 @@ parameters:
 			path: app/Models/SourceRepo.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Subm.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Subm.php
 
@@ -3307,14 +1333,8 @@ parameters:
 			path: app/Models/Subm.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Subn.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Subn.php
 
@@ -3325,49 +1345,31 @@ parameters:
 			path: app/Models/Subn.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$childInFamily\.$#'
+			message: '#^PHPDoc type array\<int, string\> of property App\\Models\\Team\:\:\$fillable is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: app/Models/Team.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Models/Tree.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsHusband\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Tree.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsWife\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Tree.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Tree\:\:\$rootPerson\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Models/Tree.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Tree.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Tree.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Models/Tree.php
-
-		-
-			message: '#^PHPDoc type array of property App\\Models\\Tree\:\:\$fillable is not covariant with PHPDoc type array\<int, string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
+			message: '#^PHPDoc type array of property App\\Models\\Tree\:\:\$fillable is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
 			identifier: property.phpDocType
 			count: 1
 			path: app/Models/Tree.php
@@ -3379,14 +1381,8 @@ parameters:
 			path: app/Models/Tree.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/Type.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/Type.php
 
@@ -3397,60 +1393,6 @@ parameters:
 			path: app/Models/Type.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$dna_uploads_count\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$is_premium\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$level\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$ownedTeams\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$profile_photo_path\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$total_points\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$trial_ends_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:recent\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/User.php
-
-		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany\:\:byActivity\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -3459,12 +1401,18 @@ parameters:
 		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany\:\:recent\(\)\.$#'
 			identifier: method.notFound
+			count: 2
+			path: app/Models/User.php
+
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
 			count: 1
 			path: app/Models/User.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Cannot call method diffInDays\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: app/Models/User.php
 
@@ -3475,57 +1423,39 @@ parameters:
 			path: app/Models/User.php
 
 		-
-			message: '#^Method App\\Models\\User\:\:pendingSocialConnections\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\SocialFamilyConnection\>\.$#'
-			identifier: return.type
+			message: '#^PHPDoc type array\<int, string\> of property App\\Models\\User\:\:\$appends is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$appends\.$#'
+			identifier: property.phpDocType
 			count: 1
 			path: app/Models/User.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\UserAchievement\:\:\$unlocked_at\.$#'
+			message: '#^PHPDoc type array\<int, string\> of property App\\Models\\User\:\:\$fillable is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^PHPDoc type array\<int, string\> of property App\\Models\\User\:\:\$hidden is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$hidden\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Property ''profile_photo_url'' does not exist in model\.$#'
+			identifier: rules.modelAppends
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Models/UserAchievement.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\UserChecklist\:\:\$due_date\.$#'
-			identifier: property.notFound
-			count: 1
 			path: app/Models/UserChecklist.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\UserChecklist\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/UserChecklist.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/UserChecklist.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Models/UserChecklist.php
-
-		-
-			message: '#^Method App\\Models\\UserChecklist\:\:completedItems\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserChecklistItem\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/UserChecklist.php
-
-		-
-			message: '#^Method App\\Models\\UserChecklist\:\:items\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Query\\Builder\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/UserChecklist.php
-
-		-
-			message: '#^Method App\\Models\\UserChecklist\:\:pendingItems\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserChecklistItem\>\.$#'
-			identifier: return.type
-			count: 1
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
+			count: 2
 			path: app/Models/UserChecklist.php
 
 		-
@@ -3535,115 +1465,37 @@ parameters:
 			path: app/Models/UserChecklist.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\UserChecklistItem\:\:\$userChecklist\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$status\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Models/UserChecklistItem.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\UserPoint\:\:\$activity_type\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/UserPoint.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\UserPoint\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/UserPoint.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\UserProgress\:\:\$current_progress\.$#'
-			identifier: property.notFound
-			count: 6
-			path: app/Models/UserProgress.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\UserProgress\:\:\$last_updated_at\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/UserProgress.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\UserProgress\:\:\$progress_data\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/UserProgress.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\UserProgress\:\:\$target_progress\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Models/UserProgress.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$accepted_count\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$end_time\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$max_attendees\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$start_time\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$timezone\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:check\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:items\(\)\.$#'
 			identifier: method.notFound
 			count: 1
-			path: app/Models/VirtualEvent.php
+			path: app/Models/UserChecklistItem.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:markAsCompleted\(\)\.$#'
 			identifier: method.notFound
 			count: 1
-			path: app/Models/VirtualEvent.php
+			path: app/Models/UserChecklistItem.php
 
 		-
-			message: '#^Method App\\Models\\VirtualEvent\:\:acceptedAttendees\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\VirtualEventAttendee\>\.$#'
-			identifier: return.type
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:markAsStarted\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Models/UserChecklistItem.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Models/VirtualEvent.php
 
 		-
-			message: '#^Method App\\Models\\VirtualEvent\:\:actualAttendees\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\VirtualEventAttendee\>\.$#'
+			message: '#^Method App\\Models\\VirtualEvent\:\:getDurationInMinutesAttribute\(\) should return int but returns float\.$#'
 			identifier: return.type
 			count: 1
 			path: app/Models/VirtualEvent.php
@@ -3661,82 +1513,52 @@ parameters:
 			path: app/Models/VirtualEvent.php
 
 		-
-			message: '#^Method App\\Models\\VirtualEvent\:\:hosts\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\VirtualEventAttendee\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Method App\\Models\\VirtualEvent\:\:moderators\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\VirtualEventAttendee\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/VirtualEvent.php
-
-		-
-			message: '#^Method App\\Models\\VirtualEvent\:\:pendingAttendees\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\VirtualEventAttendee\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Models/VirtualEvent.php
-
-		-
 			message: '#^Unsafe call to private method App\\Models\\VirtualEvent\:\:getTenantId\(\) through static\:\:\.$#'
 			identifier: staticClassAccess.privateMethod
 			count: 2
 			path: app/Models/VirtualEvent.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$attended\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/VirtualEventAttendee.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$duration_minutes\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/VirtualEventAttendee.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$joined_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/VirtualEventAttendee.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$left_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/VirtualEventAttendee.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$person\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$email\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Models/VirtualEventAttendee.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$rsvp_status\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$givn\.$#'
 			identifier: property.notFound
-			count: 3
-			path: app/Models/VirtualEventAttendee.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$user\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/VirtualEventAttendee.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEventAttendee\:\:\$virtualEvent\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Models/VirtualEventAttendee.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
 			count: 1
-			path: app/Modules/Admin/AdminModule.php
+			path: app/Models/VirtualEventAttendee.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/VirtualEventAttendee.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$start_time\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/VirtualEventAttendee.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/VirtualEventAttendee.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$surn\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/VirtualEventAttendee.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:canJoin\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Models/VirtualEventAttendee.php
 
 		-
 			message: '#^Instantiated class App\\Modules\\Admin\\Services\\ChangeService not found\.$#'
@@ -3769,60 +1591,6 @@ parameters:
 			path: app/Modules/Admin/Filament/Resources/TypeResource.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Chan\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Chan\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Chan\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Refn\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Type\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Type\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Type\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Type\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Admin/Services/AdminService.php
-
-		-
 			message: '#^Property App\\Modules\\BaseModule\:\:\$description on left side of \?\? is not nullable nor uninitialized\.$#'
 			identifier: nullCoalesce.initializedProperty
 			count: 1
@@ -3841,100 +1609,28 @@ parameters:
 			path: app/Modules/BaseModule.php
 
 		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Modules/Core/CoreModule.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:updateOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Core/Services/GedcomService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:updateOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Core/Services/GedcomService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Modules/Core/Services/GedcomService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Core/Services/TreeService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$childInFamily\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Core/Services/TreeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Modules/Core/Services/TreeService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsHusband\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Modules/Core/Services/TreeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsWife\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Modules/Core/Services/TreeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$givn\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Core/Services/TreeService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: app/Modules/Core/Services/TreeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Modules/Core/Services/TreeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$surn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Core/Services/TreeService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Core/Services/TreeService.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Modules/DNA/DNAModule.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/Modules/Events/EventsModule.php
 
 		-
 			message: '#^Instantiated class App\\Modules\\Events\\Services\\TimelineService not found\.$#'
@@ -3943,76 +1639,22 @@ parameters:
 			path: app/Modules/Events/EventsModule.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$date\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$person\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Events/Services/EventsService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
+			message: '#^Relation ''person'' is not found in App\\Models\\PersonEvent model\.$#'
+			identifier: larastan.relationExistence
+			count: 5
 			path: app/Modules/Events/Services/EventsService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
+			message: '#^Relation ''place'' is not found in App\\Models\\PersonEvent model\.$#'
+			identifier: larastan.relationExistence
+			count: 5
 			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:selectRaw\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:whereBetween\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Events/Services/EventsService.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/Modules/Family/FamilyModule.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Family\:\:\$divorce_date\.$#'
@@ -4033,46 +1675,10 @@ parameters:
 			path: app/Modules/Family/Services/FamilyService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Family/Services/FamilyService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Family/Services/FamilyService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:whereHas\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Modules/Family/Services/FamilyService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:withCount\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Family/Services/FamilyService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Relation ''children'' is not found in App\\Models\\Family model\.$#'
+			identifier: larastan.relationExistence
 			count: 2
 			path: app/Modules/Family/Services/FamilyService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Family/Services/FamilyService.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Modules/Import/ImportModule.php
 
 		-
 			message: '#^Instantiated class App\\Modules\\Import\\Services\\ExportService not found\.$#'
@@ -4091,12 +1697,6 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: app/Modules/Import/ImportModule.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/Modules/Media/MediaModule.php
 
 		-
 			message: '#^Instantiated class App\\Modules\\Media\\Services\\MediaProcessorService not found\.$#'
@@ -4123,12 +1723,6 @@ parameters:
 			path: app/Modules/ModuleManager.php
 
 		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Modules/Notes/NotesModule.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Note\:\:\$category\.$#'
 			identifier: property.notFound
 			count: 1
@@ -4136,18 +1730,6 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Note\:\:\$content\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Note\:\:\$created_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Note\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Notes/Services/NotesService.php
@@ -4165,75 +1747,15 @@ parameters:
 			path: app/Modules/Notes/Services/NotesService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Note\:\:\$updated_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:id\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Note\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Note\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Note\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Note\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Note\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Notes/Services/NotesService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$confidence_score\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Person/Filament/Resources/DuplicateMatchResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$duplicatePerson\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 2
 			path: app/Modules/Person/Filament/Resources/DuplicateMatchResource.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$primaryPerson\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
 			identifier: property.notFound
 			count: 2
-			path: app/Modules/Person/Filament/Resources/DuplicateMatchResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$reviewed_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Person/Filament/Resources/DuplicateMatchResource.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DuplicateMatch\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 3
 			path: app/Modules/Person/Filament/Resources/DuplicateMatchResource.php
 
 		-
@@ -4261,116 +1783,44 @@ parameters:
 			path: app/Modules/Person/Filament/Resources/PersonResource.php
 
 		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/Modules/Person/PersonModule.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$child_in_family_id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Person\:\:\$children\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Person/Services/PersonService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsHusband\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$date\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Person/Services/PersonService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsWife\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$description\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Person/Services/PersonService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$givn\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
-			count: 2
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 8
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$surn\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 1
 			path: app/Modules/Person/Services/PersonService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$title\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Modules/Person/Services/PersonService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 5
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereNull\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Modules/Person/Services/PersonService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Call to static method table\(\) on an unknown class DB\.$#'
-			identifier: class.notFound
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: app/Modules/Person/Services/PersonService.php
 
@@ -4379,12 +1829,6 @@ parameters:
 			identifier: nullsafe.neverNull
 			count: 1
 			path: app/Modules/Person/Services/PersonService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Place\:\:distinct\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Places/Filament/Resources/PlaceResource.php
 
 		-
 			message: '#^Call to static method make\(\) on an unknown class App\\Modules\\Places\\Filament\\Resources\\IconColumn\.$#'
@@ -4403,12 +1847,6 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: app/Modules/Places/Filament/Resources/PlaceResource.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/Modules/Places/PlacesModule.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Place\:\:\$city\.$#'
@@ -4447,12 +1885,6 @@ parameters:
 			path: app/Modules/Places/Services/GeocodingService.php
 
 		-
-			message: '#^Call to static method warning\(\) on an unknown class Log\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/Modules/Places/Services/GeocodingService.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Place\:\:\$city\.$#'
 			identifier: property.notFound
 			count: 3
@@ -4462,12 +1894,6 @@ parameters:
 			message: '#^Access to an undefined property App\\Models\\Place\:\:\$country\.$#'
 			identifier: property.notFound
 			count: 3
-			path: app/Modules/Places/Services/PlacesService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Place\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
 			path: app/Modules/Places/Services/PlacesService.php
 
 		-
@@ -4501,42 +1927,6 @@ parameters:
 			path: app/Modules/Places/Services/PlacesService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Place\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Places/Services/PlacesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Place\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Places/Services/PlacesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Place\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Places/Services/PlacesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Place\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Places/Services/PlacesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Place\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Modules/Places/Services/PlacesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Repository\:\:pluck\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Sources/Filament/Resources/SourceResource.php
-
-		-
 			message: '#^Call to static method route\(\) on an unknown class App\\Modules\\Sources\\Filament\\Resources\\SourceResource\\Pages\\CreateSource\.$#'
 			identifier: class.notFound
 			count: 1
@@ -4555,12 +1945,6 @@ parameters:
 			path: app/Modules/Sources/Filament/Resources/SourceResource.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Repository\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Source\:\:\$author\.$#'
 			identifier: property.notFound
 			count: 5
@@ -4568,18 +1952,6 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Source\:\:\$call_number\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Source\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Source\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Sources/Services/SourcesService.php
@@ -4615,40 +1987,10 @@ parameters:
 			path: app/Modules/Sources/Services/SourcesService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Source\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Relation ''repository'' is not found in App\\Models\\Source model\.$#'
+			identifier: larastan.relationExistence
 			count: 1
 			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Source\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Source\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Source\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 6
-			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Source\:\:whereNotNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Modules/Sources/Services/SourcesService.php
-
-		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/Modules/Sources/SourcesModule.php
 
 		-
 			message: '#^Instantiated class App\\Modules\\Sources\\Services\\CitationService not found\.$#'
@@ -4663,69 +2005,51 @@ parameters:
 			path: app/Modules/Sources/SourcesModule.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Modules/Tree/Services/TreeBuilderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$childInFamily\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Modules/Tree/Services/TreeBuilderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$child_in_family_id\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Tree/Services/TreeBuilderService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Modules/Tree/Services/TreeBuilderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsHusband\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Modules/Tree/Services/TreeBuilderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$familiesAsWife\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Modules/Tree/Services/TreeBuilderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$givn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Modules/Tree/Services/TreeBuilderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 6
 			path: app/Modules/Tree/Services/TreeBuilderService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/Modules/Tree/Services/TreeBuilderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$surn\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Modules/Tree/Services/TreeBuilderService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:husband\(\)\.$#'
+			identifier: method.notFound
 			count: 5
+			path: app/Modules/Tree/Services/TreeBuilderService.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:wife\(\)\.$#'
+			identifier: method.notFound
+			count: 5
+			path: app/Modules/Tree/Services/TreeBuilderService.php
+
+		-
+			message: '#^Cannot access property \$year on string\.$#'
+			identifier: property.nonObject
+			count: 4
+			path: app/Modules/Tree/Services/TreeBuilderService.php
+
+		-
+			message: '#^Cannot call method diffInYears\(\) on string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Modules/Tree/Services/TreeBuilderService.php
+
+		-
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
+			count: 2
 			path: app/Modules/Tree/Services/TreeBuilderService.php
 
 		-
@@ -4735,76 +2059,10 @@ parameters:
 			path: app/Modules/Tree/Services/TreeBuilderService.php
 
 		-
-			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Modules/Tree/TreeModule.php
-
-		-
-			message: '#^Call to static method deleteDirectory\(\) on an unknown class File\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Modules/Tree/TreeModule.php
-
-		-
-			message: '#^Call to static method exists\(\) on an unknown class File\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Modules/Tree/TreeModule.php
-
-		-
 			message: '#^Instantiated class App\\Modules\\Tree\\Services\\TreeRenderService not found\.$#'
 			identifier: class.notFound
 			count: 1
 			path: app/Modules/Tree/TreeModule.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Notifications/AchievementUnlockedNotification.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$icon\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Notifications/AchievementUnlockedNotification.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Notifications/AchievementUnlockedNotification.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$key\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Notifications/AchievementUnlockedNotification.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Notifications/AchievementUnlockedNotification.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$points\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Notifications/AchievementUnlockedNotification.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Observers/FamilyObserver.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Observers/PersonEventObserver.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$person\.$#'
@@ -4813,68 +2071,8 @@ parameters:
 			path: app/Observers/PersonEventObserver.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\PersonEvent\:\:\$person_id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Observers/PersonEventObserver.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Observers/PersonEventObserver.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Observers/PersonObserver.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Observers/PersonObserver.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ResearchSpace\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Policies/ResearchSpacePolicy.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ResearchSpace\:\:\$owner_id\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Policies/ResearchSpacePolicy.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 6
-			path: app/Policies/ResearchSpacePolicy.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ResearchSpaceCollaborator\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 3
-			path: app/Policies/ResearchSpacePolicy.php
-
-		-
-			message: '#^Call to static method warning\(\) on an unknown class Log\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Providers/AppServiceProvider.php
-
-		-
 			message: '#^Anonymous function never returns Illuminate\\Contracts\\Routing\\UrlGenerator so it can be removed from the return type\.$#'
 			identifier: return.unusedType
-			count: 1
-			path: app/Providers/Filament/AdminPanelProvider.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: app/Providers/Filament/AdminPanelProvider.php
 
@@ -4885,64 +2083,22 @@ parameters:
 			path: app/Providers/Filament/AppPanelProvider.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Auth\\Factory\:\:user\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Providers/Filament/AppPanelProvider.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Support\\Optional\:\:\$email\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Providers/HorizonServiceProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$childInFamily\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Services/CompletenessService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/CompletenessService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Tree\:\:\$rootPerson\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Services/CompletenessService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
+			identifier: property.notFound
 			count: 1
 			path: app/Services/CompletenessService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereIn\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/CompletenessService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/CompletenessService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:whereIn\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/CompletenessService.php
-
-		-
-			message: '#^Call to an undefined static method Laravel\\Cashier\\Subscription\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/DatabaseUpdateService.php
 
 		-
 			message: '#^Offset 0 on non\-empty\-list\<string\> on left side of \?\? always exists and is not nullable\.$#'
@@ -4981,130 +2137,10 @@ parameters:
 			path: app/Services/Dna/SegmentMatcher.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$consent_given\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$current_team_id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$consent_given_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$file_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$user_id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Dna\:\:\$variable_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/DnaImportService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/DnaTriangulationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:findOrFail\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 4
-			path: app/Services/DnaTriangulationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Dna\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 1
 			path: app/Services/DnaTriangulationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DnaMatching\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/DnaTriangulationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DnaMatching\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/DnaTriangulationService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Services/DuplicateCheckerService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Services/DuplicateCheckerService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DuplicateCheckerService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$current_team_id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DuplicateCheckerService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/DuplicateCheckerService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DuplicateCheck\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/DuplicateCheckerService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereHas\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/DuplicateCheckerService.php
 
 		-
 			message: '#^Comparison operation "\>" between 0\.5\|0\.7\|0\.8\|1\.0 and 0 is always true\.$#'
@@ -5113,237 +2149,75 @@ parameters:
 			path: app/Services/DuplicateCheckerService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$email\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$givn\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$phone\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$surn\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/DuplicateDetectionService.php
-
-		-
 			message: '#^Anonymous function never returns array so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: app/Services/DuplicateDetectionService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\DuplicateMatch\:\:firstOrNew\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:select\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^Comparison operation "\>" between \*NEVER\* and float results in an error\.$#'
-			identifier: greater.invalid
-			count: 1
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^If condition is always false\.$#'
-			identifier: if.alwaysFalse
-			count: 1
-			path: app/Services/DuplicateDetectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\FaceEncoding\:\:\$encoding\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$file_path\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Services/FacialRecognitionService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\FaceEncoding\:\:\$person\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Services/FacialRecognitionService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\FaceEncoding\:\:\$person_id\.$#'
-			identifier: property.notFound
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:fullname\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: app/Services/FacialRecognitionService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\PersonPhoto\:\:\$file_path\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$husband\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Services/FacialRecognitionService.php
+			path: app/Services/FindMyPastMatchingProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\PersonPhoto\:\:\$id\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$wife\.$#'
 			identifier: property.notFound
+			count: 1
+			path: app/Services/FindMyPastMatchingProvider.php
+
+		-
+			message: '#^Cannot access property \$year on string\.$#'
+			identifier: property.nonObject
+			count: 14
+			path: app/Services/FindMyPastMatchingProvider.php
+
+		-
+			message: '#^Cannot call method addDays\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 3
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PersonPhoto\:\:\$team_id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PhotoTag\:\:\$bounding_box\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PhotoTag\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PhotoTag\:\:\$person_id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PhotoTag\:\:\$photo\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PhotoTag\:\:\$status\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\PhotoTag\:\:\$team_id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\FaceEncoding\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PhotoTag\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Method App\\Services\\FacialRecognitionService\:\:getPendingTags\(\) should return Illuminate\\Database\\Eloquent\\Collection but returns Illuminate\\Support\\Collection\<int, stdClass\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Services/FacialRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$cached_profile_data\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$provider\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ConnectedAccount\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ConnectedAccount\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:whereHas\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\SocialConnectionPrivacy\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\SocialFamilyConnection\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\SocialFamilyConnection\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/FamilyMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 8
 			path: app/Services/FindMyPastMatchingProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$childInFamily\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/FindMyPastMatchingProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 8
-			path: app/Services/FindMyPastMatchingProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
+			message: '#^Cannot call method addMonths\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 1
+			path: app/Services/FindMyPastMatchingProvider.php
+
+		-
+			message: '#^Cannot call method diffInYears\(\) on string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Services/FindMyPastMatchingProvider.php
+
+		-
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: app/Services/FindMyPastMatchingProvider.php
+
+		-
+			message: '#^Using nullsafe method call on non\-nullable type string\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 6
 			path: app/Services/FindMyPastMatchingProvider.php
 
 		-
@@ -5353,202 +2227,22 @@ parameters:
 			path: app/Services/FindMyPastMatchingProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$key\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 3
 			path: app/Services/GamificationService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Achievement\:\:\$points\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 8
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$latestTeam\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$level\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$total_points\.$#'
-			identifier: property.notFound
-			count: 7
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:incomplete\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany\:\:incomplete\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: app/Services/GamificationService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Achievement\:\:active\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Relation ''person'' is not found in App\\Models\\PersonEvent model\.$#'
+			identifier: larastan.relationExistence
 			count: 1
 			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonEvent\:\:whereHas\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\User\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserAchievement\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserPoint\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserPoint\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserProgress\:\:updateOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\UserProgress\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to protected method increment\(\) of class Illuminate\\Database\\Eloquent\\Model\.$#'
-			identifier: method.protected
-			count: 1
-			path: app/Services/GamificationService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\ImportJob\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/GedcomService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\DocumentTranscription\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\TranscriptionCorrection\:\:\$corrected_text\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\TranscriptionCorrection\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\TranscriptionCorrection\:\:\$original_text\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DocumentTranscription\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\DocumentTranscription\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\TranscriptionCorrection\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\TranscriptionCorrection\:\:whereHas\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/HandwritingRecognitionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/HistoricalEventService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/HistoricalEventService.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\HistoricalEvent\>\:\:betweenDates\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Services/HistoricalEventService.php
 
 		-
 			message: '#^If condition is always false\.$#'
@@ -5569,295 +2263,49 @@ parameters:
 			path: app/Services/HistoricalEventService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\Menu\:\:whereNull\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/MenuService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$appellative\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Services/PersonMergeService.php
+			path: app/Services/PersonSearchService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
+			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Services/PersonMergeService.php
+			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$burial_day\.$#'
+			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathplace\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Services/PersonMergeService.php
+			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$child_in_family_id\.$#'
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Services/PersonMergeService.php
+			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
+			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathplace\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Services/PersonMergeService.php
+			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$email\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$gid\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$givn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 4
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$phone\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$surn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$titl\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$tree_position_x\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$tree_position_y\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Family\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonAlia\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\PersonAsso\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/PersonMergeService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$givn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$surn\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Contracts\\Auth\\Authenticatable\:\:\$currentTeam\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Query\\Builder\:\:deceased\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:withoutGlobalScope\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Team\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Method App\\Services\\PersonSearchService\:\:searchEvents\(\) should return Illuminate\\Database\\Eloquent\\Collection but returns Illuminate\\Support\\Collection\<int, stdClass\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Method App\\Services\\PersonSearchService\:\:searchPlaces\(\) should return Illuminate\\Database\\Eloquent\\Collection but returns Illuminate\\Support\\Collection\<int, stdClass\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Method App\\Services\\PersonSearchService\:\:searchSources\(\) should return Illuminate\\Database\\Eloquent\\Collection but returns Illuminate\\Support\\Collection\<int, stdClass\>\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Services/PersonSearchService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$first_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$last_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/ExampleProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 1
 			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$first_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$last_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
@@ -5869,64 +2317,10 @@ parameters:
 			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$first_name\.$#'
-			identifier: property.notFound
-			count: 1
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
+			count: 4
 			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$last_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\AISuggestedMatch\:\:\$candidate_data\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/RecordMatcherService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\AISuggestedMatch\:\:\$local_person_id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/RecordMatcherService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\AIMatchModel\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/RecordMatcher/RecordMatcherService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\AIMatchModel\:\:orderBy\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/RecordMatcher/RecordMatcherService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\AISuggestedMatch\:\:updateOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/RecordMatcher/RecordMatcherService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:find\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: app/Services/RecordMatcher/RecordMatcherService.php
 
 		-
 			message: '#^Using nullsafe property access "\?\-\>weights" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
@@ -5935,57 +2329,9 @@ parameters:
 			path: app/Services/RecordMatcher/RecordMatcherService.php
 
 		-
-			message: '#^Call to an undefined static method App\\Models\\SiteSettings\:\:first\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/SiteSettingsService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthday\.$#'
-			identifier: property.notFound
+			message: '#^Cannot call method format\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 4
-			path: app/Services/SmartMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathday\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Services/SmartMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SmartMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$sex\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SmartMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$current_team_id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SmartMatchingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SmartMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\Person\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/SmartMatchingService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\SmartMatch\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
 			path: app/Services/SmartMatchingService.php
 
 		-
@@ -5995,70 +2341,10 @@ parameters:
 			path: app/Services/SmartMatchingService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$email\.$#'
-			identifier: property.notFound
+			message: '#^Cannot call method diffInHours\(\) on string\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$enable_family_matching\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$last_synced_at\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$nickname\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$provider\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\ConnectedAccount\:\:\$provider_id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Call to an undefined static method App\\Models\\SocialConnectionPrivacy\:\:firstOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Services/SocialMediaConnectionService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$dna_uploads_count\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/SubscriptionService.php
 
 		-
 			message: '#^Call to an undefined method Laravel\\Cashier\\Subscription\:\:cancelled\(\)\.$#'
@@ -6067,91 +2353,7 @@ parameters:
 			path: app/Services/SubscriptionService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$creator\.$#'
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$email\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$description\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$end_time\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 10
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$join_url\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$max_attendees\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$meeting_id\.$#'
-			identifier: property.notFound
-			count: 12
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$meeting_url\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$platform\.$#'
-			identifier: property.notFound
-			count: 18
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$start_time\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$timezone\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\VirtualEvent\:\:\$title\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Query\\Builder\:\:with\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Services/VideoConferencingService.php
-
-		-
-			message: '#^Method App\\View\\Components\\AppLayout\:\:render\(\) should return Illuminate\\View\\View but returns Illuminate\\Contracts\\View\\View\.$#'
-			identifier: return.type
-			count: 1
-			path: app/View/Components/AppLayout.php
-
-		-
-			message: '#^Method App\\View\\Components\\GuestLayout\:\:render\(\) should return Illuminate\\View\\View but returns Illuminate\\Contracts\\View\\View\.$#'
-			identifier: return.type
-			count: 1
-			path: app/View/Components/GuestLayout.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - vendor/larastan/larastan/extension.neon
     - phpstan-baseline.neon
 
 parameters:
@@ -8,9 +9,15 @@ parameters:
     excludePaths:
         analyse:
             - app/Modules/*/vendor/*
-    # No larastan: it isn't a committed dependency, so the gate runs plain
-    # PHPStan (already available transitively). The codebase carries pre-existing
-    # drift + Laravel magic PHPStan can't see without larastan; the baseline
-    # captures all of it so the gate is green today and fails only on NEW issues
-    # (undefined symbols, obvious type errors). Ratchet: add larastan + shrink
-    # the baseline / raise the level over time.
+    # larastan teaches PHPStan about Eloquent: without it, every Model::where(),
+    # ->find() and $model->column read as an undefined symbol, which drowned real
+    # findings ~60% noise (1568 -> 624). It also adds checks plain PHPStan cannot
+    # do at all — notably relationExistence, which resolves relation names inside
+    # with()/whereHas(). Eloquent only resolves those at query time, so a dead
+    # relation name is invisible until it throws in production; that check alone
+    # found three live fatals here.
+    #
+    # The baseline still covers pre-existing drift. It is a debt ledger, not a
+    # verdict: it once swallowed a genuine "class not found" that PHPStan had
+    # correctly reported. Shrink it rather than grow it, and prefer fixing a
+    # finding to re-baselining it. Ratchet: raise the level once it is thinner.

--- a/tests/Feature/Services/DeadRelationRegressionTest.php
+++ b/tests/Feature/Services/DeadRelationRegressionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\Person;
+use App\Models\User;
+use App\Services\DuplicateCheckerService;
+use App\Services\FamilyMatchingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * Both services eager-loaded relations that do not exist on Person — there is no
+ * `user` relation (people are owned by a team, not a user, and there is no
+ * user_id column) and no `gedcom` relation. Eloquent only resolves a relation
+ * name at query time, so both threw "Call to undefined method" on every call:
+ * the duplicate-check action fataled, and social family matching silently
+ * matched nobody. Neither service had a test.
+ *
+ * larastan's relationExistence check is what surfaced these; plain PHPStan
+ * cannot see relation names at all.
+ */
+class DeadRelationRegressionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_duplicate_check_runs_for_a_users_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $teamId = $user->current_team_id;
+
+        Person::factory()->create(['givn' => 'John', 'surn' => 'Doe', 'team_id' => $teamId]);
+        Person::factory()->create(['givn' => 'John', 'surn' => 'Doe', 'team_id' => $teamId]);
+
+        $check = (new DuplicateCheckerService)->runDuplicateCheck($user);
+
+        $this->assertSame('completed', $check->status);
+    }
+
+    public function test_duplicate_check_only_sees_its_own_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $other = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Person::factory()->create(['givn' => 'Ada', 'surn' => 'Byron', 'team_id' => $other->current_team_id]);
+
+        $check = (new DuplicateCheckerService)->runDuplicateCheck($user);
+
+        $this->assertSame('completed', $check->status);
+        $this->assertSame(0, $check->duplicates_found);
+    }
+
+    public function test_family_matching_reads_surnames_from_the_users_teams(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Person::factory()->create(['surn' => 'Lovelace', 'team_id' => $user->current_team_id]);
+        Person::factory()->create(['surn' => 'Babbage', 'team_id' => $user->current_team_id]);
+
+        // Protected, and its public callers reach out to social providers.
+        $method = new ReflectionMethod(FamilyMatchingService::class, 'getUserFamilySurnames');
+        $method->setAccessible(true);
+
+        $surnames = $method->invoke(new FamilyMatchingService, $user);
+
+        sort($surnames);
+        $this->assertSame(['Babbage', 'Lovelace'], $surnames);
+    }
+
+    public function test_family_matching_excludes_other_teams_surnames(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $other = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Person::factory()->create(['surn' => 'Mine', 'team_id' => $user->current_team_id]);
+        Person::factory()->create(['surn' => 'Theirs', 'team_id' => $other->current_team_id]);
+
+        $method = new ReflectionMethod(FamilyMatchingService::class, 'getUserFamilySurnames');
+        $method->setAccessible(true);
+
+        $this->assertSame(['Mine'], $method->invoke(new FamilyMatchingService, $user));
+    }
+
+    /**
+     * with('parents') threw on every render: parents() returns a Collection built
+     * from childInFamily->husband/wife, so it is not eager-loadable.
+     */
+    public function test_pedigree_chart_widget_eager_load_does_not_throw(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Person::factory()->create();
+
+        $people = Person::with(['childInFamily.husband', 'childInFamily.wife'])->get();
+
+        $this->assertCount(1, $people);
+    }
+}


### PR DESCRIPTION
The larastan ratchet flagged in #1514, plus the real bugs it immediately found.

## Why

The gate ran **plain PHPStan with no larastan**, so it couldn't see Eloquent — every `Model::where()`, `->find()` and `$model->column` read as an undefined symbol. That was ~60% of all findings, and the baseline built to absorb the noise swallowed real errors with it.

Concretely: the baseline had captured a genuine `Class ... PhotosRelationManager not found`. PHPStan reported it **correctly**; the baseline buried it; it shipped as a fatal person edit page (fixed in #1516). A gate that can't tell noise from a bug teaches you to ignore it.

| | findings |
|---|---|
| plain PHPStan | 1568 |
| with larastan | 624 |
| after fixing what it found | **615** |

## The three live fatals

larastan adds checks plain PHPStan **cannot do at all** — notably `relationExistence`, which resolves relation names inside `with()`/`whereHas()`. Eloquent only resolves those at query time, so a dead relation name is invisible until it throws at a user. Each verified against the running app:

**1. `DuplicateCheckerService`** — `Person::whereHas('user', ...)`. People are owned by a *team*, not a user; there is no `user_id` column. The service catches `Exception`, and `BadMethodCallException` is one — so the fatal was **swallowed** and every duplicate check quietly recorded `status = failed` instead of crashing. Reachable from the `DuplicateCheckResource` action.

**2. `FamilyMatchingService`** — `Person::whereHas('gedcom', ...)`, plus `whereNotNull('surname')` — also not a column (it's `surn`). Social family matching **matched nobody, ever**. Reachable from the `SocialConnections` Livewire component.

**3. `PedigreeChartWidget`** — `Person::with('parents')`. `parents()` returns a Collection built from `childInFamily->husband/wife`, so it isn't eager-loadable: `Collection::addEagerConstraints does not exist` on every render. The `with()` was trying to fix an N+1 and instead guaranteed a crash; now eager-loads what it actually walks.

## Sorting real from noise

`relationExistence` flagged 35. Most were **false positives** — `childInFamily`, `familiesAsHusband`, `events` all work fine at runtime. The cause: a relation method with no declared return type is invisible to larastan. Adding the return type **and its import** (the import matters — without it `: BelongsTo` resolves to `App\Models\BelongsTo`) fixed them: 35 → 18. I probed every remaining one against the live app rather than trusting the report; that's what separated the 3 real bugs from the 5 false positives.

## Deliberately not fixed

- **Vendor-inherited relations** (`PersonEvent::place`, `Family::children`, …) — overriding a vendor method to satisfy a linter isn't a fix. Baselined.
- **`app/Modules/Sources/Services/SourcesService`** — written against a schema that never existed (`title`, `author`, `publisher`, `url`, `call_number` are not columns) and has **zero callers**. Repairing it is a rewrite, not a lint fix. Baselined.
- The remaining 615 (mostly `property.notFound` needing `@property-read` docblocks) stay baselined. The ratchet from here: shrink the baseline, then raise the level.

## Notes on the dependency change

`composer.lock` is deliberately **minimal**: `2 installs, 0 updates, 0 removals` — larastan and its one dep. I computed it from `origin/main`'s lock in an isolated checkout rather than from my working tree, because the working tree's lock carries an unrelated in-flight update (80+ version changes, 11 packages removed, `laravel/fortify` **downgraded**) that has nothing to do with this PR.

Verified: `composer validate --check-lock` passes, and `composer install --dry-run` from the committed lock resolves `larastan/larastan (v3.10.0)`.

## Verification

- **560 passed / 0 failed** (was 555).
- **Mutation-tested**: restoring the original dead relations fails 4 of the 5 new regression tests.
- PHPStan green at **CI's 1G limit** (not just my local 2G), from a cleared result cache.