### PR TITLE
fix(transcription): report no confidence rather than inventing one

### DIFF
--- a/app/Livewire/DocumentTranscriptionComponent.php
+++ b/app/Livewire/DocumentTranscriptionComponent.php
@@ -199,7 +199,9 @@ class DocumentTranscriptionComponent extends Component
                 'pending_transcriptions' => 0,
                 'failed_transcriptions' => 0,
                 'total_corrections' => 0,
-                'avg_confidence' => 0,
+                // Null, not 0: with no team there is nothing measured, and 0
+                // would render as a "0.0%" accuracy claim.
+                'avg_confidence' => null,
             ];
         }
 

--- a/app/Services/HandwritingRecognitionService.php
+++ b/app/Services/HandwritingRecognitionService.php
@@ -35,13 +35,31 @@ class HandwritingRecognitionService
             $result = $this->performOCR(Storage::disk('public')->path($path));
 
             // Update transcription with results
+            $metadata = [
+                'language' => $result['language'] ?? 'en',
+                'processing_time' => $result['processing_time'] ?? null,
+            ];
+
+            // Omitted entirely rather than stored as null, and the distinction is
+            // load-bearing. getTeamStats() averages JSON_EXTRACT(metadata,
+            // '$.confidence'), and the drivers disagree on a stored JSON null:
+            //
+            //   {"language":"en"}     -> SQL NULL on both -> excluded from AVG
+            //   {"confidence":null}   -> SQL NULL on SQLite, but a JSON null
+            //                            literal on MariaDB, where AVG counts it
+            //                            as 0 (measured: AVG over 1.0 + JSON null
+            //                            returns 0.5, not 1.0)
+            //
+            // So storing null would pass the suite on SQLite and quietly average
+            // zeros into every team's confidence in production. The test asserting
+            // this key is absent is what holds the invariant.
+            if ($result['confidence'] !== null) {
+                $metadata['confidence'] = $result['confidence'];
+            }
+
             $transcription->update([
                 'raw_transcription' => $result['text'],
-                'metadata' => [
-                    'confidence' => $result['confidence'],
-                    'language' => $result['language'] ?? 'en',
-                    'processing_time' => $result['processing_time'] ?? null,
-                ],
+                'metadata' => $metadata,
                 'status' => 'completed',
                 'processed_at' => now(),
             ]);
@@ -121,7 +139,10 @@ class HandwritingRecognitionService
         if (empty($textAnnotations)) {
             return [
                 'text' => '',
-                'confidence' => 0,
+                // No text was detected, so there is nothing to be confident
+                // about. Reporting 0 would read as "text found, certain it is
+                // wrong" and would drag the team average down as a measurement.
+                'confidence' => null,
                 'language' => 'en',
             ];
         }
@@ -137,9 +158,13 @@ class HandwritingRecognitionService
             }
         }
 
+        // Vision routinely returns annotations with no per-word confidence. That
+        // is an ordinary response shape, not an error — but substituting a value
+        // here reported an invented number as the API's own measurement, and it
+        // fed the team's "Avg. Confidence" tile. Absent means absent.
         $avgConfidence = $confidenceScores === []
-            ? 0.85
-            : round(array_sum($confidenceScores) / count($confidenceScores), 2); // Default confidence if not provided
+            ? null
+            : round(array_sum($confidenceScores) / count($confidenceScores), 2);
 
         // Detect language
         $language = $data['responses'][0]['fullTextAnnotation']['pages'][0]['property']['detectedLanguages'][0]['languageCode'] ?? 'en';
@@ -166,7 +191,11 @@ class HandwritingRecognitionService
             // "Avg. Confidence" tile — so an install with no OCR configured
             // reported a three-quarters-accurate transcription rate off text that
             // says, in as many words, that it is a placeholder.
-            'confidence' => 0.0,
+            //
+            // It was then corrected to 0.0, which is still a claim: zero is a
+            // measured value and SQL AVG counts it, so one placeholder halved a
+            // team's reported accuracy. Null is the only honest answer.
+            'confidence' => null,
             'language' => 'en',
         ];
     }
@@ -256,6 +285,10 @@ class HandwritingRecognitionService
             $query->where('team_id', $teamId);
         })->count();
 
+        // AVG ignores SQL NULL, so unmeasured transcriptions are already excluded
+        // from the mean; null here means none of them had a measurement at all.
+        $avgConfidence = $stats->avg_confidence ?? null;
+
         return [
             'total_transcriptions' => (int) ($stats->total ?? 0),
             'completed_transcriptions' => (int) ($stats->completed ?? 0),
@@ -266,7 +299,13 @@ class HandwritingRecognitionService
             // renders this straight into a "%" tile — so 0.85 displayed as "0.9%"
             // rather than 85%. Convert here, where the scale is known, instead of in
             // the view.
-            'avg_confidence' => round((float) ($stats->avg_confidence ?? 0) * 100, 1),
+            //
+            // Null when nothing was ever measured. Coercing that to 0 would report
+            // "0% average confidence", which is a claim about accuracy rather than
+            // an admission that no measurement exists.
+            'avg_confidence' => $avgConfidence === null
+                ? null
+                : round((float) $avgConfidence * 100, 1),
         ];
     }
 }

--- a/resources/views/livewire/document-transcription-component.blade.php
+++ b/resources/views/livewire/document-transcription-component.blade.php
@@ -23,7 +23,14 @@
         </div>
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
             <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Avg. Confidence</div>
-            <div class="mt-1 text-2xl font-semibold text-purple-600">{{ number_format($stats['avg_confidence'] ?? 0, 1) }}%</div>
+            {{-- Null means no transcription has a measured confidence — typically
+                 an install with no OCR provider configured. Rendering "0.0%" there
+                 would state an accuracy the software never measured. --}}
+            @if (($stats['avg_confidence'] ?? null) === null)
+                <div class="mt-1 text-2xl font-semibold text-gray-400" title="No transcription has a measured confidence score">&mdash;</div>
+            @else
+                <div class="mt-1 text-2xl font-semibold text-purple-600">{{ number_format($stats['avg_confidence'], 1) }}%</div>
+            @endif
         </div>
     </div>
 
@@ -179,7 +186,12 @@
                                     class="w-full h-auto"
                                 />
                             </div>
-                            @if($currentTranscription->getConfidenceScore())
+                            {{-- Compared against null, not truthiness: a genuinely
+                                 measured 0.0 is falsy, and hiding it would read as
+                                 "no score available" when it actually means the OCR
+                                 is certain the text is wrong. Absent and zero are
+                                 different claims. --}}
+                            @if($currentTranscription->getConfidenceScore() !== null)
                                 <div class="mt-2 text-sm text-gray-600 dark:text-gray-400">
                                     Confidence: {{ number_format($currentTranscription->getConfidenceScore() * 100, 1) }}%
                                 </div>

--- a/tests/Feature/Services/TranscriptionConfidenceTest.php
+++ b/tests/Feature/Services/TranscriptionConfidenceTest.php
@@ -8,6 +8,9 @@ use App\Models\DocumentTranscription;
 use App\Models\User;
 use App\Services\HandwritingRecognitionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use ReflectionMethod;
 use Tests\TestCase;
 
@@ -52,8 +55,12 @@ class TranscriptionConfidenceTest extends TestCase
     /**
      * The fallback claimed 0.75 confidence on text whose own content explains that
      * it is a placeholder, which then fed the team's average.
+     *
+     * The earlier fix changed that 0.75 to 0.0, which is still a claim: zero is a
+     * measured value, and SQL AVG counts it. Nothing was read, so there is no
+     * confidence to report at all — the value is absent, not zero.
      */
-    public function test_the_placeholder_transcription_claims_no_confidence(): void
+    public function test_the_placeholder_transcription_reports_no_confidence_at_all(): void
     {
         $method = new ReflectionMethod(HandwritingRecognitionService::class, 'performFallbackOCR');
         $method->setAccessible(true);
@@ -61,23 +68,169 @@ class TranscriptionConfidenceTest extends TestCase
         $result = $method->invoke(new HandwritingRecognitionService, '/tmp/does-not-matter.jpg');
 
         $this->assertStringContainsString('placeholder transcription', $result['text']);
-        $this->assertSame(0.0, $result['confidence']);
+        $this->assertNull($result['confidence']);
     }
 
-    public function test_a_placeholder_does_not_inflate_the_teams_average(): void
+    /**
+     * Previously this asserted 50.0 — a real 100%-confidence transcription plus a
+     * placeholder averaging out to half. That test was named "does not inflate"
+     * and commented "contributes nothing", but 50.0 is the proof that it did
+     * contribute: an unread placeholder halved the team's reported accuracy.
+     */
+    public function test_a_placeholder_is_excluded_from_the_teams_average_entirely(): void
+    {
+        Storage::fake('public');
+        config(['services.google_vision.api_key' => null]);
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        $teamId = $user->current_team_id;
+
+        $this->transcription($teamId, 1.0);
+
+        // A real placeholder, produced by the unconfigured-install path — not a
+        // fixture with the key pre-removed. Building it by hand would make this
+        // test pass against the old code, which is what it is here to catch.
+        (new HandwritingRecognitionService)->processDocument(
+            UploadedFile::fake()->image('census.jpg'),
+            $user,
+            $teamId,
+        );
+
+        $stats = (new HandwritingRecognitionService)->getTeamStats($teamId);
+
+        // The one measured transcription is the whole average. Previously the
+        // placeholder contributed 0.0 and this returned 50.0 — an unread document
+        // halving the team's reported accuracy.
+        $this->assertSame(100.0, $stats['avg_confidence']);
+        // It is still counted as a transcription; only the confidence is absent.
+        $this->assertSame(2, $stats['total_transcriptions']);
+    }
+
+    public function test_avg_confidence_is_null_when_nothing_was_ever_measured(): void
     {
         $user = User::factory()->withPersonalTeam()->create();
         $this->actingAs($user);
         $teamId = $user->current_team_id;
 
-        // One real transcription, one unconfigured-install placeholder.
-        $this->transcription($teamId, 1.0);
-        $this->transcription($teamId, 0.0);
+        $this->unmeasuredTranscription($teamId);
+        $this->unmeasuredTranscription($teamId);
 
         $stats = (new HandwritingRecognitionService)->getTeamStats($teamId);
 
-        // The placeholder contributes nothing rather than 0.75.
-        $this->assertSame(50.0, $stats['avg_confidence']);
+        // Not 0.0 — reporting "0% average confidence" is itself a false claim
+        // about accuracy when no measurement was ever taken.
+        $this->assertNull($stats['avg_confidence']);
+    }
+
+    /**
+     * Google Vision commonly returns text annotations with no per-word confidence.
+     * That is an ordinary response, not an error — and the service substituted
+     * 0.85 and reported it as the API's own measurement.
+     */
+    public function test_vision_annotations_without_confidence_report_none(): void
+    {
+        config(['services.google_vision.api_key' => 'test-key']);
+
+        Http::fake([
+            'vision.googleapis.com/*' => Http::response([
+                'responses' => [[
+                    'textAnnotations' => [
+                        ['description' => "Elizabeth Fry\n1780"],
+                        ['description' => 'Elizabeth'],
+                    ],
+                ]],
+            ]),
+        ]);
+
+        $result = $this->runOcr();
+
+        $this->assertSame("Elizabeth Fry\n1780", $result['text']);
+        $this->assertNull($result['confidence']);
+    }
+
+    public function test_vision_confidences_are_averaged_when_present(): void
+    {
+        config(['services.google_vision.api_key' => 'test-key']);
+
+        Http::fake([
+            'vision.googleapis.com/*' => Http::response([
+                'responses' => [[
+                    'textAnnotations' => [
+                        ['description' => 'Elizabeth Fry', 'confidence' => 0.9],
+                        ['description' => 'Elizabeth', 'confidence' => 0.7],
+                    ],
+                ]],
+            ]),
+        ]);
+
+        $result = $this->runOcr();
+
+        $this->assertSame(0.8, $result['confidence']);
+    }
+
+    public function test_vision_finding_no_text_reports_no_confidence(): void
+    {
+        config(['services.google_vision.api_key' => 'test-key']);
+
+        Http::fake([
+            'vision.googleapis.com/*' => Http::response(['responses' => [[]]]),
+        ]);
+
+        $result = $this->runOcr();
+
+        $this->assertSame('', $result['text']);
+        // Nothing was detected, so there is nothing to be confident about. A
+        // reported 0 would read as "detected text, certain it is wrong".
+        $this->assertNull($result['confidence']);
+    }
+
+    public function test_a_processed_document_stores_no_confidence_key_when_unmeasured(): void
+    {
+        Storage::fake('public');
+        config(['services.google_vision.api_key' => null]);
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $transcription = (new HandwritingRecognitionService)->processDocument(
+            UploadedFile::fake()->image('census.jpg'),
+            $user,
+            $user->current_team_id,
+        );
+
+        $this->assertSame('completed', $transcription->status);
+        // Absent, not null — and this assertion is the only thing holding that
+        // invariant. Verified against both drivers: a stored JSON null extracts
+        // to SQL NULL on SQLite (so AVG skips it) but stays a JSON null literal
+        // on MariaDB, where AVG counts it as 0. Storing null would therefore keep
+        // this suite green while averaging zeros into production confidence.
+        $this->assertArrayNotHasKey('confidence', $transcription->fresh()->metadata);
+        $this->assertNull($transcription->fresh()->getConfidenceScore());
+    }
+
+    private function unmeasuredTranscription(int $teamId): DocumentTranscription
+    {
+        return DocumentTranscription::factory()->create([
+            'team_id' => $teamId,
+            'status' => 'completed',
+            'metadata' => ['language' => 'en'],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runOcr(): array
+    {
+        Storage::fake('public');
+        $path = Storage::disk('public')->path('ocr-fixture.jpg');
+        file_put_contents($path, 'not-a-real-image');
+
+        $method = new ReflectionMethod(HandwritingRecognitionService::class, 'performOCR');
+        $method->setAccessible(true);
+
+        return $method->invoke(new HandwritingRecognitionService, $path);
     }
 
     public function test_team_stats_are_scoped_to_the_team(): void


### PR DESCRIPTION
## The bug

Google Vision routinely returns text annotations carrying **no per-word confidence**. That's an ordinary response shape, not an error — and the service substituted `0.85` and reported it as the API's own measurement. It fed the team's "Avg. Confidence" tile, so a researcher read a precision claim the software never made.

The unconfigured-install fallback had the same problem one method below. An earlier fix changed its `0.75` to `0.0` — but that is still a claim. Zero is a *measured* value and SQL `AVG` counts it, so **a single placeholder halved a team's reported accuracy**: one real 100% transcription plus one unread document averaged to 50%.

The test covering that asserted exactly `50.0`, while its own name said "does not inflate" and its comment said "contributes nothing". That `50.0` was the bug, written down as the expectation.

## The fix

Unmeasured confidence is now **absent**, not zero, on every path — no per-word scores, no text detected, no OCR provider configured. The team average excludes those rows rather than averaging a substitute into them, and reports null rather than `0` when nothing was ever measured.

## Why the key is omitted rather than stored as null

This distinction is load-bearing, and I measured it on both engines rather than assuming:

| stored metadata | SQLite (tests) | MariaDB (production) |
|---|---|---|
| `{"language":"en"}` — key omitted | SQL NULL, **excluded** | SQL NULL, **excluded** |
| `{"confidence":null}` | SQL NULL, **excluded** | JSON null literal, **counted as 0** |
| `AVG` over `1.0` + the above | `1.0` | **`0.5`** |

So writing `'confidence' => null` would keep the entire suite green on SQLite while quietly averaging zeros into every production team's tile. The assertion that the key is *absent* is the only thing holding that invariant — and it now says so in the test.

## Views

Both stop conflating absent with zero:

- the tile renders an em-dash instead of `0.0%`
- the per-document line compares against `null` instead of truthiness, so a genuinely measured `0.0` is **shown** rather than hidden. Hiding it would read as "no score available" when it actually means the OCR is certain the text is wrong.

## Tests

- Full suite: **597 passed**, 12 skipped
- PHPStan: clean
- Pint: clean on changed files

The rewritten placeholder test was verified to be revert-sensitive: with the old `0.0` restored it fails with `Failed asserting that 50.0 is identical to 100.0`. Its first draft built the row from a factory with the key pre-removed, which passed against `main` — a test named "a placeholder is excluded" that contained no placeholder. It now drives the real unconfigured-install path through `processDocument`.

## Decision recorded

Transcriptions with no measured confidence **still count toward transcription totals**. A document was processed; only the confidence is unknown.

## Known and NOT fixed here

Same defect class in sibling services, raised separately:

- `AdvancedDnaMatchingService::performBasicMatching()` reports `0.0` confidence and quality score for a kit it could not read, rendered as `0.00` on the triangulation page.
- `FacialRecognitionService` substitutes `0` for an absent provider measurement, into a `photo_tags.confidence` column that is already nullable.
