### PR TITLE
fix(notifications): store database notifications instead of failing on them

### DIFF
--- a/database/migrations/2026_07_19_120000_fix_notifications_primary_key_type.php
+++ b/database/migrations/2026_07_19_120000_fix_notifications_primary_key_type.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The notifications table was created in 2017 with an auto-incrementing integer
+ * primary key, but Laravel's database notification channel writes a UUID string.
+ * Every insert has been rejected ever since, so no in-app notification has ever
+ * been stored.
+ *
+ * Note what that means operationally: every notification class here implements
+ * ShouldQueue, and Laravel dispatches one job per channel. The database write
+ * therefore failed *inside its own queue job*, which was retried and ultimately
+ * failed. Nothing was silently discarded — since 2017 each in-app notification
+ * has become a failed job. Installs that keep a failed_jobs backlog may have a
+ * large one, and it should be reviewed and purged separately from this change.
+ * The mail channel is a separate job and was never affected.
+ *
+ * The original migration cannot simply be corrected: it has already run on live
+ * installs, and editing it changes nothing that exists.
+ *
+ * Because no row could ever be written, the table is necessarily empty, and
+ * recreating it is both safe and simpler than altering a primary key's type
+ * across MariaDB and SQLite. That assumption is asserted rather than trusted —
+ * if rows are somehow present, this migration stops instead of destroying them.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('notifications')) {
+            $this->createTable();
+
+            return;
+        }
+
+        if ($this->alreadyUsesStringKey()) {
+            return;
+        }
+
+        $existing = DB::table('notifications')->count();
+
+        if ($existing > 0) {
+            throw new RuntimeException(
+                "The notifications table holds {$existing} row(s), which should be impossible: "
+                .'its integer primary key rejects the UUIDs Laravel writes. Inspect them before '
+                .'rerunning this migration — it recreates the table and they would be lost.'
+            );
+        }
+
+        Schema::drop('notifications');
+        $this->createTable();
+    }
+
+    /**
+     * Restores the original integer key. Unlike up(), this direction destroys
+     * rows that genuinely can exist — once this migration has run, real
+     * notifications accumulate, and no integer-keyed table can hold them. So
+     * the guard matters more here than it does going forward: refuse rather
+     * than silently discard a user's notification history during a rollback
+     * triggered by some unrelated migration.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('notifications')) {
+            $existing = DB::table('notifications')->count();
+
+            if ($existing > 0) {
+                throw new RuntimeException(
+                    "Refusing to roll back: the notifications table holds {$existing} row(s), "
+                    .'and the integer primary key this restores cannot store them. Export or '
+                    .'delete them first if you genuinely intend to lose them.'
+                );
+            }
+
+            Schema::drop('notifications');
+        }
+
+        Schema::create('notifications', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function createTable(): void
+    {
+        Schema::create('notifications', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Guards against rerunning on an install that has already been corrected,
+     * and against a fresh install where a future consolidated schema already
+     * declares the column correctly.
+     */
+    private function alreadyUsesStringKey(): bool
+    {
+        return ! in_array(
+            Schema::getColumnType('notifications', 'id'),
+            ['integer', 'bigint', 'int', 'int8'],
+            true,
+        );
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,6 +30,11 @@
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
+        <!-- Without a from address every rendered mailable throws "An email must
+             have a From or a Sender header", so no test could exercise the mail
+             channel at all. The array mailer still sends nothing. -->
+        <env name="MAIL_FROM_ADDRESS" value="testing@example.com"/>
+        <env name="MAIL_FROM_NAME" value="Testing"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/Notifications/DatabaseNotificationChannelTest.php
+++ b/tests/Feature/Notifications/DatabaseNotificationChannelTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\Achievement;
+use App\Models\User;
+use App\Notifications\AchievementUnlockedNotification;
+use App\Notifications\DnaMatchFoundNotification;
+use App\Notifications\DuplicatePersonDetectedNotification;
+use App\Notifications\RecordSuggestionNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The database notification channel must actually store notifications.
+ *
+ * The notifications table declared its primary key as an auto-incrementing
+ * integer, while Laravel writes a UUID string. Every insert was rejected, so
+ * no in-app notification had ever been stored since the table was created in
+ * 2017 — the classes existed, were dispatched, and were thrown away by the
+ * database.
+ *
+ * These tests dispatch for real (no Notification::fake) precisely because the
+ * failure was in the write itself; faking the facade is what hid it.
+ */
+class DatabaseNotificationChannelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // Mail is deliberately NOT faked. phpunit.xml already uses the array
+    // mailer, so nothing is sent — and letting the mail channel render means
+    // a broken toMail() template surfaces here too. Mail is currently the only
+    // channel that reaches a user at all (see the class docblock), so hiding it
+    // would be the wrong trade.
+
+    public function test_a_database_notification_is_stored_and_readable_by_its_recipient(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notify(new DnaMatchFoundNotification(3));
+
+        $stored = $user->fresh()->notifications;
+
+        $this->assertCount(1, $stored);
+        $this->assertSame(DnaMatchFoundNotification::class, $stored->first()->type);
+        $this->assertSame(3, $stored->first()->data['count']);
+    }
+
+    public function test_the_primary_key_is_the_uuid_laravel_writes(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notify(new DnaMatchFoundNotification(1));
+
+        $id = $user->fresh()->notifications->first()->id;
+
+        // A 36-character UUID, not an integer. Guards against the column being
+        // "fixed" to a string type that silently truncates or re-numbers.
+        $this->assertIsString($id);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i',
+            $id
+        );
+    }
+
+    public function test_every_database_channel_notification_stores(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notify(new DnaMatchFoundNotification(1));
+        $user->notify(new RecordSuggestionNotification(2));
+        $user->notify(new DuplicatePersonDetectedNotification(4));
+        $user->notify(new AchievementUnlockedNotification($this->achievement()));
+
+        $this->assertCount(4, $user->fresh()->notifications);
+    }
+
+    /**
+     * The achievement notification is the one whose failure was genuinely
+     * invisible: its listener wraps dispatch in a try/catch that logs a warning
+     * and swallows the exception. It also builds the richest payload of the
+     * four, dereferencing the achievement across eight keys.
+     */
+    public function test_the_achievement_notification_stores_its_full_payload(): void
+    {
+        $user = User::factory()->create();
+        $achievement = $this->achievement();
+
+        $user->notify(new AchievementUnlockedNotification($achievement));
+
+        $data = $user->fresh()->notifications->first()->data;
+
+        $this->assertSame('achievement_unlocked', $data['type']);
+        $this->assertSame($achievement->id, $data['achievement_id']);
+        $this->assertSame($achievement->key, $data['achievement_key']);
+        $this->assertSame($achievement->points, $data['points_awarded']);
+    }
+
+    private function achievement(): Achievement
+    {
+        return Achievement::create([
+            'key' => 'first_person',
+            'name' => 'First Person',
+            'description' => 'Added your first person.',
+            'icon' => 'heroicon-o-user',
+            'category' => 'tree',
+            'points' => 10,
+            'requirements' => [],
+            'badge_color' => 'green',
+        ]);
+    }
+
+    public function test_notifications_can_be_marked_read(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notify(new DnaMatchFoundNotification(1));
+
+        $this->assertCount(1, $user->fresh()->unreadNotifications);
+
+        $user->fresh()->unreadNotifications->markAsRead();
+
+        $this->assertCount(0, $user->fresh()->unreadNotifications);
+    }
+}


### PR DESCRIPTION
## The bug

`notifications.id` has been an auto-incrementing integer since the table was created in 2017. Laravel's database channel writes a **UUID**. Every insert has been rejected ever since.

So no in-app notification has ever been stored — not one, for any event: DNA match found, record suggestion, duplicate person detected, achievement unlocked.

## It wasn't silent

All five notification classes implement `ShouldQueue`, and Laravel dispatches **one job per channel**. The database write failed inside its own queue job and was retried until it failed for good.

Since 2017, every in-app notification has become a **failed job**, not a discarded one. Installs that retain a `failed_jobs` backlog may have a large one — worth reviewing and purging separately from this change. The `mail` channel is a separate job and was never affected, which is why nobody noticed.

## The fix

The 2017 migration can't just be corrected — it has already run on live installs. A new migration recreates the table with the key Laravel actually writes.

**Why drop-and-recreate is safe here:** no row could ever have been inserted. `config/database.php` sets `strict => true` for both the mysql and mariadb connections, so a UUID could not have been coerced to `0`; on SQLite `bigIncrements` is a rowid alias that rejects non-integers outright. Nothing else writes to the table — no seeder, no factory, no package. The premise is asserted rather than trusted: the migration **refuses to run** if rows are somehow present, rather than destroying them.

`down()` carries the same guard, and needs it more. Once this ships, real notifications accumulate and the integer key it restores cannot hold them — so a rollback triggered by some unrelated migration would otherwise delete a user's notification history without a word.

## Verification

Verified against **MariaDB directly**, not just the SQLite the suite uses. The full migration chain applied to an empty database yields `char(36)` `PRIMARY` on `notifications` — the same upgrade path a live install takes.

```
id    char(36)    NO    PRI
```

- Full suite: **597 passed**, 12 skipped
- PHPStan: clean
- Pint: clean on changed files

> `down()` is exercised on SQLite only. A local privilege quirk blocked `migrate:rollback` against the dev MariaDB (`DB::table('migrations')->count()` succeeds as the same user, but the migrator's query gets a 1044), so that direction is unverified on MySQL.

## phpunit.xml

Adds a mail from-address. Without one, every rendered mailable throws `An email must have a "From" or a "Sender" header` — so **no test in the suite could exercise the mail channel at all**. That matters here because mail is currently the only channel that reaches anyone. The array mailer still sends nothing.

## Known and NOT fixed here

**Nothing reads these notifications.** No `databaseNotifications()` on any of the three panels, no `unreadNotifications` in any view, no `DatabaseNotification` reference, no API route.

Storing is not delivering. The user-visible effect of this commit **alone is zero** until a consumer exists. The fix is still correct and necessary — rows have to exist before anything can show them, and the failed-job churn stops either way — but this should not be read as "in-app notifications now work." Enabling Filament's `databaseNotifications()` on the app panel is roughly a one-line follow-up if that's the intended surface.
