### PR TITLE
fix(tenancy): refuse teams the user does not belong to [tenant-isolation #01]

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,7 +9,7 @@ use Filament\Models\Contracts\HasDefaultTenant;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -152,12 +152,27 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
      */
     public function getTenants(Panel $panel): array|Collection
     {
-        return $this->ownedTeams;
+        // Owned teams AND teams joined. Listing only owned teams left a member
+        // of someone else's team with no way to reach it, which is the mirror
+        // image of the access check below being too permissive.
+        return $this->allTeams();
     }
 
+    /**
+     * Filament calls this to authorise the tenant in the URL.
+     *
+     * This returned an unconditional true, with the real condition commented
+     * out on the same line, so any authenticated user could open any team by
+     * typing its URL. Nothing in the interface led there, because the switcher
+     * lists only reachable teams — it was reachable by editing the address bar.
+     *
+     * The commented-out condition tested ownership. Restoring it verbatim would
+     * have locked every member out of teams they legitimately belong to but do
+     * not own, so the test is membership: belongsToTeam() covers both.
+     */
     public function canAccessTenant(Model $tenant): bool
     {
-        return true; // $this->ownedTeams->contains($tenant);
+        return $this->belongsToTeam($tenant);
     }
 
     public function canAccessFilament(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,7 +9,6 @@ use Filament\Models\Contracts\HasDefaultTenant;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -17,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use JoelButcher\Socialstream\HasConnectedAccounts;
 use JoelButcher\Socialstream\SetsProfilePhotoFromUrl;
@@ -200,9 +200,35 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         };
     }
 
+    /**
+     * The team to land on when no tenant is in the URL.
+     *
+     * Two things this has to get right, both of which it previously did not.
+     *
+     * latestTeam is an unguarded belongsTo on current_team_id, so it can point
+     * at a team the user no longer belongs to — removeUser() and a bare
+     * teams()->detach() both leave the column behind. Returning that team sends
+     * the user to a tenant the access check then refuses, which is a login
+     * followed immediately by a 404 and no way out. That became reachable the
+     * moment canAccessTenant stopped returning true unconditionally, so the
+     * membership test here is part of that same change rather than a tidy-up.
+     *
+     * And the fallback only considered owned teams, so a member who owns
+     * nothing — an invited account, or anyone whose own team was removed — got
+     * null and was redirected to create a team despite having one they could
+     * reach. LoginResponse calls this directly rather than going through
+     * Filament, which falls back to the tenant list on its own, so the gap
+     * showed up on the first screen after signing in.
+     */
     public function getDefaultTenant(Panel $panel): ?Model
     {
-        return $this->latestTeam ?? $this->ownedTeams()->first();
+        $current = $this->latestTeam;
+
+        if ($current && $this->belongsToTeam($current)) {
+            return $current;
+        }
+
+        return $this->allTeams()->first();
     }
 
     public function latestTeam(): BelongsTo

--- a/tests/Feature/Tenancy/TenantAccessControlTest.php
+++ b/tests/Feature/Tenancy/TenantAccessControlTest.php
@@ -22,11 +22,13 @@ use Tests\TestCase;
  * right test, and the switcher needs the same widening or the fix is invisible
  * to exactly the users it should serve.
  *
- * What makes this survivable today is a second defect: the tenant in the URL
- * does not yet control which records are shown, so opening another team's URL
- * shows you your own data rather than theirs. That is why the scoping ticket is
- * blocked on this one — fixing scoping first would turn a confusing display
- * into a genuine cross-tenant leak.
+ * A note on what this did NOT mask, because an earlier version of this comment
+ * had it wrong. It claimed the URL did not control which records were shown, so
+ * opening another team's URL showed you your own data. That is false for anyone
+ * who legitimately belongs to the team: the SwitchTeam listener fires on
+ * TenantSet and persists current_team_id to the tenant in the URL, and the
+ * tenant scope reads that column — so data already follows the URL for them.
+ * The old behaviour was an access hole, plainly, not a half-open one.
  */
 class TenantAccessControlTest extends TestCase
 {
@@ -116,13 +118,15 @@ class TenantAccessControlTest extends TestCase
         $owner = User::factory()->withPersonalTeam()->create();
         $outsider = User::factory()->withPersonalTeam()->create();
 
-        $response = $this->actingAs($outsider)->get('/app/'.$owner->currentTeam->id);
-
-        $this->assertContains(
-            $response->getStatusCode(),
-            [403, 404],
-            'An outsider was served another team\'s panel URL.',
-        );
+        // 404 exactly, not "403 or 404": a loose assertion here would also pass
+        // if the panel route were removed altogether, which is a false green on
+        // the one test standing between a user and someone else's tenant.
+        // Filament's IdentifyTenant aborts 404 rather than 403, which also means
+        // an unauthorised team and a nonexistent one are indistinguishable — no
+        // existence disclosure.
+        $this->actingAs($outsider)
+            ->get('/app/'.$owner->currentTeam->id)
+            ->assertNotFound();
     }
 
     public function test_opening_your_own_teams_url_is_allowed(): void
@@ -143,6 +147,50 @@ class TenantAccessControlTest extends TestCase
         $this->actingAs($member->fresh())
             ->get('/app/'.$owner->current_team_id)
             ->assertSuccessful();
+    }
+
+    /**
+     * Guards a dead end this change introduced. current_team_id can outlive
+     * membership — removeUser() and a bare detach() both leave it set — and the
+     * default tenant used to be read straight off it. Once access stopped being
+     * unconditional, that meant login redirecting to a tenant the access check
+     * then refused: a 404 with no way out.
+     */
+    public function test_a_user_removed_from_their_current_team_still_lands_somewhere_reachable(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $ownTeam = $member->currentTeam;
+
+        $owner->currentTeam->users()->attach($member, ['role' => 'editor']);
+        $member->forceFill(['current_team_id' => $owner->current_team_id])->save();
+
+        // Removed from that team, but the column still points at it.
+        $owner->currentTeam->users()->detach($member);
+
+        $default = $member->fresh()->getDefaultTenant(Filament::getPanel('app'));
+
+        $this->assertNotNull($default, 'A removed member was left with no default tenant.');
+        $this->assertSame($ownTeam->id, $default->id);
+        $this->assertTrue($member->fresh()->canAccessTenant($default));
+    }
+
+    /**
+     * A member who owns nothing — an invited account — used to get null here,
+     * because the fallback only considered owned teams. LoginResponse reads this
+     * directly, so they were sent to create a team despite belonging to one.
+     */
+    public function test_a_member_who_owns_no_team_still_has_a_default_tenant(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->create();
+
+        $owner->currentTeam->users()->attach($member, ['role' => 'editor']);
+
+        $default = $member->fresh()->getDefaultTenant(Filament::getPanel('app'));
+
+        $this->assertNotNull($default, 'An invited member was left with no team to land on.');
+        $this->assertSame($owner->current_team_id, $default->id);
     }
 
     public function test_a_deleted_or_unknown_team_is_refused(): void

--- a/tests/Feature/Tenancy/TenantAccessControlTest.php
+++ b/tests/Feature/Tenancy/TenantAccessControlTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tenant authorisation returned true unconditionally, with the real condition
+ * commented out on the same line. Any authenticated user could open any team's
+ * URL by typing it. Nothing in the interface led there — the team switcher lists
+ * only teams the user owns — so it was reachable by editing the address bar.
+ *
+ * Restoring the commented-out condition verbatim would have swapped one bug for
+ * another: it tested ownership, so every member of a team they do not own would
+ * have lost access to a team they legitimately belong to. Membership is the
+ * right test, and the switcher needs the same widening or the fix is invisible
+ * to exactly the users it should serve.
+ *
+ * What makes this survivable today is a second defect: the tenant in the URL
+ * does not yet control which records are shown, so opening another team's URL
+ * shows you your own data rather than theirs. That is why the scoping ticket is
+ * blocked on this one — fixing scoping first would turn a confusing display
+ * into a genuine cross-tenant leak.
+ */
+class TenantAccessControlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_an_owner_can_access_their_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->assertTrue($user->canAccessTenant($user->currentTeam));
+    }
+
+    /**
+     * The case the commented-out ownership check would have broken.
+     */
+    public function test_a_member_can_access_a_team_they_do_not_own(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+
+        $owner->currentTeam->users()->attach($member, ['role' => 'editor']);
+
+        $this->assertTrue($member->fresh()->canAccessTenant($owner->currentTeam));
+    }
+
+    public function test_an_outsider_cannot_access_someone_elses_team(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $outsider = User::factory()->withPersonalTeam()->create();
+
+        $this->assertFalse($outsider->canAccessTenant($owner->currentTeam));
+    }
+
+    public function test_the_switcher_lists_teams_the_user_belongs_to_as_well_as_owns(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+
+        $owner->currentTeam->users()->attach($member, ['role' => 'editor']);
+
+        $tenants = $member->fresh()->getTenants(Filament::getPanel('app'));
+        $ids = collect($tenants)->pluck('id');
+
+        $this->assertTrue($ids->contains($member->current_team_id), 'Own team missing from the switcher.');
+        $this->assertTrue($ids->contains($owner->current_team_id), 'A team the user belongs to was not listed.');
+    }
+
+    public function test_the_switcher_does_not_list_teams_the_user_cannot_reach(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $stranger = User::factory()->withPersonalTeam()->create();
+
+        $tenants = $user->getTenants(Filament::getPanel('app'));
+        $ids = collect($tenants)->pluck('id');
+
+        $this->assertFalse($ids->contains($stranger->current_team_id));
+    }
+
+    /**
+     * Every team the switcher offers must also pass the access check, or the
+     * interface leads somewhere the authorisation refuses.
+     */
+    public function test_every_listed_team_is_one_the_user_may_access(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => 'editor']);
+
+        $member = $member->fresh();
+
+        foreach ($member->getTenants(Filament::getPanel('app')) as $team) {
+            $this->assertTrue(
+                $member->canAccessTenant($team),
+                "Team {$team->id} is listed in the switcher but access is refused.",
+            );
+        }
+    }
+
+    /**
+     * The predicate tests above prove the rule; this proves the route enforces
+     * it. The ticket's claim is about URLs — "any authenticated user can open
+     * any team's URL" — and a unit test on the method does not demonstrate that
+     * the panel actually refuses the request.
+     */
+    public function test_opening_another_teams_url_is_refused(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $outsider = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($outsider)->get('/app/'.$owner->currentTeam->id);
+
+        $this->assertContains(
+            $response->getStatusCode(),
+            [403, 404],
+            'An outsider was served another team\'s panel URL.',
+        );
+    }
+
+    public function test_opening_your_own_teams_url_is_allowed(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($user)
+            ->get('/app/'.$user->current_team_id)
+            ->assertSuccessful();
+    }
+
+    public function test_a_member_may_open_the_url_of_a_team_they_do_not_own(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => 'editor']);
+
+        $this->actingAs($member->fresh())
+            ->get('/app/'.$owner->current_team_id)
+            ->assertSuccessful();
+    }
+
+    public function test_a_deleted_or_unknown_team_is_refused(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->assertFalse($user->canAccessTenant(new Team));
+    }
+}


### PR DESCRIPTION
Implements **tenant-isolation ticket 01 — Restore tenant access control**.

## The hole

`canAccessTenant()` returned an unconditional `true`, with the real condition commented out on the same line:

```php
return true; // $this->ownedTeams->contains($tenant);
```

Filament calls this to authorise the tenant in the URL, so **any authenticated user could open any team by typing its address**. Nothing in the interface led there — the switcher lists only reachable teams — which is why it went unnoticed.

**Verified, not assumed.** With the old body restored, an outsider requesting another team's panel URL is served **HTTP 200**:

```
An outsider was served another team's panel URL.
Failed asserting that an array contains 200.
```

That test is in this PR and fails against the previous code.

## Why not just uncomment the line

The commented-out condition tested **ownership**. Restoring it verbatim would have swapped one bug for another: every member of a team they do not own would have lost access to a team they legitimately belong to. The check is membership — Jetstream's `belongsToTeam()` covers owner and member alike.

`getTenants()` had the mirror-image problem, listing owned teams only, so a member of someone else's team had no way to reach it even once the access check was right. It now lists every team the user belongs to.

Fixing either alone leaves the interface and the authorisation disagreeing in opposite directions, so both are here. A test asserts every team the switcher offers also passes the access check.

## Two defects found in review, both fixed here

**A login dead end this change introduced.** The default tenant was read straight off `current_team_id`, unguarded. That column outlives membership — `removeUser()` and a bare `teams()->detach()` both leave it set. While the access check returned `true` that was harmless; making the check real turned it into a **login that redirects to a tenant the check then refuses — a 404 with no way out.** Now guarded by a membership test.

**The same gap this PR claimed to close, one layer down.** The fallback considered owned teams only, so a member who owns nothing — an invited account — got `null` and was sent to create a team despite belonging to one. `LoginResponse` calls this directly rather than through Filament, which has its own fallback, so it landed on the first screen after signing in.

Both are covered by tests verified to fail against the previous implementation.

## A claim I got wrong, now corrected

I originally wrote that this fix had to precede the data-scoping work, because scoping alone would leak. **That does not hold.**

The `SwitchTeam` listener fires on `TenantSet` and persists `current_team_id` to the tenant in the URL, and the tenant scope reads that column — so data already follows the URL for anyone who passes the membership test. The old behaviour was an access hole plainly, not a half-open one. That incorrect rationale was in the ticket, the first commit and the test docblock; all three are corrected.

Ticket 02 needs re-scoping as a result — the remaining real defect there is that `TeamsPermission` runs *before* `IdentifyTenant`, so permissions resolve against the pre-switch team for one request.

## Tests

Twelve tests: owner, member and outsider against the predicate; the switcher's contents both ways; switcher-and-authorisation agreement; three at the **HTTP layer**; and two regression tests for the default-tenant defects above.

The HTTP test asserts **404 exactly**, not "403 or 404". A two-value assertion would also pass if the panel route were deleted outright — a false green on the one test standing between a user and someone else's data. 404 is also the right status: an unauthorised team and a nonexistent one are indistinguishable, so enumerating ids discloses nothing.

Four of the predicate tests pass against the old code too, since it returned `true` unconditionally. They document the rule rather than catching the regression; the outsider, switcher, URL and default-tenant tests are the load-bearing ones.

- Full suite: **667 passed**, 12 skipped
- PHPStan: clean
- Pint: clean on changed files

The `Collection` import moves from Eloquent to Support, which is what Filament's `HasTenants` contract declares — `ownedTeams` returned an Eloquent collection and happened to satisfy the narrower local type; `allTeams()` surfaced the mismatch.

> On Pint: I first reported the `User.php` failure as pre-existing, on the strength of a stash that was **empty** because the work was already committed — so I compared the same version against itself. Pint on pristine `main` touches only the traits block; relocating the import was mine, and is fixed. Main's remaining issue is untouched.
