### PR TITLE
fix(transcription): placeholder claimed 75% confidence; stat shown 100x too small

### DIFF
--- a/app/Services/HandwritingRecognitionService.php
+++ b/app/Services/HandwritingRecognitionService.php
@@ -161,7 +161,12 @@ class HandwritingRecognitionService
         // In a real application, you would use Tesseract or another OCR library
         return [
             'text' => "This is a placeholder transcription.\n\nTo enable real handwriting recognition, configure Google Cloud Vision API key in config/services.php:\n\n'google_vision' => [\n    'api_key' => env('GOOGLE_VISION_API_KEY'),\n],\n\nAnd set GOOGLE_VISION_API_KEY in your .env file.",
-            'confidence' => 0.75,
+            // Nothing was read, so there is nothing to be confident about. This
+            // claimed 0.75, which getTeamStats() averages into the team's
+            // "Avg. Confidence" tile — so an install with no OCR configured
+            // reported a three-quarters-accurate transcription rate off text that
+            // says, in as many words, that it is a placeholder.
+            'confidence' => 0.0,
             'language' => 'en',
         ];
     }
@@ -257,7 +262,11 @@ class HandwritingRecognitionService
             'pending_transcriptions' => (int) ($stats->pending ?? 0),
             'failed_transcriptions' => (int) ($stats->failed ?? 0),
             'total_corrections' => $totalCorrections,
-            'avg_confidence' => round((float) ($stats->avg_confidence ?? 0), 2),
+            // Stored confidence is Google Vision's 0-1 scale, but the only consumer
+            // renders this straight into a "%" tile — so 0.85 displayed as "0.9%"
+            // rather than 85%. Convert here, where the scale is known, instead of in
+            // the view.
+            'avg_confidence' => round((float) ($stats->avg_confidence ?? 0) * 100, 1),
         ];
     }
 }

--- a/tests/Feature/Services/TranscriptionConfidenceTest.php
+++ b/tests/Feature/Services/TranscriptionConfidenceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\DocumentTranscription;
+use App\Models\User;
+use App\Services\HandwritingRecognitionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * Unlike the other "AI" services in this app, handwriting recognition is honest:
+ * it calls Google Cloud Vision for real when configured, and its fallback returns
+ * text that says outright it is a placeholder. Two things about the numbers around
+ * it were not honest, though.
+ */
+class TranscriptionConfidenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function transcription(int $teamId, float $confidence): DocumentTranscription
+    {
+        return DocumentTranscription::factory()->create([
+            'team_id' => $teamId,
+            'status' => 'completed',
+            'metadata' => ['confidence' => $confidence],
+        ]);
+    }
+
+    /**
+     * Google Vision reports confidence on a 0-1 scale and it is stored that way,
+     * but the only consumer renders this value straight into a "%" tile.
+     */
+    public function test_team_stats_reports_confidence_as_a_percentage(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        $teamId = $user->current_team_id;
+
+        $this->transcription($teamId, 0.9);
+        $this->transcription($teamId, 0.8);
+
+        $stats = (new HandwritingRecognitionService)->getTeamStats($teamId);
+
+        // Mean of 0.9 and 0.8 is 0.85 -> 85%, not "0.9%".
+        $this->assertSame(85.0, $stats['avg_confidence']);
+    }
+
+    /**
+     * The fallback claimed 0.75 confidence on text whose own content explains that
+     * it is a placeholder, which then fed the team's average.
+     */
+    public function test_the_placeholder_transcription_claims_no_confidence(): void
+    {
+        $method = new ReflectionMethod(HandwritingRecognitionService::class, 'performFallbackOCR');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(new HandwritingRecognitionService, '/tmp/does-not-matter.jpg');
+
+        $this->assertStringContainsString('placeholder transcription', $result['text']);
+        $this->assertSame(0.0, $result['confidence']);
+    }
+
+    public function test_a_placeholder_does_not_inflate_the_teams_average(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        $teamId = $user->current_team_id;
+
+        // One real transcription, one unconfigured-install placeholder.
+        $this->transcription($teamId, 1.0);
+        $this->transcription($teamId, 0.0);
+
+        $stats = (new HandwritingRecognitionService)->getTeamStats($teamId);
+
+        // The placeholder contributes nothing rather than 0.75.
+        $this->assertSame(50.0, $stats['avg_confidence']);
+    }
+
+    public function test_team_stats_are_scoped_to_the_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $other = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $this->transcription($user->current_team_id, 0.5);
+        $this->transcription($other->current_team_id, 1.0);
+
+        $this->assertSame(1, (new HandwritingRecognitionService)->getTeamStats($user->current_team_id)['total_transcriptions']);
+    }
+}


### PR DESCRIPTION
Closes out the fabrication sweep started in #1520/#1521. **The good news is the headline: there is no fifth fake engine.**

## The sweep came back clean

Counted random-generator calls against real HTTP calls for every file in `app/` and `config/`:

| file | random | http | markers |
|---|---|---|---|
| `FacialRecognition/Providers/MockProvider` | 11 | 0 | already gated in #1521 |
| `HandwritingRecognitionService` | **0** | 1 | 9 |
| everything else | — | — | false positives |

The remaining hits were noise: `ZoomService` has randoms but six real HTTP calls; `UserForm`/`ViewUser` matched on Filament `placeholder` attributes; `config/logging.php` on driver names.

## Handwriting recognition is the *good* pattern

Worth stating plainly, since the last four services weren't: it calls Google Cloud Vision for real when a key is configured, and its fallback returns text that says outright *"This is a placeholder transcription. To enable real handwriting recognition, configure Google Cloud Vision API key…"*. **Zero randoms.** It doesn't pretend.

The numbers around it were the problem.

## Two real bugs

**1. The placeholder claimed 75% confidence.**

```php
'text' => "This is a placeholder transcription. ...",
'confidence' => 0.75,     // <-- on text that says it's a placeholder
```

`getTeamStats()` averages the confidence of every completed transcription into the UI's "Avg. Confidence" tile. So an install with no OCR key reported a **three-quarters-accurate transcription rate**, computed entirely from placeholder text. Nothing was read, so there's nothing to be confident about → `0.0`.

**2. The confidence stat displays 100× too small.**

Google Vision reports confidence on a **0–1** scale and it's stored that way, but the only consumer renders it straight into a `%` tile:

```blade
{{ number_format($stats['avg_confidence'] ?? 0, 1) }}%
```

So 85% confidence displayed as **"0.9%"**. Converted in `getTeamStats()`, where the scale is known, rather than in the view.

## Verification

- **592 passed / 0 failed** (was 588); phpstan and pint green.
- Mutation-tested — restoring both originals fails 3 of 4 with exactly the bugs:
  - `Failed asserting that 0.85 is identical to 85.0` (the 100× display bug)
  - `Failed asserting that 0.75 is identical to 0.0` (the placeholder's claimed confidence)
- The 4th (team scoping) correctly survives both mutations — it's unrelated, and that's the control.