### PR TITLE
fix(docker): the production image has never booted — 6 stacked faults + main is red

### DIFF
--- a/.docker/octane/RoadRunner/supervisord.roadrunner.conf
+++ b/.docker/octane/RoadRunner/supervisord.roadrunner.conf
@@ -14,4 +14,4 @@ stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
 [include]
-files = /etc/supervisord.conf /etc/supervisor/conf.d/supervisord.services.conf
+files = /etc/supervisor/supervisord.conf

--- a/.docker/supervisord.horizon.conf
+++ b/.docker/supervisord.horizon.conf
@@ -13,4 +13,4 @@ stderr_logfile_maxbytes = 0
 stopwaitsecs = 3600
 
 [include]
-files = /etc/supervisord.conf
+files = /etc/supervisor/supervisord.conf

--- a/.docker/supervisord.reverb.conf
+++ b/.docker/supervisord.reverb.conf
@@ -13,4 +13,4 @@ stderr_logfile_maxbytes = 0
 minfds = 10000
 
 [include]
-files = /etc/supervisord.conf
+files = /etc/supervisor/supervisord.conf

--- a/.docker/supervisord.scheduler.conf
+++ b/.docker/supervisord.scheduler.conf
@@ -25,4 +25,4 @@ stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
 [include]
-files = /etc/supervisord.conf
+files = /etc/supervisor/supervisord.conf

--- a/.docker/supervisord.worker.conf
+++ b/.docker/supervisord.worker.conf
@@ -12,4 +12,4 @@ stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
 [include]
-files = /etc/supervisord.conf
+files = /etc/supervisor/supervisord.conf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,59 @@ jobs:
       - name: Run tests
         run: ./vendor/bin/phpunit --no-coverage
 
+  # The image is only built on push, and it pushes straight to Docker Hub — so a
+  # broken image was published before anyone could see it, and pull requests never
+  # exercised the Dockerfile at all. The image had never once booted: five separate
+  # faults stacked up behind each other (missing opcache.file_cache directory,
+  # route:cache tripping on duplicate route names, view:cache on module view paths
+  # that do not exist, supervisord including a root-only file it cannot read as the
+  # octane user, and no frontend build at all, so every @vite page returned 500).
+  # None of it is visible in dev, which caches nothing and runs as root.
+  #
+  # This runs on pull requests too, and it does not just build: it boots the image
+  # and asks it for a page. A green test suite says nothing about any of the above.
+  prod-image-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the production image
+        run: docker build -f Dockerfile -t genalogy-prod:smoke .
+
+      - name: Boot it and serve a request
+        run: |
+          set -euo pipefail
+          docker run -d --name prod-smoke \
+            -e APP_KEY=base64:$(head -c 32 /dev/urandom | base64) \
+            -e APP_ENV=production -e APP_DEBUG=false \
+            -e DB_CONNECTION=sqlite -e DB_DATABASE=/tmp/smoke.sqlite \
+            -e CACHE_STORE=file -e SESSION_DRIVER=file -e QUEUE_CONNECTION=sync \
+            genalogy-prod:smoke
+          docker exec prod-smoke sh -c 'touch /tmp/smoke.sqlite && php artisan migrate --force'
+
+          # Octane needs a moment; fail loudly with logs rather than a bare timeout.
+          for i in $(seq 1 30); do
+            if docker exec prod-smoke sh -c 'wget -q -O /dev/null http://127.0.0.1:8000/' 2>/dev/null; then
+              echo "image serves /"
+              exit 0
+            fi
+            if [ "$(docker inspect -f '{{.State.Status}}' prod-smoke)" != "running" ]; then
+              echo "::error::the production image exited on boot"
+              docker logs prod-smoke
+              exit 1
+            fi
+            sleep 2
+          done
+
+          echo "::error::the production image booted but never served a request"
+          docker logs prod-smoke
+          docker exec prod-smoke sh -c 'tail -40 storage/logs/laravel.log' || true
+          exit 1
+
   docker:
     if: github.event_name == 'push'
-    needs: laravel-tests
+    needs: [laravel-tests, prod-image-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,30 @@ RUN composer install \
 
 
 ###########################################
+# Frontend asset stage
+###########################################
+# Nothing built the frontend, and /public/build is gitignored, so the image had no
+# public/build/manifest.json and every page rendering @vite returned 500 — the
+# container booted, reported healthy, and could not serve a single request.
+#
+# vendor/ is copied in because the Filament theme entrypoints @import CSS out of
+# vendor/filament, and app/ because Tailwind 4 @source-scans it; without either the
+# build fails or silently emits stylesheets missing every Filament class.
+FROM node:22-alpine AS assets
+
+WORKDIR /app
+
+COPY package.json package-lock.json vite.config.js tailwind.config.js ./
+RUN npm ci --no-audit --no-fund
+
+COPY --from=composer-deps /app/vendor ./vendor
+COPY resources ./resources
+COPY app ./app
+
+RUN npm run build
+
+
+###########################################
 # Main application stage
 ###########################################
 FROM php:${PHP_VERSION}-cli-alpine
@@ -138,6 +162,10 @@ COPY --chown=${USER}:${USER} composer.json composer.lock ./
 # Copy application code first so autoloader can resolve all files
 COPY --chown=${USER}:${USER} . .
 
+# After the source copy, or `COPY . .` would clobber it. /public/build is gitignored,
+# so it is never in the build context and has to come from the assets stage.
+COPY --from=assets --chown=${USER}:${USER} /app/public/build ./public/build
+
 # Generate optimized autoloader now that all app files are present
 RUN composer dump-autoload --classmap-authoritative --no-dev && \
     composer clear-cache
@@ -151,6 +179,14 @@ RUN mkdir -p \
     storage/logs \
     bootstrap/cache && \
     chmod -R a+rw storage
+
+# .docker/php.ini sets opcache.file_cache to this path, and PHP refuses to start
+# at all if it does not exist: "Fatal Error opcache.file_cache must be a full path
+# of an accessible directory". Nothing created it, so the image built fine and then
+# exited 254 on every boot. It must be writable by ${USER}, which is who Octane runs
+# as — /tmp being world-writable is not enough once the directory is pre-created.
+RUN mkdir -p /tmp/opcache-file-cache && \
+    chown -R ${USER}:${USER} /tmp/opcache-file-cache
 
 # Copy configuration files
 COPY --chown=${USER}:${USER} .docker/supervisord.conf /etc/supervisor/

--- a/app/Events/ModuleDisabled.php
+++ b/app/Events/ModuleDisabled.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ModuleDisabled
+{
+    use Dispatchable;
+
+    public function __construct(public ModuleInterface $module) {}
+}

--- a/app/Events/ModuleEnabled.php
+++ b/app/Events/ModuleEnabled.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ModuleEnabled
+{
+    use Dispatchable;
+
+    public function __construct(public ModuleInterface $module) {}
+}

--- a/app/Events/ModuleInstalled.php
+++ b/app/Events/ModuleInstalled.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ModuleInstalled
+{
+    use Dispatchable;
+
+    public function __construct(public ModuleInterface $module) {}
+}

--- a/app/Events/ModuleUninstalled.php
+++ b/app/Events/ModuleUninstalled.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ModuleUninstalled
+{
+    use Dispatchable;
+
+    public function __construct(public ModuleInterface $module) {}
+}

--- a/app/Modules/Admin/Providers/AdminServiceProvider.php
+++ b/app/Modules/Admin/Providers/AdminServiceProvider.php
@@ -30,10 +30,19 @@ class AdminServiceProvider extends ServiceProvider
         // $this->loadRoutesFrom(__DIR__ . '/../routes/api.php');
 
         // Load admin views
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'admin');
+        // Guarded because none of these module resource directories exist. An
+        // unguarded loadViewsFrom() is harmless at runtime but fatal to
+        // `php artisan view:cache`, which walks every registered path — so this
+        // passed in dev and broke the production image on boot. ModuleServiceProvider
+        // already guards the same call this way.
+        if (is_dir(__DIR__.'/../resources/views')) {
+            $this->loadViewsFrom(__DIR__.'/../resources/views', 'admin');
+        }
 
         // Load admin translations
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'admin');
+        if (is_dir(__DIR__.'/../resources/lang')) {
+            $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'admin');
+        }
 
         // Publish admin assets
         $this->publishes([

--- a/app/Modules/BaseModule.php
+++ b/app/Modules/BaseModule.php
@@ -7,8 +7,6 @@ use App\Events\ModuleEnabled;
 use App\Events\ModuleInstalled;
 use App\Events\ModuleUninstalled;
 use App\Modules\Contracts\ModuleInterface;
-use App\Modules\Traits\Configurable;
-use App\Modules\Traits\HasModuleHooks;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
@@ -17,13 +15,14 @@ use ReflectionClass;
 
 abstract class BaseModule implements ModuleInterface
 {
-    use Configurable;
-    use HasModuleHooks;
-
     protected string $name;
+
     protected string $version;
+
     protected string $description;
+
     protected array $dependencies = [];
+
     protected array $config = [];
 
     public function __construct()
@@ -97,19 +96,19 @@ abstract class BaseModule implements ModuleInterface
 
     protected function loadModuleInfo(): void
     {
-        $moduleInfoPath = $this->getModulePath() . '/module.json';
+        $moduleInfoPath = $this->getModulePath().'/module.json';
 
         if (File::exists($moduleInfoPath)) {
             $moduleInfo = json_decode(File::get($moduleInfoPath), true) ?? [];
 
-            $this->name        = $moduleInfo['name'] ?? class_basename($this);
-            $this->version     = $moduleInfo['version'] ?? '1.0.0';
+            $this->name = $moduleInfo['name'] ?? class_basename($this);
+            $this->version = $moduleInfo['version'] ?? '1.0.0';
             $this->description = $moduleInfo['description'] ?? '';
             $this->dependencies = $moduleInfo['dependencies'] ?? [];
-            $this->config      = $moduleInfo['config'] ?? [];
+            $this->config = $moduleInfo['config'] ?? [];
         } else {
-            $this->name        = $this->name ?? class_basename($this);
-            $this->version     = $this->version ?? '1.0.0';
+            $this->name = $this->name ?? class_basename($this);
+            $this->version = $this->version ?? '1.0.0';
             $this->description = $this->description ?? '';
         }
     }
@@ -117,15 +116,16 @@ abstract class BaseModule implements ModuleInterface
     protected function getModulePath(): string
     {
         $reflection = new ReflectionClass($this);
+
         return dirname($reflection->getFileName());
     }
 
     protected function runMigrations(): void
     {
-        $migrationsPath = $this->getModulePath() . '/database/migrations';
+        $migrationsPath = $this->getModulePath().'/database/migrations';
 
         if (File::exists($migrationsPath)) {
-            $relative = str_replace(base_path() . '/', '', $migrationsPath);
+            $relative = str_replace(base_path().'/', '', $migrationsPath);
             Artisan::call('migrate', ['--path' => $relative, '--force' => true]);
         }
     }
@@ -135,7 +135,7 @@ abstract class BaseModule implements ModuleInterface
     protected function publishAssets(): void
     {
         Artisan::call('vendor:publish', [
-            '--tag'   => strtolower($this->name) . '-assets',
+            '--tag' => strtolower($this->name).'-assets',
             '--force' => true,
         ]);
     }

--- a/app/Modules/Core/Providers/CoreServiceProvider.php
+++ b/app/Modules/Core/Providers/CoreServiceProvider.php
@@ -57,10 +57,19 @@ class CoreServiceProvider extends ServiceProvider
     protected function bootCoreServices(): void
     {
         // Load core views
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'core');
+        // Guarded because none of these module resource directories exist. An
+        // unguarded loadViewsFrom() is harmless at runtime but fatal to
+        // `php artisan view:cache`, which walks every registered path — so this
+        // passed in dev and broke the production image on boot. ModuleServiceProvider
+        // already guards the same call this way.
+        if (is_dir(__DIR__.'/../resources/views')) {
+            $this->loadViewsFrom(__DIR__.'/../resources/views', 'core');
+        }
 
         // Load core translations
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'core');
+        if (is_dir(__DIR__.'/../resources/lang')) {
+            $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'core');
+        }
 
         // Load core routes
         $this->loadRoutesFrom(__DIR__.'/../routes/web.php');

--- a/app/Modules/Family/routes/web.php
+++ b/app/Modules/Family/routes/web.php
@@ -14,7 +14,12 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware(['web'])->prefix('families')->name('families.')->group(function (): void {
+// Name prefix is module-scoped: 'families.' collided with routes/api.php's
+// apiResource('families'), which claims the same families.index/store/show/... names.
+// Duplicate route names are only fatal when routes are cached, so this never
+// surfaced in dev and made `php artisan route:cache` — and therefore the whole
+// production image — fail to boot. Nothing referenced these names by route().
+Route::middleware(['web'])->prefix('families')->name('modules.families.')->group(function (): void {
     Route::get('/', [FamilyController::class, 'index'])->name('index');
     Route::get('/create', [FamilyController::class, 'create'])->name('create');
     Route::post('/', [FamilyController::class, 'store'])->name('store');

--- a/app/Modules/Person/Providers/PersonServiceProvider.php
+++ b/app/Modules/Person/Providers/PersonServiceProvider.php
@@ -37,10 +37,19 @@ class PersonServiceProvider extends ServiceProvider
         $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
 
         // Load person views
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'person');
+        // Guarded because none of these module resource directories exist. An
+        // unguarded loadViewsFrom() is harmless at runtime but fatal to
+        // `php artisan view:cache`, which walks every registered path — so this
+        // passed in dev and broke the production image on boot. ModuleServiceProvider
+        // already guards the same call this way.
+        if (is_dir(__DIR__.'/../resources/views')) {
+            $this->loadViewsFrom(__DIR__.'/../resources/views', 'person');
+        }
 
         // Load person translations
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'person');
+        if (is_dir(__DIR__.'/../resources/lang')) {
+            $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'person');
+        }
 
         // Publish person assets
         $this->publishes([

--- a/app/Modules/Places/Providers/PlacesServiceProvider.php
+++ b/app/Modules/Places/Providers/PlacesServiceProvider.php
@@ -33,10 +33,19 @@ class PlacesServiceProvider extends ServiceProvider
         // $this->loadRoutesFrom(__DIR__ . '/../routes/api.php');
 
         // Load places views
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'places');
+        // Guarded because none of these module resource directories exist. An
+        // unguarded loadViewsFrom() is harmless at runtime but fatal to
+        // `php artisan view:cache`, which walks every registered path — so this
+        // passed in dev and broke the production image on boot. ModuleServiceProvider
+        // already guards the same call this way.
+        if (is_dir(__DIR__.'/../resources/views')) {
+            $this->loadViewsFrom(__DIR__.'/../resources/views', 'places');
+        }
 
         // Load places translations
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'places');
+        if (is_dir(__DIR__.'/../resources/lang')) {
+            $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'places');
+        }
 
         // Publish places assets
         $this->publishes([

--- a/app/Modules/Places/routes/web.php
+++ b/app/Modules/Places/routes/web.php
@@ -14,7 +14,9 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware(['web'])->prefix('places')->name('places.')->group(function (): void {
+// Module-scoped name prefix — see Family/routes/web.php: 'places.' collided with
+// routes/api.php's apiResource('places') and broke route:cache in production.
+Route::middleware(['web'])->prefix('places')->name('modules.places.')->group(function (): void {
     Route::get('/', [PlacesController::class, 'index'])->name('index');
     Route::get('/create', [PlacesController::class, 'create'])->name('create');
     Route::post('/', [PlacesController::class, 'store'])->name('store');


### PR DESCRIPTION
**Two things you should know before anything else:**

1. **`main`'s CI is entirely red right now** — Tests, Docker, Install, Quality and Security all die on `php artisan key:generate`.
2. **The production Docker image has never once booted**, and CI publishes it to Docker Hub anyway.

I found this by doing something I hadn't done in ten merged PRs: actually building the image and running it, instead of trusting a green test suite.

## Why nobody saw it

`main.yml` gates the image build on `if: github.event_name == 'push'`, so **pull requests never exercise the Dockerfile** — and the job does `push: true`. A broken image ships before anyone can look. None of the six faults below are visible in dev, which caches nothing and runs as root.

## Six faults, stacked

Each only appeared once the one in front of it was fixed:

| # | Fault | Symptom |
|---|---|---|
| 1 | `opcache.file_cache` dir never created | PHP won't start; **exit 254** |
| 2 | `BaseModule` uses traits that don't exist | **kills all 5 CI workflows on main** |
| 3 | Duplicate route names (`families.*`, `places.*`) | `route:cache` FAIL |
| 4 | `loadViewsFrom()` on dirs that don't exist | `view:cache` FAIL |
| 5 | supervisord includes a **root-only** file, container runs as `octane` | supervisord refuses to start |
| 6 | **No frontend build at all**; `/public/build` is gitignored | booted "healthy", **every page 500** |

Fault 2 is why main is red: `BaseModule` uses `App\Modules\Traits\Configurable` and `HasModuleHooks` — **neither exists anywhere** — and dispatches `App\Events\Module*` classes that were never committed. Removed the dead traits; added the four event classes (`enable()`/`disable()` dispatch them, and `enableDefaultModules()` runs on boot).

Fault 6 is the one worth staring at: **the healthcheck lies.** It runs `octane:status`, which only asks whether the process is alive — so the container reported `healthy` while returning 500 for every single request.

## Proof

Built from a clean `git archive origin/main` each time, overlaying only the files this PR commits:

```
before:  Exited (254)   Fatal Error opcache.file_cache must be a full path...
then:    Exited (1)     Trait "App\Modules\Traits\Configurable" not found
then:    routes ...     FAIL  (duplicate route name families.index)
then:    views  ...     FAIL  (Admin/Providers/../resources/views does not exist)
then:    Exited (2)     .ini file does not include supervisord section
then:    healthy        but every route 500 — Vite manifest not found
after:   healthy        /  200   /privacy  200   /terms-and-conditions  200
```

`✓ built in 3.67s` — Vite now runs inside the image. The assets stage needs `vendor/` (the Filament theme entrypoints `@import` out of it) and `app/` (Tailwind 4 `@source`-scans it), which is presumably why it was never attempted.

## The guard

`prod-image-smoke` builds the image **on pull requests**, boots it, and requires it to **serve a request** — with the publish job gated behind it. It fails loudly with container logs rather than a bare timeout. A green test suite says nothing about any of the six faults above.

## Known, and deliberately NOT fixed

`/app/login` and `/admin/login` still 500: `Route [password.request] not defined`. The panels set `Fortify::$registersRoutes = false` and own auth themselves, so Fortify never registers `password.request` — but the published `resources/views/auth/login.blade.php` still links to it. Only surfaces under `route:cache`.

Which password-reset flow is canonical (Fortify's, or the panels' own `filament.*.auth.password-reset.request`) is a **decision, not a typo**, so I've left it. The smoke job asserts `/` serves, which is honest and passes.

## Notes

- The `BaseModule`/Events fix came from your other session's working tree, on your say-so — it's the same change I'd have made, and main can't build without it.
- I could not verify against MySQL: another project on this machine holds port 3307, so the smoke test uses sqlite. Every 500 I attributed to the app was re-checked against that.