### PR TITLE
fix(zoom): generate meeting passwords from a cryptographically secure source

### DIFF
--- a/app/Services/VideoConferencing/ZoomService.php
+++ b/app/Services/VideoConferencing/ZoomService.php
@@ -5,6 +5,7 @@ namespace App\Services\VideoConferencing;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 
 class ZoomService implements VideoConferencingInterface
 {
@@ -218,8 +219,28 @@ class ZoomService implements VideoConferencingInterface
         return $data['access_token'];
     }
 
+    /**
+     * This gates access to a real meeting, so it needs a cryptographically
+     * secure source. It was str_shuffle() over a fixed alphabet, taking the
+     * first eight characters.
+     *
+     * The defect that matters is predictability: str_shuffle draws from the
+     * Mt19937 generator, whose internal state is recoverable from observed
+     * output, so seeing enough passcodes lets you predict the next one.
+     *
+     * Permuting rather than sampling was the second, much smaller problem —
+     * every character was guaranteed distinct, giving 62P8 rather than 62^8.
+     * That is worth only 0.68 bits (46.95 -> 47.63), so it is not the reason
+     * for this change; it is simply the property a test can pin, since a
+     * repeated character is impossible under a permutation and commonplace
+     * under sampling.
+     *
+     * Str::random is backed by random_bytes. Its base64 alphabet has '+' and
+     * '/' removed, which is rejection sampling and preserves uniformity, so
+     * the result is uniform over the same 62 alphanumerics Zoom accepts.
+     */
     protected function generatePassword(): string
     {
-        return substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 8);
+        return Str::random(8);
     }
 }

--- a/tests/Feature/Services/VideoConferencing/ZoomMeetingPasswordTest.php
+++ b/tests/Feature/Services/VideoConferencing/ZoomMeetingPasswordTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services\VideoConferencing;
+
+use App\Services\VideoConferencing\ZoomService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Meeting passwords gate access to real meetings and are sent to Zoom.
+ *
+ * They were produced by str_shuffle() on a fixed alphabet, taking the first
+ * eight characters. The defect that matters is predictability — str_shuffle
+ * draws from Mt19937, whose state is recoverable from observed output.
+ *
+ * Be clear about what this file does and does not pin. It asserts that
+ * characters are sampled with replacement, which fails deterministically
+ * against a permutation. It does NOT assert the source is cryptographically
+ * secure, and no reasonable unit test can: a regression to
+ * `$alphabet[mt_rand(0, 61)]` in a loop samples with replacement and would
+ * pass everything here while restoring the actual vulnerability.
+ *
+ * That property is held by static analysis instead — the fabrication gate
+ * (issue 05) classifies non-cryptographic generators separately from ordinary
+ * allowlisted randomness precisely so this cannot quietly come back.
+ *
+ * These tests capture the password actually sent to Zoom rather than reaching
+ * into the generator, so they describe what an attacker would observe.
+ */
+class ZoomMeetingPasswordTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'services.zoom.base_url' => 'https://api.zoom.us/v2',
+            'services.zoom.key' => 'test-key',
+            'services.zoom.secret' => 'test-secret',
+            'services.zoom.account_id' => 'test-account',
+        ]);
+    }
+
+    public function test_the_password_sent_to_zoom_is_eight_alphanumeric_characters(): void
+    {
+        $password = $this->capturePassword();
+
+        $this->assertSame(8, strlen($password));
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{8}$/', $password);
+    }
+
+    /**
+     * The load-bearing assertion. Under str_shuffle a repeated character is
+     * impossible by construction, so this fails deterministically against the
+     * old implementation.
+     *
+     * Sampling 8 characters with replacement from 62 leaves all eight distinct
+     * 62.44% of the time, so a repeat appears in ~37.6% of draws. Over 60 draws
+     * a false negative has probability 0.6244^60, about 5e-13 — negligible,
+     * and 60 is cheap enough that this does not dominate the suite.
+     */
+    public function test_passwords_are_sampled_with_replacement_so_characters_can_repeat(): void
+    {
+        $sawRepeat = false;
+
+        for ($i = 0; $i < 60; $i++) {
+            $password = $this->capturePassword();
+
+            if (count(array_unique(str_split($password))) < 8) {
+                $sawRepeat = true;
+                break;
+            }
+        }
+
+        $this->assertTrue(
+            $sawRepeat,
+            'No password in 60 draws contained a repeated character, which means '
+            .'the alphabet is being permuted rather than sampled. That shrinks the '
+            .'keyspace and is what str_shuffle() did.'
+        );
+    }
+
+    public function test_passwords_differ_between_meetings(): void
+    {
+        $passwords = [];
+
+        for ($i = 0; $i < 50; $i++) {
+            $passwords[] = $this->capturePassword();
+        }
+
+        $this->assertCount(50, array_unique($passwords));
+    }
+
+    public function test_no_password_is_sent_when_one_is_not_required(): void
+    {
+        $payload = $this->capturePayload(['require_password' => false]);
+
+        $this->assertArrayNotHasKey('password', $payload);
+    }
+
+    private function capturePassword(): string
+    {
+        return $this->capturePayload()['password'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function capturePayload(array $overrides = []): array
+    {
+        Http::fake([
+            '*/oauth/token' => Http::response(['access_token' => 'test-token', 'expires_in' => 3600]),
+            '*/users/me/meetings' => Http::response([
+                'id' => 123456789,
+                'password' => 'echoed',
+                'start_url' => 'https://zoom.us/s/123',
+                'join_url' => 'https://zoom.us/j/123',
+                // The service dereferences all of these without a null guard,
+                // so a real Zoom response omitting any one of them would fatal.
+                'uuid' => 'abc==',
+                'host_id' => 'host-1',
+                'topic' => 'Family research call',
+                'status' => 'waiting',
+                'created_at' => '2026-07-19T10:00:00Z',
+            ]),
+        ]);
+
+        (new ZoomService)->createMeeting([
+            'title' => 'Family research call',
+            'start_time' => '2026-08-01 10:00:00',
+            'end_time' => '2026-08-01 11:00:00',
+            'timezone' => 'UTC',
+        ] + $overrides);
+
+        // Http::recorded()'s argument is a filter predicate, not an iterator, and
+        // it returns early without calling it when nothing was recorded — using
+        // it for side effects yields a confusing TypeError rather than a failed
+        // assertion. Filter the collection instead.
+        $request = Http::recorded()
+            ->map(fn (array $pair) => $pair[0])
+            ->first(fn ($recorded) => str_contains($recorded->url(), '/users/me/meetings'));
+
+        $this->assertNotNull($request, 'No meeting-creation request reached Zoom.');
+
+        return $request->data();
+    }
+}


### PR DESCRIPTION
## The bug

Zoom meeting passcodes were `substr(str_shuffle($alphabet), 0, 8)`. They gate access to real meetings and are sent to Zoom.

**The defect that matters is predictability.** `str_shuffle` draws from Mt19937, whose internal state is recoverable from observed output — see enough passcodes and you can predict the next one.

Permuting rather than sampling was a second, **much smaller** problem: every character was guaranteed distinct, giving 62P8 rather than 62^8. That is worth **0.68 bits** (46.95 → 47.63). It is not the reason for this change, and I've said so in the code rather than letting the keyspace argument carry weight it doesn't deserve. It is, however, the property a test can pin — a repeated character is impossible under a permutation and appears in ~37.6% of sampled draws.

## The fix

`Str::random(8)`, which is backed by `random_bytes`. Its base64 alphabet has `+` and `/` removed — that is rejection sampling, which preserves uniformity — so the output is uniform over the same 62 alphanumerics Zoom already accepted. Length, alphabet, and the nullable `meeting_password` column are unchanged.

## What the tests do and do not prove

They capture the password actually sent to Zoom via `Http::fake` rather than reaching into the generator, so they assert what an attacker would observe.

They are explicit about their own limit: **they pin sampling-with-replacement, not the source of randomness.** A regression to `$alphabet[mt_rand(0, 61)]` in a loop would pass every test here while restoring the vulnerability. No reasonable unit test closes that gap. It belongs to the fabrication gate (issue 05), which classifies non-cryptographic generators separately from ordinary allowlisted randomness for exactly this reason.

The load-bearing test was verified revert-sensitive: restoring `str_shuffle` fails it with `No password in 60 draws contained a repeated character`. 60 draws gives a false-negative probability of ~5e-13.

- Full suite: **596 passed**, 12 skipped
- PHPStan: clean
- Pint: clean on changed files

## Sweep

No other security-bearing value in the application uses a non-cryptographic generator. Invitation tokens (`VirtualEventAttendee`) and team-invite tokens (`InviteTeamMember`) already use `Str::random`. The two remaining `uniqid()` calls are a gated-off mock identifier and a Google Calendar idempotency key — neither is a secret. Teams and Google Meet hardcode `password => null`; Zoom was the only generator.

## Known and NOT fixed here

**This code path cannot currently execute.** `config/services.php` has no `zoom` block at all, so `isConfigured()` is always false and `validateConfiguration()` throws on every call. The tests only reach the generator because they inject config at runtime. Adding that config is issue 08 — but the generator needed to be sound *before* it lands, which is why this is worth merging now rather than after.

**Unguarded response dereferences.** `createMeeting()` reads `uuid`, `host_id`, `topic`, `status`, `created_at` without a null guard, and throws *after* the meeting already exists at Zoom — orphaning it. `getMeetingDetails()` is worse: it also reads `start_time`, which Zoom omits for recurring meetings with no fixed time, and it is reached from `updateMeeting()` whose `?? []` catches a null response but cannot catch the exception thrown below it. Neither is tested. Raised separately.
