### PR TITLE
fix(dna): prune match rows recorded from comparisons that never ran

### DIFF
--- a/app/Console/Commands/PruneNoComparisonMatchesCommand.php
+++ b/app/Console/Commands/PruneNoComparisonMatchesCommand.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\DnaMatching;
+use App\Services\Dna\RelationshipEstimator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Removes dna_matchings rows that record a comparison which never happened.
+ *
+ * When a kit file could not be read, AdvancedDnaMatchingService did not throw —
+ * it logged and returned performBasicMatching() under the label
+ * "Unknown (Basic Analysis)". The queued job persisted that verbatim, wrote a
+ * reciprocal row for the other user, and notified them that a new DNA match had
+ * been found. The job no longer does this, but the rows it already wrote are
+ * still in the database and still render as findings.
+ *
+ * Those rows are worse than they first appear. Until 6df2fd87 (2026-07-16)
+ * performBasicMatching() did not return zeroes — it returned
+ * random_int(10, 150) shared cM, random_int(5, 25) segments and a matching
+ * largest-segment figure. That range is plausible third-to-fourth-cousin
+ * territory, so a researcher had no way to tell an invented match from a real
+ * one. Any database in service before that commit is likely to hold fabricated
+ * genetic measurements under this label, not merely honest zeroes.
+ *
+ * The two zero-centimorgan cases are reliably distinguishable, which is what
+ * makes this safe to automate:
+ *
+ *   no comparison ran   -> 'Unknown (Basic Analysis)'   (performBasicMatching)
+ *   compared, 0 shared  -> 'Unrelated / No significant match'  (RelationshipEstimator)
+ *
+ * RelationshipEstimator cannot emit the former — its floor label is
+ * 'Unrelated / No significant match' — so this is an exact marker, not a
+ * heuristic on the cM value. Rows in the second group are genuine findings and
+ * are deliberately left alone.
+ *
+ * Deletion rather than recomputation: a row asserting a comparison that did not
+ * happen has no salvageable content, and the queued job will compare those kits
+ * again on its next run if their files are now readable. Recomputing here would
+ * duplicate that logic for no gain.
+ *
+ * This is a command rather than a migration on purpose. Migrations run
+ * unattended on deploy, and this deletes rows a user may have seen; an operator
+ * should be able to inspect the count with --dry-run first.
+ */
+class PruneNoComparisonMatchesCommand extends Command
+{
+    /**
+     * Labels that mark a row as recording something other than a real
+     * comparison.
+     *
+     * Caveat worth knowing before running this: predicted_relationship is a
+     * free-text TextInput on DnaMatchingResource, so a user with edit rights
+     * could in principle type one of these strings into a hand-curated row and
+     * have it pruned. Constraining that field to the estimator's own labels
+     * would close the gap; until then --dry-run and --export exist so nothing
+     * disappears unseen.
+     *
+     * 'Unknown (Basic Analysis)' — performBasicMatching(), when a kit could not
+     * be read. This is the population this command exists for.
+     *
+     * 'Unknown (Fallback Analysis)' — the removed MatchKitsCommand, which
+     * invented centimorgans with random_int() in its catch block. It never set
+     * user_id, which is NOT NULL, so every insert threw and no such row should
+     * exist. It is included because if one somehow does, its values were
+     * fabricated outright and it is the last thing that should survive a prune.
+     */
+    private const NO_COMPARISON_LABELS = [
+        'Unknown (Basic Analysis)',
+        'Unknown (Fallback Analysis)',
+    ];
+
+    #[\Override]
+    protected $signature = 'dna:prune-no-comparison-matches
+                            {--dry-run : Report what would be deleted without deleting it}
+                            {--export= : Write the matched rows to this JSON path before deleting}
+                            {--force : Skip the confirmation prompt}';
+
+    #[\Override]
+    protected $description = 'Delete DNA match rows recorded from comparisons that never ran';
+
+    public function handle(): int
+    {
+        $query = DnaMatching::withoutGlobalScopes()
+            ->whereIn('predicted_relationship', self::NO_COMPARISON_LABELS);
+
+        $count = (clone $query)->count();
+
+        // Reported for contrast so the operator can see the distinction being
+        // drawn, and satisfy themselves that genuine findings are untouched.
+        $genuineZeroes = DnaMatching::withoutGlobalScopes()
+            ->where('predicted_relationship', RelationshipEstimator::NO_MATCH_LABEL)
+            ->count();
+
+        $this->reportUnclassified();
+
+        if ($count === 0) {
+            $this->info('No rows recorded from comparisons that never ran.');
+            $this->line("Genuine 'compared, nothing shared' results left alone: {$genuineZeroes}");
+
+            return Command::SUCCESS;
+        }
+
+        $this->warn("{$count} row(s) record a comparison that never ran.");
+        $this->line("Genuine 'compared, nothing shared' results that will be kept: {$genuineZeroes}");
+
+        if ($this->option('dry-run')) {
+            $this->info("Dry run: {$count} row(s) would be deleted. Nothing was changed.");
+
+            return Command::SUCCESS;
+        }
+
+        $this->warn('dna_matchings has no soft deletes — this cannot be undone.');
+
+        if (! $this->option('force') && ! $this->confirm("Delete {$count} row(s)?")) {
+            $this->info('Aborted. Nothing was changed.');
+
+            return Command::SUCCESS;
+        }
+
+        // dna_matchings has no soft deletes, so this cannot be undone. Give the
+        // operator a way to keep the evidence before it goes.
+        if ($path = $this->option('export')) {
+            File::put($path, (clone $query)->get()->toJson(JSON_PRETTY_PRINT));
+            $this->info("Exported {$count} row(s) to {$path}");
+        }
+
+        $deleted = $query->delete();
+
+        // Both directions of a pairing carry the same label, so a reciprocal row
+        // is removed by the same predicate as its counterpart — no orphans.
+        $this->info("Deleted {$deleted} row(s).");
+        Log::info("Pruned {$deleted} DNA match row(s) recorded from comparisons that never ran.");
+
+        // Users were notified when these rows were written. The notification
+        // carries only a count, not the identity of the supposed match, so
+        // there is nothing to correct beyond removing the rows themselves; a
+        // user following an old notification simply finds nothing there.
+        $this->line('Note: affected users may have received a "new DNA match" notification at the time.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Rows whose label this command does not recognise are reported rather than
+     * passed over in silence. A row with a NULL or unfamiliar
+     * predicted_relationship might be a legitimate finding from an older
+     * version, or another no-comparison result recorded under a label that no
+     * longer exists in the code — this command cannot tell, so it says so
+     * instead of guessing.
+     */
+    private function reportUnclassified(): void
+    {
+        $known = [...self::NO_COMPARISON_LABELS, ...RelationshipEstimator::labels()];
+
+        $unclassified = DnaMatching::withoutGlobalScopes()
+            ->where(function ($query) use ($known): void {
+                $query->whereNull('predicted_relationship')
+                    ->orWhereNotIn('predicted_relationship', $known);
+            })
+            ->count();
+
+        if ($unclassified === 0) {
+            return;
+        }
+
+        $this->warn("{$unclassified} row(s) carry a label this command does not recognise.");
+        $this->line('They are left untouched. Older versions of the matching engine used labels');
+        $this->line('that no longer exist in the code, so these cannot be classified automatically.');
+    }
+}

--- a/app/Providers/DnaServiceProvider.php
+++ b/app/Providers/DnaServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Console\Commands\BulkImportDnaCommand;
 use App\Console\Commands\ProcessLargeScaleDnaCommand;
+use App\Console\Commands\PruneNoComparisonMatchesCommand;
 use App\Console\Commands\TriangulateDnaCommand;
 use App\Services\AdvancedDnaMatchingService;
 use App\Services\DnaImportService;
@@ -41,6 +42,7 @@ class DnaServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 ProcessLargeScaleDnaCommand::class,
+                PruneNoComparisonMatchesCommand::class,
                 BulkImportDnaCommand::class,
                 TriangulateDnaCommand::class,
             ]);

--- a/app/Services/Dna/RelationshipEstimator.php
+++ b/app/Services/Dna/RelationshipEstimator.php
@@ -38,6 +38,12 @@ class RelationshipEstimator
         [20.0, 'Distant Cousin', 'low'],
     ];
 
+    /**
+     * The label emitted when a real comparison found nothing significant.
+     * Distinct from the matching service's "no comparison ran" labels.
+     */
+    public const NO_MATCH_LABEL = 'Unrelated / No significant match';
+
     // cM below this is treated as noise / no genealogically significant match.
     private const NO_MATCH_THRESHOLD = 20.0;
 
@@ -47,11 +53,23 @@ class RelationshipEstimator
     /**
      * @return array{predicted_relationship: string, confidence_level: string, match_quality_score: float}
      */
+    /**
+     * Every relationship label this estimator can emit. Consumers that need to
+     * tell a stored row apart from one written by some other path — a prune, an
+     * audit — must be able to ask rather than hardcode the list.
+     *
+     * @return list<string>
+     */
+    public static function labels(): array
+    {
+        return [self::NO_MATCH_LABEL, ...array_column(self::BANDS, 1)];
+    }
+
     public function estimate(float $totalSharedCm): array
     {
         $cm = max(0.0, $totalSharedCm);
 
-        $relationship = 'Unrelated / No significant match';
+        $relationship = self::NO_MATCH_LABEL;
         $confidence = 'low';
 
         if ($cm >= self::NO_MATCH_THRESHOLD) {

--- a/tests/Feature/Commands/PruneNoComparisonMatchesTest.php
+++ b/tests/Feature/Commands/PruneNoComparisonMatchesTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commands;
+
+use App\Models\DnaMatching;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Before the matching job was fixed, an unreadable kit produced a durable
+ * dna_matchings row: the service's zeroed "basic analysis" result persisted
+ * verbatim, plus a reciprocal row for the other user, plus a notification
+ * saying a new DNA match had been found. Those rows are still in the database.
+ *
+ * They are distinguishable from a genuine finding of nothing shared, which is
+ * the whole reason this can be done safely:
+ *
+ *   no comparison ran   -> 'Unknown (Basic Analysis)'  (performBasicMatching)
+ *   compared, 0 shared  -> 'Unrelated / No significant match'  (RelationshipEstimator)
+ *
+ * RelationshipEstimator never emits the former, so the label is a reliable
+ * marker rather than a heuristic.
+ */
+class PruneNoComparisonMatchesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_deletes_rows_where_no_comparison_ran(): void
+    {
+        $this->match('Unknown (Basic Analysis)', 0.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->assertSuccessful();
+
+        $this->assertSame(0, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * The removed MatchKitsCommand used a different label and fabricated its
+     * centimorgans with random_int(). It never persisted a row — user_id is
+     * NOT NULL and it never set it — but if one exists it is invented data.
+     */
+    public function test_it_deletes_rows_from_the_removed_fabricating_command(): void
+    {
+        $this->match('Unknown (Fallback Analysis)', 87.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->assertSuccessful();
+
+        $this->assertSame(0, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    public function test_it_keeps_a_genuine_finding_of_nothing_shared(): void
+    {
+        $this->match('Unrelated / No significant match', 0.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->assertSuccessful();
+
+        // Zero shared centimorgans is a real result when a comparison actually
+        // ran. Deleting it would destroy a finding.
+        $this->assertSame(1, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    public function test_it_keeps_real_matches(): void
+    {
+        $this->match('Second Cousin', 212.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->assertSuccessful();
+
+        $this->assertSame(1, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * The job wrote both directions with the same values, so both carry the
+     * marker and both must go. A surviving reciprocal would leave one party
+     * still looking at a match that never happened.
+     */
+    public function test_reciprocal_rows_are_removed_together(): void
+    {
+        $a = User::factory()->withPersonalTeam()->create();
+        $b = User::factory()->withPersonalTeam()->create();
+
+        $this->match('Unknown (Basic Analysis)', 0.0, $a, $b);
+        $this->match('Unknown (Basic Analysis)', 0.0, $b, $a);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->assertSuccessful();
+
+        $this->assertSame(0, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * A pairing where only one side carries the marker — reachable if the
+     * second save() failed, or via the free-text relationship field on
+     * DnaMatchingResource. The marked row goes; the unmarked one is a genuine
+     * finding and must not be swept up with it.
+     */
+    public function test_only_the_marked_side_of_a_pairing_is_deleted(): void
+    {
+        $a = User::factory()->withPersonalTeam()->create();
+        $b = User::factory()->withPersonalTeam()->create();
+
+        $this->match('Unknown (Basic Analysis)', 0.0, $a, $b);
+        $kept = $this->match('2nd-3rd Cousin', 120.0, $b, $a);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->assertSuccessful();
+
+        $rows = DnaMatching::withoutGlobalScopes()->get();
+        $this->assertCount(1, $rows);
+        $this->assertSame($kept->id, $rows->first()->id);
+    }
+
+    /**
+     * A label from an older matching engine is neither prunable nor a current
+     * estimator label. It must survive and be reported, not silently ignored.
+     */
+    public function test_an_unrecognised_label_is_kept_and_reported(): void
+    {
+        $this->match('No significant relationship detected', 0.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->expectsOutputToContain('does not recognise')
+            ->assertSuccessful();
+
+        $this->assertSame(1, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * The confirmation prompt is the only thing between a mistaken invocation
+     * and permanent loss, so declining it needs to be proven to do nothing.
+     */
+    public function test_declining_the_confirmation_deletes_nothing(): void
+    {
+        $this->match('Unknown (Basic Analysis)', 0.0);
+
+        $this->artisan('dna:prune-no-comparison-matches')
+            ->expectsConfirmation('Delete 1 row(s)?', 'no')
+            ->expectsOutputToContain('Aborted')
+            ->assertSuccessful();
+
+        $this->assertSame(1, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    public function test_it_exports_the_rows_before_deleting_them(): void
+    {
+        $this->match('Unknown (Basic Analysis)', 0.0);
+        $path = storage_path('app/pruned-matches-test.json');
+        @unlink($path);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true, '--export' => $path])
+            ->assertSuccessful();
+
+        $this->assertFileExists($path);
+        $exported = json_decode(file_get_contents($path), true);
+        $this->assertCount(1, $exported);
+        $this->assertSame('Unknown (Basic Analysis)', $exported[0]['predicted_relationship']);
+
+        $this->assertSame(0, DnaMatching::withoutGlobalScopes()->count());
+        @unlink($path);
+    }
+
+    public function test_dry_run_reports_without_deleting(): void
+    {
+        $this->match('Unknown (Basic Analysis)', 0.0);
+        $this->match('Second Cousin', 212.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--dry-run' => true])
+            ->expectsOutputToContain('1 row(s) would be deleted')
+            ->assertSuccessful();
+
+        $this->assertSame(2, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    public function test_it_reports_when_there_is_nothing_to_do(): void
+    {
+        $this->match('Second Cousin', 212.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->expectsOutputToContain('No rows')
+            ->assertSuccessful();
+
+        $this->assertSame(1, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * A row this command cannot classify must survive and be reported, not be
+     * swept up by a looser predicate such as "zero centimorgans".
+     */
+    public function test_unclassifiable_rows_are_kept_and_reported(): void
+    {
+        $this->match(null, 0.0);
+
+        $this->artisan('dna:prune-no-comparison-matches', ['--force' => true])
+            ->expectsOutputToContain('cannot be classified')
+            ->assertSuccessful();
+
+        $this->assertSame(1, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    private function match(?string $relationship, float $cm, ?User $owner = null, ?User $other = null): DnaMatching
+    {
+        $owner ??= User::factory()->withPersonalTeam()->create();
+        $other ??= User::factory()->withPersonalTeam()->create();
+
+        return DnaMatching::withoutGlobalScopes()->create([
+            'team_id' => $owner->current_team_id,
+            'user_id' => $owner->id,
+            'match_id' => $other->id,
+            'match_name' => $other->name,
+            'file1' => 'kit_a.txt',
+            'file2' => 'kit_b.txt',
+            'total_shared_cm' => $cm,
+            'largest_cm_segment' => $cm > 0 ? 45.0 : 0.0,
+            'predicted_relationship' => $relationship,
+            'analysis_date' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
Adds `dna:prune-no-comparison-matches`, which removes `dna_matchings` rows written when a kit file could not be read. The matching job no longer creates them (#1524), but the ones it already wrote are still in the database and still render as findings.

## Correcting something I got wrong

I claimed in several earlier PRs that **no fabricated row was ever written**. That was true only of the removed `MatchKitsCommand`.

Until `6df2fd87` (2026-07-16) the matching service's own `performBasicMatching()` returned:

```php
$totalSharedCm    = random_int(10, 150);
$largestCmSegment = random_int(5, min($totalSharedCm, 50));
'predicted_relationship' => 'Unknown (Basic Analysis)',
'shared_segments_count'  => random_int(5, 25),
```

The queued job persisted that verbatim, **in both directions**, with no guard — the `comparison_performed` check only arrived in #1524.

10–150 cM is plausible third-to-fourth-cousin territory. A researcher had no way to tell an invented match from a real one. **Any database in service before that commit is likely to hold fabricated genetic measurements, not merely honest zeroes.** The ticket has been corrected; the earlier finding was propagated through several PRs before a history check caught it.

## Selection is by label, never by centimorgan value

The two zero-cM cases are distinguishable, and that distinction is the entire basis for doing this safely:

| | `predicted_relationship` | written by |
|---|---|---|
| no comparison ran | `Unknown (Basic Analysis)` | `performBasicMatching()` |
| compared, nothing shared | `Unrelated / No significant match` | `RelationshipEstimator` |

A cM-based predicate would be wrong in **both** directions — it would miss the fabricated 10–150 cM rows and destroy genuine findings of nothing shared.

`'Unknown (Fallback Analysis)'` from the removed `MatchKitsCommand` is covered too. No such row should exist, but if one does its values were invented outright.

Verified against the full history of the column: exactly four literals have ever been assigned to it, and both `Unknown` variants are covered.

## Safety

`dna_matchings` has **no soft deletes**, so:

- `--export=path` writes the matched rows to JSON before anything is removed
- `--dry-run` reports without touching them
- the confirmation prompt is covered by a test proving that declining it changes nothing
- no foreign key anywhere references `dna_matchings.id`, so there are no orphans

Rows the command **cannot** classify are reported rather than passed over: anything whose label is neither a prune marker nor one of `RelationshipEstimator`'s own labels is counted and left alone. That required the estimator to expose its label set, which it now does.

## One caveat, recorded rather than glossed

`predicted_relationship` is a free-text `TextInput` on `DnaMatchingResource`, reachable via the create/edit pages. A user with edit rights could type a prune marker into a hand-curated row and have it deleted. Constraining that field to the estimator's labels would close the gap; until then `--dry-run` and `--export` mean nothing disappears unseen. Flagged in the command's own docblock.

## Tests

**12 tests**, full suite **633 passed**, PHPStan clean, Pint clean.

The safety property is tested as hard as the deletion property — an earlier draft was not. Specifically covered after review:

- a pairing where **only one side** carries the marker (the reciprocal test alone passes for any label-based implementation, so it proved nothing on its own)
- an unrecognised legacy label survives and is reported
- a NULL label survives and is reported
- declining the confirmation deletes nothing
- the export file contains the rows before they go
