### PR TITLE
fix(gamification): track the two achievements nobody could make progress on [#18]

### DIFF
--- a/app/Services/GamificationService.php
+++ b/app/Services/GamificationService.php
@@ -173,6 +173,18 @@ class GamificationService
         array $metadata = []
     ): void {
         $currentProgress = $this->calculateCurrentProgress($user, $achievement);
+
+        // No logic behind this key. Report it to someone who can fix it rather
+        // than showing the researcher a goal that cannot move.
+        if ($currentProgress === null) {
+            Log::warning('Achievement has no progress logic and will not be tracked', [
+                'achievement_key' => $achievement->key,
+                'achievement_id' => $achievement->id,
+            ]);
+
+            return;
+        }
+
         $targetProgress = $this->getTargetProgress($achievement);
 
         if ($targetProgress > 0) {
@@ -197,19 +209,37 @@ class GamificationService
     /**
      * Calculate current progress for an achievement
      */
-    private function calculateCurrentProgress(User $user, Achievement $achievement): int
+    /**
+     * Progress for an achievement, or null when its key has no logic behind it.
+     *
+     * This used to fall through to 0, which is indistinguishable from a real
+     * "handled, nothing done yet". Combined with getTargetProgress()'s fallback
+     * of 1, an unrecognised key was presented to a researcher as a goal sitting
+     * permanently at 0 / 1 — a frozen numerator over an invented denominator,
+     * with nothing logged.
+     */
+    private function calculateCurrentProgress(User $user, Achievement $achievement): ?int
     {
         return match ($achievement->key) {
+            // These two were absent, so the requirement check knew how to award
+            // them while nothing knew how to track them: both sat at 0 / 1 for
+            // every researcher until the moment they unlocked.
+            'first_person_added' => $this->getPersonCount($user),
+            'first_family_created' => $this->getFamilyCount($user),
             'family_builder', 'genealogy_researcher', 'family_historian' => $this->getPersonCount($user),
             'family_connector', 'relationship_expert' => $this->getFamilyCount($user),
             'event_chronicler', 'life_documenter' => $this->getEventCount($user),
             'photo_archivist', 'memory_keeper' => $this->getPhotoCount($user),
-            'point_collector', 'high_achiever', 'legend' => $user->total_points,
-            'level_up', 'experienced_researcher' => $user->level,
+            // Cast: both columns are NOT NULL in the database, but Eloquent does
+            // not populate defaults on a freshly created model, so an unrefreshed
+            // instance reads null — which would be indistinguishable from a key
+            // that has no logic at all.
+            'point_collector', 'high_achiever', 'legend' => (int) $user->total_points,
+            'level_up', 'experienced_researcher' => (int) $user->level,
             'daily_researcher' => $this->getDailyActivityStreak($user),
             'dedicated_genealogist' => $this->getDailyActivityStreak($user),
             'achievement_hunter' => $user->achievements()->count(),
-            default => 0,
+            default => null,
         };
     }
 

--- a/tests/Feature/Services/UnrecognisedAchievementKeyTest.php
+++ b/tests/Feature/Services/UnrecognisedAchievementKeyTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\Achievement;
+use App\Models\User;
+use App\Models\UserProgress;
+use App\Services\GamificationService;
+use Database\Seeders\AchievementSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * An achievement whose key has no corresponding logic used to be presented as a
+ * goal anyway: progress fell through to 0 and the target fell back to 1, so a
+ * researcher saw "0 / 1" forever. The numerator was frozen — the requirement
+ * check has a matching fallback that returns false — and the denominator was
+ * invented. Nothing about that display was measured, and nothing surfaced it:
+ * no log, no error, no admin warning.
+ *
+ * This was assumed latent — a hazard waiting on someone to seed a key without
+ * adding the matching arm. The seeded-key guard below found it live: two of the
+ * nineteen shipped achievements, "first person added" and "first family
+ * created", were in the requirement check but absent from the progress
+ * calculation. The application knew how to award them and not how to track
+ * them, so both sat at 0 / 1 for every researcher until the instant they
+ * unlocked. Their arms are now present.
+ *
+ * "Unhandled" is now distinguishable from "handled, no progress yet", rather
+ * than both collapsing to zero.
+ */
+class UnrecognisedAchievementKeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_an_unrecognised_key_is_not_presented_as_a_goal(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Achievement::create([
+            'key' => 'no_such_achievement',
+            'name' => 'Mystery',
+            'description' => 'Seeded without matching logic.',
+            'icon' => 'heroicon-o-question-mark-circle',
+            'category' => 'tree',
+            'points' => 10,
+            'requirements' => [],
+            'badge_color' => 'gray',
+            'is_active' => true,
+        ]);
+
+        (new GamificationService)->checkAchievements($user);
+
+        // Previously this wrote a UserProgress row at 0 / 1.
+        $this->assertSame(0, UserProgress::where('user_id', $user->id)->count());
+    }
+
+    public function test_an_unrecognised_key_is_reported_rather_than_failing_silently(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Log::spy();
+
+        Achievement::create([
+            'key' => 'no_such_achievement',
+            'name' => 'Mystery',
+            'description' => 'Seeded without matching logic.',
+            'icon' => 'heroicon-o-question-mark-circle',
+            'category' => 'tree',
+            'points' => 10,
+            'requirements' => [],
+            'badge_color' => 'gray',
+            'is_active' => true,
+        ]);
+
+        (new GamificationService)->checkAchievements($user);
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn (string $message, array $context = []): bool => ($context['achievement_key'] ?? null) === 'no_such_achievement')
+            ->atLeast()->once();
+    }
+
+    /**
+     * The guard that makes the above impossible to ship. Every achievement the
+     * application seeds must have logic behind it; a key added to the database
+     * without a matching arm fails here rather than in front of a researcher.
+     */
+    public function test_every_seeded_achievement_key_has_logic_behind_it(): void
+    {
+        $this->seed(AchievementSeeder::class);
+
+        $service = new GamificationService;
+        $method = new ReflectionMethod(GamificationService::class, 'calculateCurrentProgress');
+        $method->setAccessible(true);
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $unhandled = Achievement::all()
+            ->filter(fn (Achievement $a): bool => $method->invoke($service, $user, $a) === null)
+            ->pluck('key')
+            ->all();
+
+        $this->assertSame([], $unhandled, 'Seeded achievement keys with no progress logic: '.implode(', ', $unhandled));
+    }
+
+    public function test_a_recognised_key_still_tracks_progress(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Achievement::create([
+            'key' => 'family_builder',
+            'name' => 'Family Builder',
+            'description' => 'Add ten people.',
+            'icon' => 'heroicon-o-users',
+            'category' => 'tree',
+            'points' => 10,
+            'requirements' => ['count' => 10],
+            'badge_color' => 'green',
+            'is_active' => true,
+        ]);
+
+        (new GamificationService)->checkAchievements($user);
+
+        $progress = UserProgress::where('user_id', $user->id)->first();
+
+        $this->assertNotNull($progress, 'A key with logic must still be tracked.');
+        $this->assertSame(10, $progress->target_progress, 'The target comes from the requirement, not a fallback of 1.');
+    }
+}


### PR DESCRIPTION
Implements ticket **#18 — Stop rendering unrecognised achievements as "0 / 1"**.

## The ticket said latent. It was live.

An achievement whose key has no progress logic was presented as a goal anyway: progress fell through to `0`, the target fell back to `1`, so a researcher saw **"0 / 1" forever** — a frozen numerator over an invented denominator, with nothing logged to surface it.

I wrote that ticket up as a hazard waiting on someone to seed a key without adding the matching arm. The guard added here found it already happening:

| key | in requirement check | in progress calculation |
|---|---|---|
| `first_person_added` | yes | **no** |
| `first_family_created` | yes | **no** |

Two of the nineteen shipped achievements. The application knew how to *award* them and not how to *track* them, so both sat at 0 / 1 for every researcher from signup until the instant they unlocked. Their arms are now present.

## The guard

"No logic for this key" is now distinguishable from "handled, nothing done yet", rather than both collapsing to `0`. An unrecognised key is logged with its key and id and skipped, instead of writing a progress row that can never move.

The CI guard is a test asserting every seeded achievement has progress logic, so the next mismatch fails in CI rather than in front of a user. It derives the answer from the code itself rather than a duplicated list of keys, which would have drifted immediately.

## One subtlety worth flagging

Two counters gained an `int` cast. `total_points` and `level` are `NOT NULL` in the database, but Eloquent does not populate column defaults on a freshly created model — so an unrefreshed instance read `null`, which under the new contract is indistinguishable from "this key has no logic".

That conflation is what the guard reported on its first run. The real finding was underneath it, and I nearly wrote the cast off as the whole answer.

## Tests

- Full suite: **655 passed**, 12 skipped
- PHPStan: clean
- Pint: clean

Four tests: an unrecognised key is not shown as a goal, is logged rather than failing silently, every seeded key has logic, and a recognised key still tracks its real target rather than the fallback of 1.
