### PR TITLE
fix(dna): count comparisons that ran, and stop scoring kits nobody read

### DIFF
--- a/app/Services/AdvancedDnaMatchingService.php
+++ b/app/Services/AdvancedDnaMatchingService.php
@@ -163,14 +163,32 @@ class AdvancedDnaMatchingService
     {
         return [
             // No comparison took place — the kits could not be read or parsed.
-            // The zeros below are placeholders for "unknown", not measurements.
             'comparison_performed' => false,
+
+            // Confidence and quality are null rather than 0.0 because they are
+            // the two figures a caller renders as a measurement: "0% confidence"
+            // and "0.00 quality" both read as findings. Null cannot be mistaken
+            // for one, so a consumer that forgets to check comparison_performed
+            // fails visibly instead of quietly displaying a score.
+            //
+            // A genuinely measured zero is still 0.0 — see the success path.
+            // Suppressing that would be the same conflation in reverse.
+            'confidence_level' => null,
+            'match_quality_score' => null,
+
+            // These stay numeric, and the reason is blast radius rather than
+            // principle: 0.0 shared cM for a kit nobody read is the same untruth
+            // as 0.0 confidence. Every consumer of all five is behind the
+            // comparison_performed guard, so nulling all of them would be
+            // equally defensible and equally invisible. The two above are picked
+            // out because they are the figures a caller renders directly as a
+            // score — "0% confidence", "0.00 quality" — whereas these are
+            // compared against thresholds and summed, where a null would change
+            // arithmetic rather than clarify it.
             'total_cms' => 0.0,
             'largest_cm' => 0.0,
-            'confidence_level' => 0.0,
-            'predicted_relationship' => 'Unknown (Basic Analysis)',
             'shared_segments_count' => 0,
-            'match_quality_score' => 0.0,
+            'predicted_relationship' => 'Unknown (Basic Analysis)',
             'detailed_report' => [
                 'analysis_date' => now()->toISOString(),
                 'analysis_notes' => ['Basic analysis: DNA kit data could not be read for segment matching.'],

--- a/app/Services/DnaTriangulationService.php
+++ b/app/Services/DnaTriangulationService.php
@@ -37,7 +37,15 @@ class DnaTriangulationService
             ],
             'matches' => [],
             'triangulated_groups' => [],
-            'total_compared' => $compareKits->count(),
+            // total_compared used to be $compareKits->count() — the number of
+            // kits offered, counted before any of them were read — and the page
+            // labelled it "Total Compared". Ten kits of which four were
+            // unreadable reported ten comparisons: work attempted presented as
+            // work done. It now counts comparisons that actually ran, and the
+            // kits that could not be read are reported rather than dropped.
+            'total_attempted' => $compareKits->count(),
+            'total_compared' => 0,
+            'unreadable_kits' => 0,
             'significant_matches' => 0,
         ];
 
@@ -55,7 +63,15 @@ class DnaTriangulationService
                 // threshold of 0 — reachable from the UI, where the minimum cM
                 // field allows 0. Require an actual comparison, not just a
                 // number that happens to pass the filter.
-                if (($matchResult['comparison_performed'] ?? false) && $matchResult['total_cms'] >= $minSharedCm) {
+                if (! ($matchResult['comparison_performed'] ?? false)) {
+                    $results['unreadable_kits']++;
+
+                    continue;
+                }
+
+                $results['total_compared']++;
+
+                if ($matchResult['total_cms'] >= $minSharedCm) {
                     $results['matches'][] = [
                         'kit_id' => $compareKit->id,
                         'kit_name' => $compareKit->name,

--- a/resources/views/filament/app/pages/dna-triangulation-page.blade.php
+++ b/resources/views/filament/app/pages/dna-triangulation-page.blade.php
@@ -28,8 +28,16 @@
             <div class="space-y-4">
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <x-filament::card>
-                        <div class="text-sm text-gray-500">Total Compared</div>
+                        <div class="text-sm text-gray-500">Kits Compared</div>
                         <div class="text-2xl font-bold">{{ $results['total_compared'] ?? 0 }}</div>
+                        {{-- Kits that could not be read are named rather than
+                             silently dropped from the count. Counting them as
+                             compared would assert work that never happened. --}}
+                        @if (($results['unreadable_kits'] ?? 0) > 0)
+                            <div class="mt-1 text-xs text-amber-600">
+                                {{ $results['unreadable_kits'] }} of {{ $results['total_attempted'] ?? 0 }} kit(s) could not be read
+                            </div>
+                        @endif
                     </x-filament::card>
 
                     <x-filament::card>

--- a/tests/Feature/Services/Dna/UnmeasuredConfidenceTest.php
+++ b/tests/Feature/Services/Dna/UnmeasuredConfidenceTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services\Dna;
+
+use App\Models\Dna;
+use App\Models\User;
+use App\Services\AdvancedDnaMatchingService;
+use App\Services\Dna\SegmentMatcher;
+use App\Services\DnaTriangulationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * When a kit cannot be read, the matching service reported a confidence level
+ * of 0.0 and a match quality score of 0.0. Those read as measurements, and no
+ * measurement was taken.
+ *
+ * Every consumer today checks comparison_performed first, so no user currently
+ * sees these — that was fixed by the guards added alongside the matching job.
+ * This closes the hole underneath those guards: a future consumer that forgets
+ * the check should get an obviously absent value rather than a plausible zero
+ * it can quietly render as "0.00 quality" or "0% confidence".
+ *
+ * Same reasoning applied to handwriting transcription: absent is not zero, and
+ * a zero that was never measured is the more dangerous of the two because it
+ * looks like a result.
+ */
+class UnmeasuredConfidenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_an_unreadable_kit_reports_no_confidence_and_no_quality_score(): void
+    {
+        Storage::fake('private');
+
+        $result = (new AdvancedDnaMatchingService)
+            ->performAdvancedMatching('a', 'missing_a.txt', 'b', 'missing_b.txt');
+
+        $this->assertFalse($result['comparison_performed']);
+        $this->assertNull($result['confidence_level']);
+        $this->assertNull($result['match_quality_score']);
+    }
+
+    public function test_a_real_comparison_still_reports_both_figures(): void
+    {
+        Storage::fake('private');
+
+        $kit = $this->buildKit();
+        Storage::disk('private')->put('kit_a.txt', $kit);
+        Storage::disk('private')->put('kit_b.txt', $kit);
+
+        $result = (new AdvancedDnaMatchingService)
+            ->performAdvancedMatching('a', 'kit_a.txt', 'b', 'kit_b.txt');
+
+        $this->assertTrue($result['comparison_performed']);
+        $this->assertNotNull($result['confidence_level']);
+        $this->assertNotNull($result['match_quality_score']);
+        $this->assertGreaterThan(0, $result['match_quality_score']);
+    }
+
+    /**
+     * A genuinely measured zero must survive. Suppressing it on truthiness
+     * would reintroduce the same conflation from the other direction — that
+     * happened on the transcription page before it was corrected.
+     */
+    public function test_a_measured_zero_quality_score_is_reported_not_suppressed(): void
+    {
+        Storage::fake('private');
+
+        // Two kits with no allele in common on any shared position: a real
+        // comparison that finds nothing.
+        Storage::disk('private')->put('kit_a.txt', $this->buildKit('AA'));
+        Storage::disk('private')->put('kit_b.txt', $this->buildKit('GG'));
+
+        $result = (new AdvancedDnaMatchingService)
+            ->performAdvancedMatching('a', 'kit_a.txt', 'b', 'kit_b.txt');
+
+        $this->assertTrue($result['comparison_performed']);
+        // Pinned exactly, not merely non-null: asserting "not null" would pass
+        // if the score came back as any number at all.
+        $this->assertSame(0.0, $result['match_quality_score'], 'A measured zero must not become null.');
+        $this->assertSame(0.0, $result['total_cms']);
+    }
+
+    /**
+     * The triangulation summary counted the kits it was *given*, before any of
+     * them were read, and the page labelled that "Total Compared". Ten kits of
+     * which four were unreadable reported ten comparisons.
+     *
+     * A count of work attempted, presented as work done.
+     */
+    public function test_the_summary_counts_comparisons_that_ran_not_kits_attempted(): void
+    {
+        Storage::fake('private');
+
+        $kit = $this->buildKit();
+        Storage::disk('private')->put('kit_a.txt', $kit);
+        Storage::disk('private')->put('kit_b.txt', $kit);
+
+        $base = $this->kit('a', 'kit_a.txt');
+        $this->kit('b', 'kit_b.txt');
+        // Two records with no file behind them.
+        $this->kit('c', 'kit_c.txt');
+        $this->kit('d', 'kit_d.txt');
+
+        $results = app(DnaTriangulationService::class)
+            ->triangulateOneAgainstMany($base->id, null, SegmentMatcher::MIN_CM);
+
+        $this->assertSame(3, $results['total_attempted'], 'Three kits were offered for comparison.');
+        $this->assertSame(1, $results['total_compared'], 'Only one of them could actually be read.');
+        $this->assertSame(2, $results['unreadable_kits'], 'The other two must be reported, not silently dropped.');
+    }
+
+    private function kit(string $varName, string $fileName): Dna
+    {
+        return Dna::create([
+            'name' => $varName,
+            'variable_name' => $varName,
+            'file_name' => $fileName,
+            'user_id' => User::factory()->withPersonalTeam()->create()->id,
+            'consent_given' => true,
+            'consent_given_at' => now(),
+        ]);
+    }
+
+    private function buildKit(string $genotype = 'AG'): string
+    {
+        $lines = [
+            '# This data file generated by 23andMe',
+            "rsid\tchromosome\tposition\tgenotype",
+        ];
+
+        for ($i = 0; $i < 600; $i++) {
+            $pos = 1_000_000 + $i * 30_000;
+            $lines[] = "rs{$i}\t1\t{$pos}\t{$genotype}";
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+}


### PR DESCRIPTION
## The live defect: a count of work attempted, presented as work done

The triangulation page showed **"Total Compared: 10"** for a run of ten kits where four could not be read. The figure was `$compareKits->count()` — the number of kits *offered*, taken before any of them were opened.

The unreadable ones were then **silently dropped** from the results table, so nothing on the page indicated they existed. That omission is what made it hard to notice: a shorter table reads as a thorough search that found less.

It now counts comparisons that actually ran and names what it couldn't do:

```
Kits Compared        1
2 of 3 kit(s) could not be read
```

## The narrower part, and what it is honestly worth

The matching service reported `0.0` confidence and `0.0` quality for a kit it never read. Those two are the figures a caller renders directly as a score, so they are now `null` — a consumer that forgets to check `comparison_performed` fails visibly rather than printing "0% confidence".

**On its own this change is invisible.** Every consumer of those fields already checks `comparison_performed` — all nineteen were traced, and independently re-traced in review. No user can currently see them. It closes the layer *underneath* the guards rather than fixing something live.

Ticket 16 was written before those guards landed and describes a defect that is already closed. The count above is the live one it was gesturing at, and I only found it because review pushed on whether the ticket's premise still held.

## The asymmetry, stated honestly

`total_cms`, `largest_cm` and `shared_segments_count` stay numeric. The comment now says why truthfully: **it is a blast-radius judgement, not a principle.** `0.0` shared cM for a kit nobody read is the same untruth, and nulling all five would be equally defensible.

The two picked out are the ones rendered as scores; the rest are compared against thresholds and summed, where a null changes arithmetic rather than clarifying it.

An earlier version of that comment claimed the `comparison_performed` guards justified the split. They cover both halves equally, so it justified nothing — a circular argument, corrected.

## Tests

- Full suite: **651 passed**, 12 skipped
- PHPStan: clean
- Pint: clean on changed files

The measured-zero test now pins the score to `0.0` **exactly**. Asserting merely non-null would have passed for any number at all — the same failure mode this series keeps finding in its own tests. The fixture was verified genuine rather than an accidental parse failure: AA vs GG kits both parse to 600 SNPs and produce `comparison_performed = true` with `0.0` shared cM.

## Ticket 16 acceptance criteria

| AC | Status |
|---|---|
| Unreadable kit produces no confidence/quality rather than zeroes | Met |
| "Not measured" distinct from measured zero at every layer | Met in service and storage |
| Triangulation page renders the distinction rather than printing 0.00 | **Met** — via the count fix; previously unreadable pairings were omitted, and omission is not a distinction |
| A genuinely measured zero still displays | Met, now pinned exactly |
| Behavioural tests cover both paths separately | Met |
