### PR TITLE
fix(dna): reject a meaningless triangulation threshold, and compare all kits

### DIFF
--- a/app/Console/Commands/TriangulateDnaCommand.php
+++ b/app/Console/Commands/TriangulateDnaCommand.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\Dna;
+use App\Services\Dna\SegmentMatcher;
 use App\Services\DnaTriangulationService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
@@ -52,6 +53,24 @@ class TriangulateDnaCommand extends Command
 
     protected function handleOneToManyTriangulation(int $baseKitId, array $compareKits, float $minCm, bool $store): int
     {
+        // A threshold of zero asks for every pair regardless of shared DNA,
+        // which is not a triangulation. Note this is an input-sanity rule, not
+        // a correctness fix: pairs that were never compared are already
+        // excluded by the comparison-performed guard in the service, whatever
+        // the threshold.
+        //
+        // The floor is the segment matcher's minimum because a *non-zero* total
+        // is a sum of segments that each cleared it, so it cannot be less than
+        // 7 cM. (Zero itself is of course reported, and is the case this rule
+        // exists to reject.) Any threshold in (0, 7] therefore behaves
+        // identically to 7, and offering finer values implies a precision the
+        // pipeline does not have.
+        if ($minCm < SegmentMatcher::MIN_CM) {
+            $this->error('Minimum cM threshold must be at least '.SegmentMatcher::MIN_CM.' — below that every value behaves the same.');
+
+            return Command::FAILURE;
+        }
+
         $this->info("Starting one-to-many triangulation for kit ID: {$baseKitId}");
         $this->info("Minimum cM threshold: {$minCm}");
         $this->newLine();

--- a/app/Filament/App/Pages/DnaTriangulationPage.php
+++ b/app/Filament/App/Pages/DnaTriangulationPage.php
@@ -3,6 +3,7 @@
 namespace App\Filament\App\Pages;
 
 use App\Models\Dna;
+use App\Services\Dna\SegmentMatcher;
 use App\Services\DnaTriangulationService;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -73,10 +74,20 @@ class DnaTriangulationPage extends Page implements HasForms
                 TextInput::make('min_cm')
                     ->label('Minimum cM Threshold')
                     ->numeric()
+                    ->required()
                     ->default(20)
-                    ->minValue(0)
+                    // Zero asks for every pair regardless of shared DNA, which is
+                    // not a triangulation. An input-sanity rule, not a correctness
+                    // one — the service's comparison-performed guard already
+                    // excludes uncompared pairs at any threshold.
+                    //
+                    // The floor is the segment matcher's minimum because a
+                    // *non-zero* total is a sum of segments that each cleared it.
+                    // Zero is of course reportable; it is the value being
+                    // rejected. So anything in (0, 7] behaves identically to 7.
+                    ->minValue(SegmentMatcher::MIN_CM)
                     ->maxValue(500)
-                    ->helperText('Only show matches with at least this many shared centiMorgans'),
+                    ->helperText('Only show matches with at least this many shared centiMorgans (minimum '.SegmentMatcher::MIN_CM.')'),
             ])
             ->statePath('data');
     }
@@ -90,8 +101,12 @@ class DnaTriangulationPage extends Page implements HasForms
 
             $this->results = $triangulationService->triangulateOneAgainstMany(
                 $data['base_kit_id'],
-                $data['compare_kit_ids'] ?? null,
-                $data['min_cm'] ?? 20.0
+                // An empty multi-select yields [], not null, and [] means
+                // whereIn('id', []) — comparing against nothing at all. The
+                // field's own helper text promises the opposite, so normalise
+                // it here rather than leave the promise false.
+                filled($data['compare_kit_ids'] ?? null) ? $data['compare_kit_ids'] : null,
+                $data['min_cm']
             );
 
             // Store results in database

--- a/tests/Feature/Dna/TriangulationThresholdTest.php
+++ b/tests/Feature/Dna/TriangulationThresholdTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Dna;
+
+use App\Filament\App\Pages\DnaTriangulationPage;
+use App\Models\Dna;
+use App\Models\DnaMatching;
+use App\Models\User;
+use App\Services\Dna\SegmentMatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * A minimum shared centimorgan threshold of zero asks for every pair regardless
+ * of shared DNA, which has no genealogical meaning — triangulation is precisely
+ * the business of finding kits that share segments.
+ *
+ * It was also load-bearing by accident: a kit that could not be read reports
+ * 0.0 cM, so any positive threshold excluded it. At zero that filter stopped
+ * working. The explicit comparison-performed guard now covers that case
+ * independently, so correctness no longer rests on the threshold happening to
+ * be greater than zero — but the input should still reject a value that cannot
+ * mean anything.
+ *
+ * The floor is SegmentMatcher::MIN_CM, because a *non-zero* total is a sum of
+ * segments that each cleared it. Zero is of course reportable — it is the value
+ * being rejected — so every threshold in (0, 7] behaves identically to 7, and
+ * offering finer values implies a precision the pipeline does not have.
+ *
+ * This is an input-sanity rule rather than a correctness fix. Uncompared pairs
+ * are already excluded by the service's comparison-performed guard whatever the
+ * threshold, which DnaTriangulationNoComparisonTest proves at a 0.0 threshold.
+ */
+class TriangulationThresholdTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_the_command_rejects_a_zero_threshold(): void
+    {
+        $kit = $this->kit('a', 'kit_a.txt');
+
+        $this->artisan('dna:triangulate', ['base_kit_id' => $kit->id, '--min-cm' => 0])
+            ->expectsOutputToContain('Minimum cM threshold must be at least')
+            ->assertFailed();
+    }
+
+    public function test_the_command_rejects_a_negative_threshold(): void
+    {
+        $kit = $this->kit('a', 'kit_a.txt');
+
+        $this->artisan('dna:triangulate', ['base_kit_id' => $kit->id, '--min-cm' => -5])
+            ->assertFailed();
+    }
+
+    public function test_the_command_rejects_a_threshold_below_the_segment_floor(): void
+    {
+        $kit = $this->kit('a', 'kit_a.txt');
+
+        $this->artisan('dna:triangulate', ['base_kit_id' => $kit->id, '--min-cm' => 3])
+            ->assertFailed();
+    }
+
+    public function test_the_command_accepts_the_segment_floor_itself(): void
+    {
+        $kit = $this->kit('a', 'kit_a.txt');
+
+        $this->artisan('dna:triangulate', ['base_kit_id' => $kit->id, '--min-cm' => SegmentMatcher::MIN_CM])
+            ->assertSuccessful();
+    }
+
+    public function test_the_page_rejects_a_zero_threshold(): void
+    {
+        Storage::fake('private');
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $base = $this->kit('a', 'kit_a.txt', $user, withFile: true);
+        $this->kit('b', 'kit_b.txt', $user, withFile: true);
+
+        Livewire::test(DnaTriangulationPage::class)
+            ->set('data.base_kit_id', $base->id)
+            ->set('data.min_cm', 0)
+            ->call('runTriangulation')
+            ->assertHasErrors('data.min_cm');
+
+        // The kits ARE readable here, so this proves validation stopped the run.
+        // An earlier version used unreadable kits, where nothing would persist
+        // regardless and the assertion could not fail.
+        $this->assertSame(0, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * The positive control. Without it, tightening minValue to something absurd
+     * would leave every other test in this file green.
+     */
+    public function test_the_page_accepts_a_valid_threshold_and_stores_the_match(): void
+    {
+        Storage::fake('private');
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $base = $this->kit('a', 'kit_a.txt', $user, withFile: true);
+        $this->kit('b', 'kit_b.txt', $user, withFile: true);
+
+        Livewire::test(DnaTriangulationPage::class)
+            ->set('data.base_kit_id', $base->id)
+            ->set('data.min_cm', SegmentMatcher::MIN_CM)
+            ->call('runTriangulation')
+            ->assertHasNoErrors();
+
+        // Two identical kits share their whole run, so this clears any threshold.
+        $this->assertGreaterThan(0, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * The compare-kits field says "Leave empty to compare against all kits".
+     * An empty multi-select yields [], not null, and [] reaches
+     * whereIn('id', []) — comparing against nothing. The helper text promised
+     * the opposite of what happened.
+     */
+    public function test_leaving_compare_kits_empty_compares_against_all_kits(): void
+    {
+        Storage::fake('private');
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $base = $this->kit('a', 'kit_a.txt', $user, withFile: true);
+        $this->kit('b', 'kit_b.txt', $user, withFile: true);
+
+        Livewire::test(DnaTriangulationPage::class)
+            ->set('data.base_kit_id', $base->id)
+            ->set('data.compare_kit_ids', [])
+            ->set('data.min_cm', SegmentMatcher::MIN_CM)
+            ->call('runTriangulation')
+            ->assertHasNoErrors();
+
+        $this->assertGreaterThan(0, DnaMatching::withoutGlobalScopes()->count());
+    }
+
+    /**
+     * The three-way path never reads the threshold, so it must not be rejected
+     * for one. An earlier version of this guard sat before the branch and failed
+     * a run for a value that path ignores.
+     */
+    public function test_three_way_triangulation_is_not_blocked_by_the_threshold(): void
+    {
+        Storage::fake('private');
+
+        $a = $this->kit('a', 'kit_a.txt');
+        $b = $this->kit('b', 'kit_b.txt');
+        $c = $this->kit('c', 'kit_c.txt');
+
+        $this->artisan('dna:triangulate', [
+            'base_kit_id' => $a->id,
+            '--three-way' => true,
+            '--three-way-kits' => [$a->id, $b->id, $c->id],
+            '--min-cm' => 0,
+        ])->assertSuccessful();
+    }
+
+    private function kit(string $varName, string $fileName, ?User $owner = null, bool $withFile = false): Dna
+    {
+        if ($withFile) {
+            Storage::disk('private')->put($fileName, $this->buildKit());
+        }
+
+        return Dna::create([
+            'name' => $varName,
+            'variable_name' => $varName,
+            'file_name' => $fileName,
+            'user_id' => ($owner ?? User::factory()->withPersonalTeam()->create())->id,
+            'consent_given' => true,
+            'consent_given_at' => now(),
+        ]);
+    }
+
+    /**
+     * Mirrors DnaMatchingPipelineTest's fixture: 600 SNPs on chr1 spanning
+     * ~18 Mb, all heterozygous AG, so two copies are fully half-identical.
+     */
+    private function buildKit(): string
+    {
+        $lines = [
+            '# This data file generated by 23andMe',
+            "rsid\tchromosome\tposition\tgenotype",
+        ];
+
+        for ($i = 0; $i < 600; $i++) {
+            $pos = 1_000_000 + $i * 30_000;
+            $lines[] = "rs{$i}\t1\t{$pos}\tAG";
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+}


### PR DESCRIPTION
## The threshold

Both the triangulation page and the console command accepted a minimum shared centimorgan threshold of **zero**, which asks for every pair regardless of shared DNA — not a triangulation. Both now require at least `SegmentMatcher::MIN_CM`.

**Be clear about what this is: an input-sanity rule, not a correctness fix.** Pairs that were never compared are already excluded by the comparison-performed guard in the service whatever the threshold, and two existing tests prove that at a zero threshold.

An earlier draft of these comments claimed *"no reported total can fall below MIN_CM"*. That is false — `0.0` is very much a reported total, and it is precisely the value being rejected. The true statement is that no **non-zero** total can fall below it, because a total is a sum of segments that each cleared it. That makes every threshold in (0, 7] behave identically to 7, so offering finer values implies a precision the pipeline does not have.

The same reasoning holds for `triangulation_score`, which sums per-chromosome minimums drawn from the same MIN_CM-gated segments — so the floor is safe for `findTriangulatedGroups` too.

### A bug I introduced and then fixed

The guard first sat in `handle()`, **before** the `--three-way` branch — so a three-way run was rejected for a threshold that path never reads. Moved into `handleOneToManyTriangulation()` where the value is actually used, with a test covering it.

## The bug the positive control found

The compare-kits field says *"Leave empty to compare against all kits"* and did **the opposite**.

An empty `->multiple()` Select yields `[]`, not `null`. So `$data['compare_kit_ids'] ?? null` passed `[]` straight into `whereIn('id', [])` — comparing against **nothing at all**. Anyone using the field's documented default got silently empty results.

This surfaced only because the new positive-control test stored no match. Without that test the page would have gone on quietly returning nothing for its own advertised behaviour.

## Test quality

The page test previously asserted nothing was stored using kits with **no files behind them** — so nothing would have been stored regardless and the assertion could not fail. It now uses readable kits, proving validation is what stopped the run.

Added a positive control asserting a valid threshold **does** store. Without it, tightening `minValue` to any absurd number would have left every other test in the file green.

- Full suite: **647 passed**, 12 skipped
- PHPStan: clean
- Pint: clean on changed files

## Ticket 14 criteria

| # | Criterion | Status |
|---|---|---|
| 1 | Threshold rejects zero in form and command | Met |
| 2 | Triangulation skips uncompared pairs independently of threshold | Already met by #1524; verified independently on this branch |
| 3 | Test covers zero/absent threshold not storing for unreadable kits | Met — and the assertion that claimed this before was the vacuous one |

Also drops a now-dead `?? 20.0` default at the call site, which had quietly diverged from the enforced floor.
