### PR TITLE
fix(faces): facial recognition fabricated photo tags by default

### DIFF
--- a/app/Services/FacialRecognitionService.php
+++ b/app/Services/FacialRecognitionService.php
@@ -13,28 +13,41 @@ use Illuminate\Support\Facades\Storage;
 
 class FacialRecognitionService
 {
-    protected FacialRecognitionProviderInterface $provider;
+    protected ?FacialRecognitionProviderInterface $provider;
 
     public function __construct()
     {
-        // Default to mock provider for development
-        // Can be configured to use AWS Rekognition or other providers via config
         $this->provider = $this->getProvider();
     }
 
     /**
-     * Get the configured facial recognition provider
+     * The configured provider, or null when none is available.
+     *
+     * MockProvider does not detect anything: it invents 1-3 faces at random bounding
+     * boxes, assigns a person on a 60% coin flip with a 70-95% "confidence", and
+     * returns random_bytes() as the face encoding. It was both the default and the
+     * only implementation — aws/azure below have never existed — so every install
+     * wrote fabricated PhotoTag and FaceEncoding rows and presented them for review
+     * as detections. It is now opt-in, and anything else yields no provider at all
+     * rather than silently falling back to it.
      */
-    protected function getProvider(): FacialRecognitionProviderInterface
+    protected function getProvider(): ?FacialRecognitionProviderInterface
     {
-        $provider = config('services.facial_recognition.provider', 'mock');
-
-        return match ($provider) {
+        return match (config('services.facial_recognition.provider', 'none')) {
             'mock' => new MockProvider,
             // 'aws' => new AwsRekognitionProvider(),
             // 'azure' => new AzureFaceApiProvider(),
-            default => new MockProvider,
+            default => null,
         };
+    }
+
+    /**
+     * Whether face detection can run at all. isAvailable() was declared on the
+     * provider interface but never called by anything — this is the gate it was for.
+     */
+    public function isAvailable(): bool
+    {
+        return $this->provider?->isAvailable() ?? false;
     }
 
     /**
@@ -44,6 +57,17 @@ class FacialRecognitionService
      */
     public function analyzePhoto(PersonPhoto $photo): array
     {
+        if (! $this->isAvailable()) {
+            Log::warning('No facial recognition provider configured; photo not analysed', [
+                'photo_id' => $photo->id,
+            ]);
+
+            return [
+                'success' => false,
+                'error' => 'Facial recognition is not configured.',
+            ];
+        }
+
         try {
             $imagePath = Storage::disk('public')->path($photo->file_path);
 
@@ -174,6 +198,18 @@ class FacialRecognitionService
     public function createFaceEncoding(PhotoTag $tag): ?FaceEncoding
     {
         if (! $tag->person_id || $tag->status !== 'confirmed') {
+            return null;
+        }
+
+        // Without a provider there is nothing to encode. MockProvider returned
+        // base64_encode(random_bytes(128)) here, so confirming a tag stored random
+        // noise as that person's face signature — which any later real matching
+        // would then compare against.
+        if (! $this->isAvailable()) {
+            Log::warning('No facial recognition provider configured; no encoding created', [
+                'tag_id' => $tag->id,
+            ]);
+
             return null;
         }
 

--- a/config/services.php
+++ b/config/services.php
@@ -38,7 +38,12 @@ return [
     ],
 
     'facial_recognition' => [
-        'provider' => env('FACIAL_RECOGNITION_PROVIDER', 'mock'),
+        // Defaults to 'none': MockProvider invents faces and person matches, and it
+        // is the only provider that exists (aws/azure are commented out in
+        // FacialRecognitionService). Defaulting to 'mock' meant every install
+        // fabricated photo tags. Set FACIAL_RECOGNITION_PROVIDER=mock explicitly if
+        // you want simulated output for a demo.
+        'provider' => env('FACIAL_RECOGNITION_PROVIDER', 'none'),
         'aws' => [
             'key' => env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SECRET_ACCESS_KEY'),

--- a/tests/Feature/PhotoTaggingWorkflowTest.php
+++ b/tests/Feature/PhotoTaggingWorkflowTest.php
@@ -28,6 +28,11 @@ class PhotoTaggingWorkflowTest extends TestCase
     {
         parent::setUp();
 
+        // The workflow needs a provider to detect faces at all. MockProvider is the
+        // only one and is no longer the default (it fabricates detections), so opt in
+        // explicitly rather than lean on a default that must not exist.
+        config(['services.facial_recognition.provider' => 'mock']);
+
         $this->user = User::factory()->create();
         $this->team = Team::factory()->create();
         $this->team->users()->attach($this->user, ['role' => 'admin']);

--- a/tests/Feature/Services/FacialRecognitionGateTest.php
+++ b/tests/Feature/Services/FacialRecognitionGateTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\Person;
+use App\Models\PersonPhoto;
+use App\Models\PhotoTag;
+use App\Models\User;
+use App\Services\FacialRecognitionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * Facial recognition defaulted to MockProvider, which is the only implementation
+ * that exists (aws/azure are commented out). It invents 1-3 faces at random
+ * bounding boxes, assigns a person on a 60% coin flip with a 70-95%
+ * "confidence", and returns random_bytes() as the face encoding — and those were
+ * persisted as PhotoTag and FaceEncoding rows and shown for review as
+ * detections. The provider interface declared isAvailable() but nothing ever
+ * called it; it is now the gate, and the config defaults to 'none'.
+ */
+class FacialRecognitionGateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function photo(User $user): PersonPhoto
+    {
+        Storage::fake('public');
+
+        $person = Person::factory()->create(['team_id' => $user->current_team_id]);
+        $path = UploadedFile::fake()->image('face.jpg')->store('photos', 'public');
+
+        return PersonPhoto::factory()->create([
+            'person_id' => $person->id,
+            'team_id' => $user->current_team_id,
+            'file_path' => $path,
+        ]);
+    }
+
+    public function test_the_default_config_has_no_provider(): void
+    {
+        // The env var is unset in tests, so this is what a fresh install gets.
+        $this->assertSame('none', config('services.facial_recognition.provider'));
+        $this->assertFalse((new FacialRecognitionService)->isAvailable());
+    }
+
+    public function test_analyze_photo_creates_no_tags_without_a_provider(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $photo = $this->photo($user);
+
+        $result = (new FacialRecognitionService)->analyzePhoto($photo);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('Facial recognition is not configured.', $result['error']);
+        $this->assertDatabaseCount('photo_tags', 0);
+    }
+
+    public function test_no_face_encoding_is_stored_without_a_provider(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $photo = $this->photo($user);
+
+        $tag = PhotoTag::factory()->create([
+            'photo_id' => $photo->id,
+            'person_id' => $photo->person_id,
+            'team_id' => $user->current_team_id,
+            'status' => 'confirmed',
+            'bounding_box' => ['left' => 0.1, 'top' => 0.1, 'width' => 0.2, 'height' => 0.2],
+        ]);
+
+        // MockProvider returned base64_encode(random_bytes(128)) here, so a confirmed
+        // tag stored random noise as that person's face signature.
+        $this->assertNull((new FacialRecognitionService)->createFaceEncoding($tag));
+        $this->assertDatabaseCount('face_encodings', 0);
+    }
+
+    public function test_the_mock_provider_still_works_when_explicitly_opted_in(): void
+    {
+        config(['services.facial_recognition.provider' => 'mock']);
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $photo = $this->photo($user);
+
+        $service = new FacialRecognitionService;
+
+        $this->assertTrue($service->isAvailable());
+
+        // Opting in is deliberate, so it behaves exactly as before — including
+        // fabricating tags. That is the point of it being opt-in.
+        $result = $service->analyzePhoto($photo);
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_an_unknown_provider_name_yields_no_provider_rather_than_the_mock(): void
+    {
+        // The old match had `default => new MockProvider`, so a typo in the env var
+        // silently fabricated data instead of failing closed.
+        config(['services.facial_recognition.provider' => 'aws']);
+
+        $this->assertFalse((new FacialRecognitionService)->isAvailable());
+    }
+}

--- a/tests/Unit/Services/FacialRecognitionServiceTest.php
+++ b/tests/Unit/Services/FacialRecognitionServiceTest.php
@@ -30,6 +30,12 @@ class FacialRecognitionServiceTest extends TestCase
     {
         parent::setUp();
 
+        // These cover the tagging pipeline, which needs a provider to produce faces.
+        // The only implementation is MockProvider, and it is no longer the default —
+        // it fabricates detections, so an install without a real provider must not
+        // silently use it. Opt in explicitly here; that is what these tests exercise.
+        config(['services.facial_recognition.provider' => 'mock']);
+
         $this->service = new FacialRecognitionService;
 
         // Create test data


### PR DESCRIPTION
Direct follow-on to #1520. That PR found smart matching inventing ancestors; I said the pattern looked systemic and was worth a sweep. It was — **this is the fourth fake-data engine**, and it was on by default.

Flagged to you before changing anything; built to the option you chose (gate it off unless a real provider exists).

## Facial recognition detected nothing

`config/services.php` defaulted `FACIAL_RECOGNITION_PROVIDER` to `'mock'`, and `MockProvider` is the **only implementation that has ever existed** — the `aws`/`azure` arms of `getProvider()` are commented out and those classes don't exist. Worse, the `match` ended in `default => new MockProvider`, so even a typo in the env var fabricated data.

What it does:

```php
$faceCount = random_int(1, 3);                          // detectFaces()
'confidence' => random_int(85, 99) + ...
if (random_int(1, 100) <= 60) { ... }                   // matchFaces(): coin-flip person
return base64_encode(random_bytes(128));                // getFaceEncoding()
```

`analyzePhoto()` **persisted** these as `PhotoTag` rows, and `FacialRecognitionReview` presented them for confirmation as detections: a random rectangle, a coin-flip person, and a 70–95% number that reads as machine certainty. Confirming one then stored the random bytes as that person's `FaceEncoding` — which any future *real* matching would compare against.

## The gate already existed and was never wired

`FacialRecognitionProviderInterface` declared `isAvailable()`. **Nothing ever called it.** That's now the gate:

- config defaults to `'none'`
- an unrecognised provider name yields **no provider** rather than falling back to the mock
- both write paths (`analyzePhoto`, `createFaceEncoding`) refuse and log instead of inventing

`MockProvider` is kept and still works — but only for whoever sets `FACIAL_RECOGNITION_PROVIDER=mock` deliberately.

## The two existing tests were asserting the fabrication

`FacialRecognitionServiceTest` and `PhotoTaggingWorkflowTest` relied on the mock being the *default*. They exercise the tagging pipeline, which genuinely needs a provider — so they now opt in explicitly. That's what they were always really asserting; it just wasn't visible. (Same shape as the FindMyPast unit test deleted in #1520, which asserted `assertNotEmpty($newspaperMatches)` on fabricated data.)

## Verification

- **588 passed / 0 failed** (was 583). Baseline unchanged at 465 — this is a behaviour fix, not a typing one.
- Mutation-tested: restoring the `'mock'` default **and** `default => new MockProvider` fails 4 of the 5 new tests. The 5th correctly still passes — the mock is *meant* to work when explicitly asked for.
- Covers: default has no provider; no tags persisted without one; no encoding stored without one; opt-in still works; unknown provider name fails closed.

## The sweep that found it

Ran across `app/Services`, `app/Livewire`, `app/Jobs`, counting random-generator calls vs real HTTP calls per file. Everything else came back clean — `ZoomService` has randoms but 6 real HTTP calls (fine). Two remaining suspects worth a look later, not touched here: `HandwritingRecognitionService` (8 simulation markers, 1 HTTP call) and the rest of `FacialRecognitionService`'s aspirational comments.