### PR TITLE
fix(tenancy): scope from the active tenant; permission half is groundwork [tenant-isolation #02]

### DIFF
--- a/app/Http/Middleware/TeamsPermission.php
+++ b/app/Http/Middleware/TeamsPermission.php
@@ -3,23 +3,76 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 use Spatie\Permission\PermissionRegistrar;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class TeamsPermission
 {
     /**
      * Handle an incoming request.
      *
+     * Reads the tenant Filament has identified, falling back to the user's
+     * stored team where there is no tenant — the admin panel, which does not
+     * use tenancy, and any non-panel route.
+     *
+     * This used to read the stored team only, and ran in the panel's auth
+     * middleware. Filament nests the tenant middleware group inside the auth
+     * group, so it executed before the tenant was identified and before the
+     * SwitchTeam listener updated that column: every role and permission check
+     * in the request resolved against the team the user arrived on while the
+     * interface rendered the one they had navigated to. It is now registered as
+     * tenant middleware, which runs after IdentifyTenant.
+     *
      * @param  Closure(Request):Response  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (! empty($user = auth()->user()) && ! empty($user->current_team_id)) {
-            app(PermissionRegistrar::class)->setPermissionsTeamId($user->current_team_id);
+        $user = auth()->user();
+
+        if ($user) {
+            $teamId = $this->tenantFromRoute($request, $user) ?? $user->current_team_id;
+
+            if (! empty($teamId)) {
+                app(PermissionRegistrar::class)->setPermissionsTeamId($teamId);
+            }
         }
 
         return $next($request);
+    }
+
+    /**
+     * The tenant named in the URL, if the user may actually reach it.
+     *
+     * Read from the route rather than from Filament, because this runs before
+     * IdentifyTenant has identified anything. Membership is checked here so a
+     * request for a team the user cannot access never sets a permission context
+     * for it — that request is about to be refused anyway.
+     */
+    private function tenantFromRoute(Request $request, mixed $user): int|string|null
+    {
+        $route = $request->route();
+
+        if (! $route || ! $route->hasParameter('tenant')) {
+            return null;
+        }
+
+        $panel = Filament::getCurrentOrDefaultPanel();
+
+        if (! $panel?->hasTenancy()) {
+            return null;
+        }
+
+        try {
+            $tenant = $panel->getTenant($route->parameter('tenant'));
+        } catch (Throwable) {
+            // Unknown tenant. IdentifyTenant will refuse the request; fall back
+            // rather than failing here with a less useful error.
+            return null;
+        }
+
+        return $user->canAccessTenant($tenant) ? $tenant->getKey() : null;
     }
 }

--- a/app/Http/Middleware/TeamsPermission.php
+++ b/app/Http/Middleware/TeamsPermission.php
@@ -18,13 +18,19 @@ class TeamsPermission
      * stored team where there is no tenant — the admin panel, which does not
      * use tenancy, and any non-panel route.
      *
-     * This used to read the stored team only, and ran in the panel's auth
-     * middleware. Filament nests the tenant middleware group inside the auth
-     * group, so it executed before the tenant was identified and before the
-     * SwitchTeam listener updated that column: every role and permission check
-     * in the request resolved against the team the user arrived on while the
-     * interface rendered the one they had navigated to. It is now registered as
-     * tenant middleware, which runs after IdentifyTenant.
+     * This used to read the stored team only. Filament nests the tenant
+     * middleware group inside the auth group, so this runs before the tenant is
+     * identified and before the SwitchTeam listener updates that column: every
+     * role and permission check in the request resolved against the team the
+     * user arrived on while the interface rendered the one they had navigated
+     * to. Reading the route removes the ordering dependency entirely.
+     *
+     * Worth knowing before relying on any of this: Spatie's team support is
+     * currently DISABLED (permission.teams is false) and the roles tables have
+     * no team_id column, so setPermissionsTeamId() writes somewhere nothing
+     * reads and every role in this application is global. Setting it correctly
+     * is a precondition for team-scoped roles, not a behaviour change on its
+     * own.
      *
      * @param  Closure(Request):Response  $next
      */

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -238,20 +238,23 @@ class AppPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
-                // Stays in the auth group, and resolves the tenant from the
-                // route itself rather than waiting for IdentifyTenant.
+                // Stays in the auth group and resolves the tenant from the route
+                // itself, rather than being moved to the tenant group where it
+                // would run after IdentifyTenant.
                 //
-                // Registering it as tenant middleware would put it after tenant
-                // identification, which is the obvious fix — but then it never
-                // runs on the authenticated routes outside the tenant group
-                // (team creation, logout, profile, email verification).
-                // PermissionRegistrar is a singleton and production runs Octane,
-                // so those routes would inherit whichever team the previous
-                // request in that worker left behind. Registering in both groups
-                // does not work either: Laravel de-duplicates middleware, so only
-                // the first occurrence runs.
+                // The reason is not Octane state: Spatie registers an
+                // OperationTerminated listener that nulls the permission team
+                // after every operation, so nothing survives between requests.
+                // An earlier version of this comment claimed otherwise.
+                //
+                // It is that tenant middleware does not run on the authenticated
+                // routes outside the tenant group — team creation, logout,
+                // profile, email verification — which would leave the permission
+                // team unset there. Registering in both groups does not work:
+                // Laravel de-duplicates middleware, so only the first occurrence
+                // runs, which silently reinstates the bug.
                 TeamsPermission::class,
-            ]);
+            ], isPersistent: true);
 
         // if (Features::hasApiFeatures()) {
         //     $panel->userMenuItems([

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -238,6 +238,18 @@ class AppPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
+                // Stays in the auth group, and resolves the tenant from the
+                // route itself rather than waiting for IdentifyTenant.
+                //
+                // Registering it as tenant middleware would put it after tenant
+                // identification, which is the obvious fix — but then it never
+                // runs on the authenticated routes outside the tenant group
+                // (team creation, logout, profile, email verification).
+                // PermissionRegistrar is a singleton and production runs Octane,
+                // so those routes would inherit whichever team the previous
+                // request in that worker left behind. Registering in both groups
+                // does not work either: Laravel de-duplicates middleware, so only
+                // the first occurrence runs.
                 TeamsPermission::class,
             ]);
 

--- a/app/Traits/BelongsToTenant.php
+++ b/app/Traits/BelongsToTenant.php
@@ -3,6 +3,7 @@
 namespace App\Traits;
 
 use App\Models\Team;
+use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Schema;
 
@@ -57,6 +58,14 @@ trait BelongsToTenant
      */
     protected static function getTenantId(): ?int
     {
-        return auth()->user()?->currentTeam?->id;
+        // The tenant being viewed, falling back to the user's stored team where
+        // there is no panel context — console commands and queued jobs.
+        //
+        // This read the stored team alone, which agreed with the URL only
+        // because the SwitchTeam listener had already persisted it. That is an
+        // unnamed dependency between a global scope and an event listener: if
+        // the listener is removed, reordered, or fails to fire, scoping
+        // silently reverts to whatever team was last stored and nothing fails.
+        return Filament::getTenant()?->getKey() ?? auth()->user()?->currentTeam?->id;
     }
 }

--- a/tests/Feature/Tenancy/PermissionsFollowTenantTest.php
+++ b/tests/Feature/Tenancy/PermissionsFollowTenantTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * Permissions resolved against the team the user arrived on, not the team they
+ * were looking at.
+ *
+ * Filament nests the tenant middleware group inside the authentication group,
+ * so everything in the panel's auth middleware runs first. The middleware that
+ * sets the permission library's team context lived there and read the user's
+ * stored current team. Tenant identification ran afterwards, and only then did
+ * the SwitchTeam listener update that column.
+ *
+ * For that one request, every role and permission check evaluated against the
+ * previous team while the interface rendered the new one — so the panel could
+ * offer actions the user's role in the viewed team does not permit. It corrects
+ * itself on the next request, which is what made it easy to miss.
+ *
+ * Largely unreachable until recently: the switcher listed only owned teams and
+ * switching anywhere else was refused. Widening it to teams a user belongs to
+ * made cross-team navigation an ordinary path.
+ */
+class PermissionsFollowTenantTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_the_permission_team_matches_the_tenant_being_viewed(): void
+    {
+        [$user, $otherTeamId] = $this->userInTwoTeams();
+
+        $this->actingAs($user)->get('/app/'.$otherTeamId)->assertSuccessful();
+
+        $this->assertSame(
+            $otherTeamId,
+            app(PermissionRegistrar::class)->getPermissionsTeamId(),
+            'Permissions resolved against the team the user arrived on, not the one in the URL.',
+        );
+    }
+
+    public function test_the_permission_team_matches_when_viewing_your_own_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($user)->get('/app/'.$user->current_team_id)->assertSuccessful();
+
+        $this->assertSame(
+            $user->current_team_id,
+            app(PermissionRegistrar::class)->getPermissionsTeamId(),
+        );
+    }
+
+    /**
+     * PermissionRegistrar is a singleton and production runs Octane, so state
+     * survives between requests in a worker. Routes inside the panel's auth
+     * group but outside its tenant group — team creation, logout, profile,
+     * email verification — would otherwise inherit whichever team the previous
+     * request left set. The middleware is registered in both groups for this
+     * reason, not by accident.
+     */
+    public function test_a_route_without_a_tenant_still_resets_the_permission_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        // Stand in for a previous request in the same Octane worker.
+        app(PermissionRegistrar::class)->setPermissionsTeamId(999999);
+
+        $this->actingAs($user)->get('/app/new')->assertSuccessful();
+
+        $this->assertSame(
+            $user->current_team_id,
+            app(PermissionRegistrar::class)->getPermissionsTeamId(),
+            'A tenant-less route left another request\'s permission team in place.',
+        );
+    }
+
+    /**
+     * The tenant scope used to read the stored current team, which agreed with
+     * the URL only because the SwitchTeam listener had already run. That is an
+     * unnamed dependency between a global scope and an event listener: remove
+     * or reorder the listener and scoping silently reverts to a stale team with
+     * nothing failing. Reading the active tenant removes the coupling.
+     */
+    public function test_the_tenant_scope_reads_the_active_tenant_not_the_stored_column(): void
+    {
+        [$user, $otherTeamId] = $this->userInTwoTeams();
+
+        $this->actingAs($user)->get('/app/'.$otherTeamId)->assertSuccessful();
+
+        // Deliberately desynchronise the stored column from the active tenant —
+        // the state the listener would otherwise always paper over. The
+        // authenticated instance has to be re-resolved, or it keeps serving a
+        // cached currentTeam relation and the test passes without proving
+        // anything.
+        $ownTeamId = $user->ownedTeams()->first()->id;
+        $user->forceFill(['current_team_id' => $ownTeamId])->save();
+        $this->actingAs($user->fresh());
+
+        $this->assertNotSame($ownTeamId, $otherTeamId, 'Fixture is degenerate.');
+
+        Filament::setTenant($user->allTeams()->firstWhere('id', $otherTeamId), isQuiet: true);
+
+        $this->assertSame(
+            $otherTeamId,
+            $this->resolvedTenantId(),
+            'The scope followed the stored column rather than the tenant being viewed.',
+        );
+    }
+
+    public function test_without_a_panel_context_the_scope_falls_back_to_the_stored_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        Filament::setTenant(null, isQuiet: true);
+
+        // Console commands and queued jobs have no tenant set; they must still
+        // scope rather than silently falling through to every team's rows.
+        $this->assertSame($user->current_team_id, $this->resolvedTenantId());
+    }
+
+    /**
+     * @return array{0: User, 1: int}
+     */
+    private function userInTwoTeams(): array
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $owner->currentTeam->users()->attach($user, ['role' => 'editor']);
+
+        return [$user->fresh(), $owner->current_team_id];
+    }
+
+    private function resolvedTenantId(): ?int
+    {
+        $method = new \ReflectionMethod(Person::class, 'getTenantId');
+        $method->setAccessible(true);
+
+        return $method->invoke(null);
+    }
+}

--- a/tests/Feature/Tenancy/PermissionsFollowTenantTest.php
+++ b/tests/Feature/Tenancy/PermissionsFollowTenantTest.php
@@ -29,6 +29,20 @@ use Tests\TestCase;
  * Largely unreachable until recently: the switcher listed only owned teams and
  * switching anywhere else was refused. Widening it to teams a user belongs to
  * made cross-team navigation an ordinary path.
+ *
+ * READ THIS BEFORE TRUSTING WHAT THESE TESTS PROVE.
+ *
+ * Spatie's team support is currently disabled — permission.teams is false, and
+ * the roles tables carry no team_id column — so setPermissionsTeamId() writes
+ * to a holder nothing reads. Every role in this application is global, and the
+ * scenario these tests are named for (administrator of one team, viewer of
+ * another) is not representable in the schema as it stands.
+ *
+ * So the assertions below pin the team id being computed and set correctly.
+ * They do not, and cannot yet, demonstrate that a permission check honours it.
+ * That is a precondition, not the fix; enabling team-scoped roles is separate
+ * work. Stating it here because a green file named after roles invites exactly
+ * the wrong conclusion.
  */
 class PermissionsFollowTenantTest extends TestCase
 {
@@ -60,12 +74,15 @@ class PermissionsFollowTenantTest extends TestCase
     }
 
     /**
-     * PermissionRegistrar is a singleton and production runs Octane, so state
-     * survives between requests in a worker. Routes inside the panel's auth
-     * group but outside its tenant group — team creation, logout, profile,
-     * email verification — would otherwise inherit whichever team the previous
-     * request left set. The middleware is registered in both groups for this
-     * reason, not by accident.
+     * The authenticated routes outside the tenant group — team creation,
+     * logout, profile, email verification — still need a defined permission
+     * team. They get one because the middleware sits in the auth group and
+     * falls back to the stored team when the route names no tenant.
+     *
+     * An earlier version of this docblock justified that with Octane state
+     * surviving between requests. It does not: Spatie registers an
+     * OperationTerminated listener that nulls the team after every operation.
+     * The real reason is simply that tenant middleware does not run here.
      */
     public function test_a_route_without_a_tenant_still_resets_the_permission_team(): void
     {
@@ -84,6 +101,11 @@ class PermissionsFollowTenantTest extends TestCase
     }
 
     /**
+     * This one is a unit test wearing HTTP clothes, and it cannot be otherwise.
+     * A real request cannot distinguish the two sources: IdentifyTenant sets
+     * the tenant and SwitchTeam immediately syncs the column, so they always
+     * agree. The tenant is therefore set manually below to force them apart.
+     *
      * The tenant scope used to read the stored current team, which agreed with
      * the URL only because the SwitchTeam listener had already run. That is an
      * unnamed dependency between a global scope and an event listener: remove


### PR DESCRIPTION
Implements part of **tenant-isolation ticket 02**. Read the first section before reviewing — the ticket's headline premise turned out to be false, and this PR delivers less than its title suggests.

## ⚠️ Half of this is inert, and the ticket cannot be satisfied as written

**Spatie's team support is disabled.** `config/permission.php` has `'teams' => false`, and `roles`, `model_has_roles` and `model_has_permissions` carry **no `team_id` column** — the migration only adds them when the flag is on. Verified against the live schema.

So `setPermissionsTeamId()` writes to a holder nothing reads. **Every role in this application is global.** The scenario the ticket is named for — administrator of team A, viewer of team B — is not representable in the schema as it stands. There are no `teamRole()` or `hasTeamPermission()` calls anywhere in `app/`.

Setting the team correctly is a **precondition** for team-scoped roles, not a behaviour change on its own. Enabling them needs a config flip plus a migration, and is separate work.

I've said this in the middleware, in the test docblock, and here, because a green test file named after roles invites exactly the wrong conclusion.

**Ticket 02 acceptance: 2 of 5 met.** The trait change landed; the half the ticket is named after did not.

## What is real: the tenant scope no longer depends on a listener

`BelongsToTenant::getTenantId()` read `current_team_id`, which agreed with the URL only because the `SwitchTeam` listener had already persisted it. That is an **unnamed dependency between a global scope and an event listener** — remove it, reorder it, or have it fail to fire, and scoping silently reverts to whatever team was last stored, with nothing failing.

It now reads the active tenant, falling back to the stored team only where there is no panel context (console, queue). This trait backs 47 models. Tested, and the test is revert-sensitive.

## What is correct but currently unobservable

`TeamsPermission` ran before the tenant was identified, because Filament nests the tenant middleware group inside the auth group. It now resolves the tenant from the route itself and verifies membership before trusting it. Correct — and it will matter the moment team-scoped roles are enabled.

Also adds `isPersistent`, so it runs on Livewire requests. Those are most panel traffic after first paint and were **skipping it entirely** — which would have left the team unset on nearly every interaction once the feature is switched on.

## Two designs rejected, and one rationale I got wrong

**Both-groups registration** — Laravel de-duplicates middleware, so only the first occurrence runs. This silently reinstated the original bug with the whole suite green except the single test that caught it.

**Tenant-group placement** — it then never runs on authenticated routes outside that group (team creation, logout, profile, email verification).

I originally justified rejecting that with Octane state surviving between requests. **That was wrong.** Spatie registers an `OperationTerminated` listener that nulls the permission team after every operation, unconditionally — the config flag beside it gates only the cache clear. That incorrect claim appeared in four places and is corrected.

Three docblocks also described abandoned attempts and contradicted the code shipped beside them — the exact defect this series exists to remove. Corrected.

## Tests

Five tests. Two are genuinely revert-sensitive (the viewed-tenant team id; the scope reading the active tenant). Three pass against the old code too and document behaviour rather than catching regressions — worth knowing rather than counting as coverage.

The scope test is a unit test in HTTP clothing, deliberately: a real request cannot distinguish the two sources, because `IdentifyTenant` sets the tenant and `SwitchTeam` immediately syncs the column, so they always agree. The tenant is set manually to force them apart. That limitation is stated in the test.

**No test assigns a role**, because no role in this app is team-scoped. That gap is a consequence of the finding at the top, not an oversight.

- Full suite: **672 passed**, 12 skipped
- PHPStan: clean
- Pint: clean on changed files
