### PR TITLE
fix(matching): record providers never sent birth/death place (silent)

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 class Conversation extends Model
 {
@@ -31,8 +32,15 @@ class Conversation extends Model
         return $this->belongsTo(User::class, 'user_two');
     }
 
-    public function users()
+    /**
+     * Both participants. userOne/userTwo are belongsTo, so they resolve to single
+     * User models — merge() is a Collection method and User has none, so this threw
+     * BadMethodCallException for anyone who called it. Nothing did yet.
+     *
+     * @return Collection<int, User>
+     */
+    public function users(): Collection
     {
-        return $this->userOne->merge($this->userTwo());
+        return collect([$this->userOne, $this->userTwo])->filter()->values();
     }
 }

--- a/app/Services/RecordMatcher/Providers/AncestryProvider.php
+++ b/app/Services/RecordMatcher/Providers/AncestryProvider.php
@@ -21,9 +21,14 @@ class AncestryProvider implements ExternalRecordProviderInterface
 
     public function __construct()
     {
-        $this->apiKey = config('services.ancestry.api_key', '');
-        $this->baseUrl = config('services.ancestry.base_url', 'https://api.ancestry.com/v1');
-        $this->timeout = config('services.ancestry.timeout', 30);
+        // config(key, default) only falls back when the key is ABSENT. These keys
+        // are declared in config/services.php as env(...) with no default, so an
+        // unset variable makes the key present-but-null, the default never fires,
+        // and null hits a typed string property — the provider cannot even be
+        // constructed. Cast instead of defaulting.
+        $this->apiKey = (string) config('services.ancestry.api_key');
+        $this->baseUrl = (string) (config('services.ancestry.base_url') ?: 'https://api.ancestry.com/v1');
+        $this->timeout = (int) (config('services.ancestry.timeout') ?: 30);
     }
 
     /**
@@ -81,8 +86,12 @@ class AncestryProvider implements ExternalRecordProviderInterface
             $params['birthYear'] = $person->birthday->format('Y');
         }
 
-        if ($person->birthplace) {
-            $params['birthLocation'] = $person->birthplace->place ?? null;
+        // GEDCOM names these birthday_plac/deathday_plac, and they are plain
+        // varchars. There are no birthplace/deathplace columns or relations, so
+        // these guards were always false and the location was never sent — every
+        // provider search ran without a place, silently returning weaker matches.
+        if ($person->birthday_plac) {
+            $params['birthLocation'] = $person->birthday_plac;
         }
 
         // Death information
@@ -90,8 +99,8 @@ class AncestryProvider implements ExternalRecordProviderInterface
             $params['deathYear'] = $person->deathday->format('Y');
         }
 
-        if ($person->deathplace) {
-            $params['deathLocation'] = $person->deathplace->place ?? null;
+        if ($person->deathday_plac) {
+            $params['deathLocation'] = $person->deathday_plac;
         }
 
         // Gender

--- a/app/Services/RecordMatcher/Providers/FamilySearchProvider.php
+++ b/app/Services/RecordMatcher/Providers/FamilySearchProvider.php
@@ -21,9 +21,14 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
 
     public function __construct()
     {
-        $this->apiKey = config('services.familysearch.api_key', '');
-        $this->baseUrl = config('services.familysearch.base_url', 'https://api.familysearch.org/platform');
-        $this->timeout = config('services.familysearch.timeout', 30);
+        // config(key, default) only falls back when the key is ABSENT. These keys
+        // are declared in config/services.php as env(...) with no default, so an
+        // unset variable makes the key present-but-null, the default never fires,
+        // and null hits a typed string property — the provider cannot even be
+        // constructed. Cast instead of defaulting.
+        $this->apiKey = (string) config('services.familysearch.api_key');
+        $this->baseUrl = (string) (config('services.familysearch.base_url') ?: 'https://api.familysearch.org/platform');
+        $this->timeout = (int) (config('services.familysearch.timeout') ?: 30);
     }
 
     /**
@@ -82,8 +87,11 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
             $params['birthDate'] = $person->birthday->format('Y-m-d');
         }
 
-        if ($person->birthplace) {
-            $params['birthPlace'] = $person->birthplace->place ?? null;
+        // See AncestryProvider: the columns are birthday_plac/deathday_plac
+        // (GEDCOM), plain varchars. birthplace/deathplace never existed, so this
+        // guard was always false and the place was never sent.
+        if ($person->birthday_plac) {
+            $params['birthPlace'] = $person->birthday_plac;
         }
 
         // Death information
@@ -92,8 +100,8 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
             $params['deathDate'] = $person->deathday->format('Y-m-d');
         }
 
-        if ($person->deathplace) {
-            $params['deathPlace'] = $person->deathplace->place ?? null;
+        if ($person->deathday_plac) {
+            $params['deathPlace'] = $person->deathday_plac;
         }
 
         // Gender

--- a/app/Services/RecordMatcher/Providers/MyHeritageProvider.php
+++ b/app/Services/RecordMatcher/Providers/MyHeritageProvider.php
@@ -21,9 +21,14 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
 
     public function __construct()
     {
-        $this->apiKey = config('services.myheritage.api_key', '');
-        $this->baseUrl = config('services.myheritage.base_url', 'https://api.myheritage.com/v1');
-        $this->timeout = config('services.myheritage.timeout', 30);
+        // config(key, default) only falls back when the key is ABSENT. These keys
+        // are declared in config/services.php as env(...) with no default, so an
+        // unset variable makes the key present-but-null, the default never fires,
+        // and null hits a typed string property — the provider cannot even be
+        // constructed. Cast instead of defaulting.
+        $this->apiKey = (string) config('services.myheritage.api_key');
+        $this->baseUrl = (string) (config('services.myheritage.base_url') ?: 'https://api.myheritage.com/v1');
+        $this->timeout = (int) (config('services.myheritage.timeout') ?: 30);
     }
 
     /**
@@ -82,8 +87,11 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
             $params['birth_date'] = $person->birthday->format('Y-m-d');
         }
 
-        if ($person->birthplace) {
-            $params['birth_place'] = $person->birthplace->place ?? null;
+        // See AncestryProvider: the columns are birthday_plac/deathday_plac
+        // (GEDCOM), plain varchars. birthplace/deathplace never existed, so this
+        // guard was always false and the place was never sent.
+        if ($person->birthday_plac) {
+            $params['birth_place'] = $person->birthday_plac;
         }
 
         // Death information
@@ -92,8 +100,8 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
             $params['death_date'] = $person->deathday->format('Y-m-d');
         }
 
-        if ($person->deathplace) {
-            $params['death_place'] = $person->deathplace->place ?? null;
+        if ($person->deathday_plac) {
+            $params['death_place'] = $person->deathday_plac;
         }
 
         // Gender

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -739,6 +739,12 @@ parameters:
 			path: app/Models/Conversation.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\Conversation\:\:\$userTwo\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/Conversation.php
+
+		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
@@ -1927,52 +1933,16 @@ parameters:
 			path: app/Services/PersonSearchService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
-
-		-
 			message: '#^Cannot call method format\(\) on string\.$#'
 			identifier: method.nonObject
 			count: 2
 			path: app/Services/RecordMatcher/Providers/AncestryProvider.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
 			message: '#^Cannot call method format\(\) on string\.$#'
 			identifier: method.nonObject
 			count: 4
 			path: app/Services/RecordMatcher/Providers/FamilySearchProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$birthplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Person\:\:\$deathplace\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/RecordMatcher/Providers/MyHeritageProvider.php
 
 		-
 			message: '#^Cannot call method format\(\) on string\.$#'

--- a/tests/Feature/Models/ConversationUsersTest.php
+++ b/tests/Feature/Models/ConversationUsersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Conversation::users() called $this->userOne->merge(...). userOne is a belongsTo,
+ * so it resolves to a single User, and merge() is a Collection method — the call
+ * threw BadMethodCallException for anyone who reached it. Nothing did.
+ */
+class ConversationUsersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_users_returns_both_participants(): void
+    {
+        $one = User::factory()->create();
+        $two = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_one' => $one->id,
+            'user_two' => $two->id,
+            'status' => 1,
+        ]);
+
+        $users = $conversation->users();
+
+        $this->assertCount(2, $users);
+        $this->assertEqualsCanonicalizing(
+            [$one->id, $two->id],
+            $users->pluck('id')->all()
+        );
+    }
+}

--- a/tests/Feature/Services/RecordMatcherPlaceParamsTest.php
+++ b/tests/Feature/Services/RecordMatcherPlaceParamsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\Person;
+use App\Models\User;
+use App\Services\RecordMatcher\Providers\AncestryProvider;
+use App\Services\RecordMatcher\Providers\FamilySearchProvider;
+use App\Services\RecordMatcher\Providers\MyHeritageProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * Every provider guarded its place parameter on $person->birthplace /
+ * ->deathplace. Neither is a column or a relation — the GEDCOM names are
+ * birthday_plac / deathday_plac — and Eloquent returns null for an unknown
+ * attribute rather than throwing, so the guards were silently always false and
+ * no provider search ever sent a birth or death place. Nothing failed; matches
+ * were just quietly worse.
+ *
+ * buildSearchParams() is protected and its public caller performs a real HTTP
+ * search, so these drive it by reflection.
+ *
+ * @return array<string, array{0: class-string, 1: string, 2: string}>
+ */
+class RecordMatcherPlaceParamsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public static function providerCases(): array
+    {
+        return [
+            'ancestry' => [AncestryProvider::class, 'birthLocation', 'deathLocation'],
+            'familysearch' => [FamilySearchProvider::class, 'birthPlace', 'deathPlace'],
+            'myheritage' => [MyHeritageProvider::class, 'birth_place', 'death_place'],
+        ];
+    }
+
+    #[DataProvider('providerCases')]
+    public function test_provider_sends_the_persons_birth_and_death_place(
+        string $providerClass,
+        string $birthKey,
+        string $deathKey
+    ): void {
+        $this->actingAs(User::factory()->withPersonalTeam()->create());
+
+        $person = Person::factory()->create([
+            'givn' => 'Ada',
+            'surn' => 'Lovelace',
+            'birthday_plac' => 'Manchester, England',
+            'deathday_plac' => 'Leeds, England',
+        ]);
+
+        $method = new ReflectionMethod($providerClass, 'buildSearchParams');
+        $method->setAccessible(true);
+
+        $params = $method->invoke(new $providerClass, $person);
+
+        $this->assertSame('Manchester, England', $params[$birthKey] ?? null);
+        $this->assertSame('Leeds, England', $params[$deathKey] ?? null);
+    }
+
+    #[DataProvider('providerCases')]
+    public function test_provider_omits_place_when_the_person_has_none(
+        string $providerClass,
+        string $birthKey,
+        string $deathKey
+    ): void {
+        $this->actingAs(User::factory()->withPersonalTeam()->create());
+
+        $person = Person::factory()->create([
+            'givn' => 'Ada',
+            'surn' => 'Lovelace',
+            'birthday_plac' => null,
+            'deathday_plac' => null,
+        ]);
+
+        $method = new ReflectionMethod($providerClass, 'buildSearchParams');
+        $method->setAccessible(true);
+
+        $params = $method->invoke(new $providerClass, $person);
+
+        $this->assertArrayNotHasKey($birthKey, $params);
+        $this->assertArrayNotHasKey($deathKey, $params);
+    }
+}


### PR DESCRIPTION
Round 2 of draining what larastan surfaces (after #1517, #1518). Baseline **511 → 506**.

Small diff, but the bug it fixes is the kind that never shows up in an error log.

## Record matching ran without any place

All three providers guarded their place parameter on `$person->birthplace` / `->deathplace`. **Neither is a column or a relation** — GEDCOM names them `birthday_plac` / `deathday_plac`, plain varchars on `people`.

Eloquent returns `null` for an unknown attribute rather than throwing, so:

```php
if ($person->birthplace) {                              // always false
    $params['birthLocation'] = $person->birthplace->place ?? null;
}
```

Every Ancestry / FamilySearch / MyHeritage search ran **without a birth or death place**. Nothing errored; matches were just quietly worse. `RunRecordMatchingJob` and `SmartMatchResource` both use this. The code also chained `->place` off the result, expecting an object — the columns are strings.

Proven at runtime before touching anything:
```
person->birthday_plac = 'Manchester, England'
person->birthplace    = NULL          <-- what the guard actually read
```

## The providers couldn't be constructed without credentials

```
TypeError: Cannot assign null to property AncestryProvider::$apiKey of type string
```

`config($key, $default)` only falls back when the key is **absent**. `config/services.php` declares these as `env(...)` with no default, so an unset variable leaves the key *present-but-null*, the default never fires, and `null` hits a typed `string`. Same shape as the `GoogleMeetService` bug fixed earlier in this series. `timeout` also arrives from env as a string.

## `Conversation::users()`

`$this->userOne->merge(...)` — `userOne` is a `belongsTo`, so it's a single `User`, and `merge()` is a Collection method. Threw `BadMethodCallException` for any caller; there were none yet. Two-line fix, since the first caller would have hit a fatal.

## What I deliberately left baselined

This sweep's `property.notFound` findings looked alarming (`Place` reads city/country/latitude/longitude/name; `Source` reads author/publisher/url/title; `Note` reads content/title — **none of which are columns**). But triage against the live schema split them cleanly:

- **False positives** — `auth()->user()` typed as `Authenticatable` (156 of them), plus `selectRaw` aliases and dynamically-assigned attributes in `ResearchProgressWidget`. Not bugs.
- **`app/Modules/*` (66)** — the bespoke module framework, written against schemas that never existed, with **no callers**. `PlacesService` reads `places.latitude`; the table is `id, title, description, date, team_id`. Rewriting those is a feature project, not a lint fix.

Only the record providers and `Conversation` were live. I verified each against the running app rather than trusting the report — that's what separated ~15 real findings from ~490 that aren't.

## Verification

- **584 passed / 0 failed** (was 577); gate green at CI's 1G limit.
- Mutation-tested: restoring `$person->birthplace` fails with `Failed asserting that null is identical to 'Manchester, England'` — the silent bug, made loud.
- Tests drive `buildSearchParams()` for all three providers via a data provider, and assert the place is both **sent when present** and **omitted when absent**.