### PR TITLE
feat(tenancy): enforce the collaboration tiers [tenant-isolation #07]

### DIFF
--- a/app/Filament/App/Pages/TeamMembers.php
+++ b/app/Filament/App/Pages/TeamMembers.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Pages;
+
+use App\Models\Team;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Pages\Page;
+use Laravel\Jetstream\Jetstream;
+
+/**
+ * Lets a team owner set what each collaborator may do with the team's records.
+ *
+ * The tiers are Jetstream's, declared in the service provider and stored on the
+ * membership, and AppResource enforces them. Until both existed together each
+ * was useless: the tiers were assigned and read by nothing, and there was
+ * nowhere in the application to assign them anyway — Jetstream's own team views
+ * are not routed here and the tenant profile page has no member management. A
+ * tier could only be changed by editing the database.
+ *
+ * The set of tiers is fixed on purpose. SPEC §10 names exactly four, and they
+ * are meaningful only because AppResource knows what each one permits; a team
+ * inventing its own would produce a tier nothing could enforce. This page
+ * therefore assigns roles and never creates them, which also means it cannot
+ * mint the team-less role that would confer administration everywhere — the
+ * escalation route that has to be guarded whenever roles become editable.
+ *
+ * Ownership, not tier, gates this page. An admin-tier member holds
+ * 'manage-team', but TeamPolicy restricts member changes to the owner, and
+ * quietly widening that here would be a different decision made in the wrong
+ * place.
+ *
+ * canAccess() is the whole authorisation, and that is deliberate rather than an
+ * oversight. Filament re-runs it on every Livewire hydration, not only on
+ * mount, so it also covers ownership lost while the page sits open — the case
+ * a per-action check would normally exist for. An earlier version did carry a
+ * Gate check inside the action; it was removed on finding that no test could
+ * make it fire, because canAccess had already refused the request. A branch
+ * that cannot execute is not defence in depth, it is a reader's false
+ * assurance that the action authorises itself.
+ *
+ * TeamMembersPageTest pins the hydration behaviour this now leans on, so if
+ * Filament stops re-authorising, a test says so rather than a user finding out.
+ */
+class TeamMembers extends Page
+{
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-user-group';
+
+    #[\Override]
+    protected string $view = 'filament.app.pages.team-members';
+
+    #[\Override]
+    protected static ?string $title = 'Team Members';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'Members';
+
+    #[\Override]
+    public static function canAccess(): bool
+    {
+        $team = Filament::getTenant();
+        $user = auth()->user();
+
+        return $team && $user && $user->ownsTeam($team);
+    }
+
+    /**
+     * The owner first, then members in the order they joined. The owner holds
+     * no membership row, so they are prepended rather than queried.
+     *
+     * @return list<array{id: int, name: string, email: string, tier: string, is_owner: bool}>
+     */
+    public function getMembers(): array
+    {
+        $team = $this->team();
+
+        if (! $team) {
+            return [];
+        }
+
+        /** @var User|null $owner */
+        $owner = $team->owner;
+
+        $rows = [];
+
+        if ($owner) {
+            $rows[] = [
+                'id' => (int) $owner->getKey(),
+                'name' => (string) $owner->name,
+                'email' => (string) $owner->email,
+                'tier' => 'Owner',
+                'is_owner' => true,
+            ];
+        }
+
+        /** @var User $user */
+        foreach ($team->users as $user) {
+            $rows[] = [
+                'id' => (int) $user->getKey(),
+                'name' => (string) $user->name,
+                'email' => (string) $user->email,
+                'tier' => (string) ($user->membership->role ?? ''),
+                'is_owner' => false,
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function setTierAction(): Action
+    {
+        return Action::make('setTier')
+            ->label('Change tier')
+            ->schema([
+                Select::make('role')
+                    ->label('Collaboration tier')
+                    ->options($this->tierOptions())
+                    ->required(),
+            ])
+            ->action(function (array $arguments, array $data): void {
+                $team = $this->team();
+
+                // Only an actual member can be retiered. This rejects the
+                // owner, who has no membership row, and any id that names
+                // someone outside the team — the argument arrives from the
+                // browser and is not evidence of anything.
+                /** @var User|null $member */
+                $member = $team?->users->find($arguments['user'] ?? null);
+
+                abort_unless((bool) ($team && $member), 403);
+
+                $team->users()->updateExistingPivot($member->getKey(), ['role' => $data['role']]);
+            });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function tierOptions(): array
+    {
+        $options = [];
+
+        foreach (Jetstream::$roles as $role) {
+            $options[$role->key] = $role->name;
+        }
+
+        return $options;
+    }
+
+    protected function team(): ?Team
+    {
+        $team = Filament::getTenant();
+
+        return $team instanceof Team ? $team : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function getViewData(): array
+    {
+        return [
+            'members' => $this->getMembers(),
+        ];
+    }
+}

--- a/app/Filament/App/Pages/TreePrivacy.php
+++ b/app/Filament/App/Pages/TreePrivacy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\App\Pages;
 
 use App\Models\Tree;
+use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Support\Collection;
@@ -37,10 +38,37 @@ class TreePrivacy extends Page
     }
 
     /**
+     * Publishing is gated at the delete tier, not the update tier.
+     *
+     * Making a tree public exposes records of living relatives to anyone, and
+     * unlike an edit it cannot be taken back once the data has been seen or
+     * indexed. That is closer in consequence to deletion than to changing a
+     * field, so it sits with delete: viewers and contributors are excluded,
+     * editors and administrators are not.
+     *
+     * Pages are not resources, so nothing about AppResource applies here and
+     * the check has to be written out. Before this there was none at all — any
+     * member of a team, down to a viewer invited to read one family's research,
+     * could publish every tree the team held.
+     */
+    #[\Override]
+    public static function canAccess(): bool
+    {
+        $team = Filament::getTenant();
+        $user = auth()->user();
+
+        return $team && $user && $user->hasTeamPermission($team, 'delete');
+    }
+
+    /**
      * Flip a tree between public and private.
      */
     public function toggle(int $treeId): void
     {
+        // Re-checked here rather than trusting the page gate alone: this is a
+        // public Livewire method, so it is addressable directly.
+        abort_unless(static::canAccess(), 403);
+
         // findOrFail stays inside the tenant scope, so a foreign team's id 404s.
         $tree = Tree::findOrFail($treeId);
         $tree->is_public = ! $tree->is_public;

--- a/app/Filament/App/Resources/AppResource.php
+++ b/app/Filament/App/Resources/AppResource.php
@@ -2,38 +2,180 @@
 
 namespace App\Filament\App\Resources;
 
+use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;
 use UnitEnum;
 
+/**
+ * Base for every app-panel resource. Authorisation for all 44 of them resolves
+ * here, against the collaboration tier the member holds in the team they are
+ * looking at.
+ *
+ * Every method below used to answer auth()->check(). The tiers SPEC §10 calls
+ * for — viewer, contributor, editor, admin — were defined with explicit
+ * permissions, assigned to members when they joined a team, and then read by
+ * nothing: there was not one call to hasTeamPermission anywhere in the
+ * application. A viewer invited to look at a family's research could delete
+ * every person in it.
+ *
+ * The tier lives on the membership, so these questions are answered by
+ * Jetstream rather than by the permission library. Those are two different
+ * things and it is worth being explicit about which is which: the permission
+ * library governs application-wide rights and the admin panel, while these
+ * tiers govern what a collaborator may do to one team's records. A viewer in
+ * this sense is not a user lacking a global role; they are a member of this
+ * team, deliberately granted read access to it and nothing more.
+ *
+ * A resource needing different rules should override the specific method
+ * rather than reinstating a blanket allow.
+ *
+ * WHAT THIS DOES NOT COVER, because a base class for resources can only speak
+ * for resources, and an unqualified claim here would be worse than none:
+ *
+ * - Relation managers. Filament routes their authorisation to the model's
+ *   policy unless the manager names a related resource, and none of the six
+ *   here do. A viewer who may open a record can still act on what hangs off it.
+ * - Custom pages. Not resources, so nothing here applies; each needs its own
+ *   check. TreePrivacy has one, since publishing a family tree is the most
+ *   consequential thing in the application. The rest do not yet.
+ * - Livewire components addressed directly, and bare ->action() closures on
+ *   resources, which mutate records without consulting any of this.
+ *
+ * Those are older than this class's enforcement and are a separate ticket.
+ * They are listed because "the app panel is authorised now" is the conclusion a
+ * reader would otherwise draw, and it would be wrong.
+ */
 abstract class AppResource extends Resource
 {
     #[\Override]
     public static function canViewAny(): bool
     {
-        return auth()->check();
+        return static::tierPermits('read');
+    }
+
+    #[\Override]
+    public static function canView(Model $record): bool
+    {
+        return static::tierPermits('read');
     }
 
     #[\Override]
     public static function canCreate(): bool
     {
-        return auth()->check();
+        return static::tierPermits('create');
     }
 
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return static::tierPermits('update');
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return static::tierPermits('delete');
+    }
+
+    #[\Override]
+    public static function canDeleteAny(): bool
+    {
+        return static::tierPermits('delete');
+    }
+
+    #[\Override]
+    public static function canForceDelete(Model $record): bool
+    {
+        return static::tierPermits('delete');
+    }
+
+    #[\Override]
+    public static function canForceDeleteAny(): bool
+    {
+        return static::tierPermits('delete');
+    }
+
+    #[\Override]
+    public static function canRestore(Model $record): bool
+    {
+        return static::tierPermits('update');
+    }
+
+    #[\Override]
+    public static function canRestoreAny(): bool
+    {
+        return static::tierPermits('update');
+    }
+
+    /**
+     * Reaching the resource at all requires being able to read it. Navigation
+     * is driven from here, so a viewer still sees the resource listed and a
+     * non-member sees nothing.
+     */
     #[\Override]
     public static function canAccess(): bool
     {
-        return auth()->check();
+        return static::tierPermits('read');
     }
 
+    /**
+     * What Filament consults for actions that have no can* hook of their own.
+     *
+     * Only reading is listed explicitly, and everything else needs a stated
+     * permission. An earlier version had it the other way round — a
+     * `default => 'read'` arm — which quietly handed a viewer every action
+     * nobody had thought to name. Filament passes replicate, reorder, attach,
+     * detach, associate and dissociate through here, so a viewer could
+     * duplicate records and pull relationships apart while holding read only.
+     *
+     * The default therefore denies. An unrecognised action is more likely to be
+     * one added later than one that is safe, and refusing it produces a visible
+     * failure and a line in this match, where allowing it produces neither.
+     */
     #[\Override]
     public static function getAuthorizationResponse(string|UnitEnum $action, ?Model $record = null): Response
     {
-        if (! auth()->check()) {
+        $name = $action instanceof UnitEnum ? $action->name : (string) $action;
+
+        $permission = match ($name) {
+            'view', 'viewAny', 'read', 'access' => 'read',
+            'create', 'replicate' => 'create',
+            'update', 'edit', 'restore', 'restoreAny', 'reorder',
+            'attach', 'attachAny', 'detach', 'detachAny',
+            'associate', 'associateAny', 'dissociate', 'dissociateAny' => 'update',
+            'delete', 'deleteAny', 'forceDelete', 'forceDeleteAny' => 'delete',
+            default => null,
+        };
+
+        if ($permission === null) {
             return Response::deny();
         }
 
-        return Response::allow();
+        return static::tierPermits($permission) ? Response::allow() : Response::deny();
+    }
+
+    /**
+     * Whether the current user's tier in the team being viewed carries this
+     * permission.
+     *
+     * Denies when there is no authenticated user and when there is no tenant.
+     * The second is the one worth stating: console commands, queued jobs and
+     * any request outside the panel have no tenant, and a check that fell
+     * through to "allowed" there would leave all 44 resources open while every
+     * test still passed. Jetstream answers true for the team's owner, who holds
+     * no membership row and therefore no tier.
+     */
+    protected static function tierPermits(string $permission): bool
+    {
+        $user = auth()->user();
+        $team = Filament::getTenant();
+
+        if (! $user || ! $team) {
+            return false;
+        }
+
+        return $user->hasTeamPermission($team, $permission);
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -10,6 +10,7 @@ use App\Filament\App\Pages\GamificationPage;
 use App\Filament\App\Pages\PedigreeChartPage;
 use App\Filament\App\Pages\PremiumDashboardPage;
 use App\Filament\App\Pages\SubscriptionPage;
+use App\Filament\App\Pages\TeamMembers;
 use App\Filament\App\Pages\TrialExpiredPage;
 use App\Filament\App\Resources\AddrResource;
 use App\Filament\App\Resources\AIRecordMatchResource;
@@ -220,6 +221,7 @@ class AppPanelProvider extends PanelProvider
                 PremiumDashboardPage::class,
                 TrialExpiredPage::class,
                 EditProfile::class,
+                TeamMembers::class,
             ])
             ->discoverWidgets(in: app_path('Filament/App/Widgets'), for: 'App\\Filament\\App\\Widgets')
             ->widgets([

--- a/database/migrations/2026_07_19_140000_backfill_collaboration_tier.php
+++ b/database/migrations/2026_07_19_140000_backfill_collaboration_tier.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Gives every existing membership an explicit collaboration tier.
+ *
+ * The tier column is nullable and, until now, nothing read it — so rows were
+ * created without one and it did not matter. It matters from this release:
+ * AppResource resolves authorisation through the tier, and a membership with
+ * none is refused everything, reading included.
+ *
+ * That is the right runtime answer to "no tier" and the wrong thing to do to
+ * people who already had access. Only a team owner can set a tier, so an
+ * existing collaborator would be locked out with no way to ask for it back
+ * except out of band.
+ *
+ * Viewer, not editor, because a null carries no evidence of what anyone
+ * intended, and read-only is the reading that cannot grant something nobody
+ * meant to grant. This does narrow existing access, deliberately: before this
+ * release every member could delete anything, so any tier at all is a
+ * reduction. Owners can raise individuals from the Members page.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('team_user') || ! Schema::hasColumn('team_user', 'role')) {
+            return;
+        }
+
+        DB::table('team_user')->whereNull('role')->update(['role' => 'viewer']);
+    }
+
+    /**
+     * Not reversed. Restoring the nulls would restore the lockout, and there is
+     * no record of which rows were originally null once they are not.
+     */
+    public function down(): void {}
+};

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -27,7 +27,14 @@ class UserSeeder extends Seeder
         ]);
 
         $team = Team::firstOrFail();
-        $adminUser->teams()->syncWithoutDetaching([$team->id]);
+
+        // With an explicit collaboration tier. This attached the admin with no
+        // tier at all, which was harmless while nothing read the column and is
+        // not any more: AppResource resolves every app-panel permission through
+        // it, and a membership carrying none is refused even reading. A fresh
+        // install would have seeded an administrator who could not open a
+        // single resource.
+        $adminUser->teams()->syncWithoutDetaching([$team->id => ['role' => 'admin']]);
         $adminUser->forceFill(['current_team_id' => $team->id])->save();
 
         // Role assignments carry a team now, and seeding has no request to take

--- a/resources/views/filament/app/pages/team-members.blade.php
+++ b/resources/views/filament/app/pages/team-members.blade.php
@@ -1,0 +1,28 @@
+<x-filament-panels::page>
+    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+        <table class="w-full text-sm">
+            <thead class="border-b border-gray-200 dark:border-white/10">
+                <tr class="text-left text-gray-500 dark:text-gray-400">
+                    <th class="px-4 py-3 font-medium">{{ __('Name') }}</th>
+                    <th class="px-4 py-3 font-medium">{{ __('Email') }}</th>
+                    <th class="px-4 py-3 font-medium">{{ __('Tier') }}</th>
+                    <th class="px-4 py-3"><span class="sr-only">{{ __('Actions') }}</span></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-white/10">
+                @foreach ($members as $member)
+                    <tr>
+                        <td class="px-4 py-3 text-gray-950 dark:text-white">{{ $member['name'] }}</td>
+                        <td class="px-4 py-3 text-gray-500 dark:text-gray-400">{{ $member['email'] }}</td>
+                        <td class="px-4 py-3 text-gray-950 dark:text-white">{{ \Illuminate\Support\Str::headline($member['tier']) }}</td>
+                        <td class="px-4 py-3 text-right">
+                            @unless ($member['is_owner'])
+                                {{ ($this->setTierAction)(['user' => $member['id']]) }}
+                            @endunless
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/Filament/Resources/ImportJobResourceTest.php
+++ b/tests/Feature/Filament/Resources/ImportJobResourceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Filament\Resources;
 use App\Filament\App\Resources\ImportJobResource;
 use App\Models\ImportJob;
 use App\Models\User;
+use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Tests\TestCase;
@@ -47,9 +48,18 @@ class ImportJobResourceTest extends TestCase
         $this->assertFalse(ImportJobResource::canCreate());
     }
 
-    public function test_can_view_any_returns_true_for_authenticated_user(): void
+    /**
+     * Being authenticated used to be the whole test, because the base resource
+     * answered every authorisation question with auth()->check(). It now asks
+     * whether the user's collaboration tier in the team being viewed carries
+     * read, so the fixture needs a team and a tenant — see
+     * CollaborationTierEnforcementTest for the tiers themselves.
+     */
+    public function test_can_view_any_returns_true_for_a_member_of_the_team_being_viewed(): void
     {
-        Auth::login($this->user);
+        $user = User::factory()->withPersonalTeam()->create();
+        Auth::login($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
 
         $this->assertTrue(ImportJobResource::canViewAny());
     }
@@ -57,6 +67,19 @@ class ImportJobResourceTest extends TestCase
     public function test_can_view_any_returns_false_when_unauthenticated(): void
     {
         Auth::logout();
+
+        $this->assertFalse(ImportJobResource::canViewAny());
+    }
+
+    /**
+     * Authenticated is no longer sufficient. Without a team in view there is
+     * nothing to resolve a tier against, which is the state console commands
+     * and queued jobs are in.
+     */
+    public function test_can_view_any_returns_false_without_a_team_in_view(): void
+    {
+        Auth::login($this->user);
+        Filament::setTenant(null, isQuiet: true);
 
         $this->assertFalse(ImportJobResource::canViewAny());
     }

--- a/tests/Feature/Tenancy/BackfillCollaborationTierTest.php
+++ b/tests/Feature/Tenancy/BackfillCollaborationTierTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Filament\App\Resources\PersonResource;
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The migration that stops existing collaborators being locked out.
+ *
+ * It runs once, against real data, on an upgrade, and on a fresh database it is
+ * a no-op — so nothing else in this suite exercises it. Enforcing the tiers
+ * turned a null tier from harmless into a total refusal, which would have taken
+ * access away from every membership row created before tiers were read.
+ */
+class BackfillCollaborationTierTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_membership_with_no_tier_is_given_the_read_only_one(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => null]);
+
+        $this->runMigration();
+
+        $this->assertSame(
+            'viewer',
+            DB::table('team_user')->where('user_id', $member->id)->value('role'),
+        );
+    }
+
+    /**
+     * The point of the migration rather than its mechanism: the member can
+     * still open the panel afterwards.
+     */
+    public function test_a_backfilled_member_can_read_again(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => null]);
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+        $this->assertFalse(PersonResource::canViewAny(), 'Fixture is degenerate: they could already read.');
+
+        $this->runMigration();
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        $this->assertTrue(PersonResource::canViewAny(), 'A backfilled member still could not read.');
+        $this->assertFalse(PersonResource::canDelete($this->person()), 'The backfill granted more than reading.');
+    }
+
+    public function test_it_does_not_disturb_a_tier_someone_chose(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $editor = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($editor, ['role' => 'editor']);
+
+        $this->runMigration();
+
+        $this->assertSame(
+            'editor',
+            DB::table('team_user')->where('user_id', $editor->id)->value('role'),
+            'The backfill overwrote a tier that had been set deliberately.',
+        );
+    }
+
+    private function person(): Person
+    {
+        return Person::factory()->make(['team_id' => Filament::getTenant()?->getKey()]);
+    }
+
+    private function runMigration(): void
+    {
+        (require database_path('migrations/2026_07_19_140000_backfill_collaboration_tier.php'))->up();
+    }
+}

--- a/tests/Feature/Tenancy/CollaborationTierEnforcementTest.php
+++ b/tests/Feature/Tenancy/CollaborationTierEnforcementTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Filament\App\Resources\PersonResource;
+use App\Models\Person;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The collaboration tiers govern what a member may do to a team's records.
+ *
+ * SPEC §10 names four of them — viewer, contributor, editor, admin — and they
+ * are defined, with explicit permissions, in the Jetstream service provider.
+ * Members are given one when they are added to a team, and it is stored against
+ * their membership.
+ *
+ * Nothing read it. Not one call to hasTeamPermission or hasTeamRole existed in
+ * the application, and the base resource that all 44 app-panel resources extend
+ * answered every authorisation question with auth()->check(). So a viewer
+ * invited to look at a family's research could delete every person in it, and
+ * the tier they were given was decoration.
+ *
+ * The tiers are strict supersets of one another, so these tests walk the
+ * boundaries rather than asserting each tier in isolation: the interesting
+ * question is always where one tier stops and the next begins.
+ */
+class CollaborationTierEnforcementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_viewer_may_read_but_not_change_anything(): void
+    {
+        $this->actingAsMemberWithTier('viewer');
+
+        $this->assertTrue(PersonResource::canViewAny(), 'A viewer could not read.');
+        $this->assertFalse(PersonResource::canCreate(), 'A viewer could create records.');
+        $this->assertFalse(PersonResource::canEdit($this->person()), 'A viewer could edit records.');
+        $this->assertFalse(PersonResource::canDelete($this->person()), 'A viewer could delete records.');
+    }
+
+    public function test_a_contributor_may_create_and_update_but_not_delete(): void
+    {
+        $this->actingAsMemberWithTier('contributor');
+
+        $this->assertTrue(PersonResource::canCreate());
+        $this->assertTrue(PersonResource::canEdit($this->person()));
+        $this->assertFalse(
+            PersonResource::canDelete($this->person()),
+            'A contributor could delete records; the tier exists precisely to withhold that.',
+        );
+    }
+
+    public function test_an_editor_may_delete(): void
+    {
+        $this->actingAsMemberWithTier('editor');
+
+        $this->assertTrue(PersonResource::canDelete($this->person()));
+    }
+
+    /**
+     * The owner is not a row in the membership table and holds no tier, so a
+     * naive lookup returns nothing for them. They must not lose access to their
+     * own team's records.
+     */
+    public function test_the_owner_may_do_everything_without_holding_a_tier(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($owner);
+        Filament::setTenant($owner->currentTeam, isQuiet: true);
+
+        $this->assertTrue(PersonResource::canViewAny());
+        $this->assertTrue(PersonResource::canCreate());
+        $this->assertTrue(PersonResource::canDelete($this->person()));
+    }
+
+    /**
+     * Guards the failure mode that would make every test above pass while the
+     * application was wide open: a check that resolves to "allowed" whenever it
+     * cannot determine a tier.
+     */
+    public function test_someone_with_no_membership_at_all_is_refused(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $outsider = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($outsider);
+        Filament::setTenant($owner->currentTeam, isQuiet: true);
+
+        $this->assertFalse(PersonResource::canCreate(), 'A non-member could create records in another team.');
+        $this->assertFalse(PersonResource::canViewAny(), 'A non-member could read another team\'s records.');
+    }
+
+    /**
+     * Console commands and queued jobs have no tenant. Authorisation must not
+     * silently allow everything there.
+     */
+    public function test_without_a_tenant_nothing_is_authorised(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant(null, isQuiet: true);
+
+        $this->assertFalse(PersonResource::canCreate());
+    }
+
+    /**
+     * Every hook, not just the ones a first pass thinks of.
+     *
+     * An adversarial review gutted canView, canDeleteAny, canForceDelete,
+     * canForceDeleteAny, canRestore and canRestoreAny to return true and the
+     * suite stayed green — six of the ten authorisation hooks were asserted by
+     * nothing. Enumerating them here means adding a hook without a test is the
+     * thing that fails.
+     */
+    public function test_every_mutating_hook_refuses_a_viewer(): void
+    {
+        $this->actingAsMemberWithTier('viewer');
+        $person = $this->person();
+
+        $this->assertTrue(PersonResource::canView($person), 'A viewer must still be able to read.');
+
+        $refused = [
+            'canCreate' => PersonResource::canCreate(),
+            'canEdit' => PersonResource::canEdit($person),
+            'canDelete' => PersonResource::canDelete($person),
+            'canDeleteAny' => PersonResource::canDeleteAny(),
+            'canForceDelete' => PersonResource::canForceDelete($person),
+            'canForceDeleteAny' => PersonResource::canForceDeleteAny(),
+            'canRestore' => PersonResource::canRestore($person),
+            'canRestoreAny' => PersonResource::canRestoreAny(),
+        ];
+
+        $this->assertSame(
+            array_fill_keys(array_keys($refused), false),
+            $refused,
+            'A viewer was permitted a mutating action.',
+        );
+    }
+
+    /**
+     * The authorisation response is what Filament consults for actions that do
+     * not have their own can* hook, and it was untested: it could be replaced
+     * with an unconditional allow without a single failure.
+     *
+     * The action names below are the ones Filament passes for record mutation
+     * beyond plain create/update/delete. They were previously unlisted, so they
+     * fell through a `default => 'read'` arm and a viewer held every one of
+     * them — replicate duplicates a record, detach and dissociate tear apart
+     * relationships. The default now denies, so a name nobody anticipated is
+     * refused rather than quietly treated as reading.
+     */
+    public function test_unanticipated_mutating_actions_are_refused_for_a_viewer(): void
+    {
+        $this->actingAsMemberWithTier('viewer');
+
+        $mutating = ['replicate', 'reorder', 'attach', 'detach', 'detachAny', 'associate', 'dissociate', 'dissociateAny', 'somethingNobodyHasWrittenYet'];
+
+        $allowed = array_values(array_filter(
+            $mutating,
+            fn (string $action): bool => PersonResource::getAuthorizationResponse($action)->allowed(),
+        ));
+
+        $this->assertSame([], $allowed, 'A viewer was allowed actions that mutate records.');
+    }
+
+    public function test_the_authorization_response_still_permits_what_a_tier_carries(): void
+    {
+        $this->actingAsMemberWithTier('editor');
+
+        $this->assertTrue(PersonResource::getAuthorizationResponse('view')->allowed());
+        $this->assertTrue(PersonResource::getAuthorizationResponse('create')->allowed());
+        $this->assertTrue(PersonResource::getAuthorizationResponse('delete')->allowed());
+    }
+
+    /**
+     * A membership can carry no tier at all — the column is nullable, and rows
+     * predating enforcement have nothing in it.
+     *
+     * Such a member is refused everything, including reading, and that is the
+     * correct runtime answer: a tier nobody chose is not evidence of a grant.
+     * But it is a lockout with no way back, since only the owner can set a
+     * tier, so leaving existing rows to hit it would be silently taking access
+     * away from real collaborators. They are backfilled by migration instead —
+     * see BackfillCollaborationTierTest — and this pins the behaviour that
+     * makes the backfill necessary rather than optional.
+     */
+    public function test_a_membership_with_no_tier_is_refused(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+
+        $owner->currentTeam->users()->attach($member, ['role' => null]);
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        $this->assertFalse(PersonResource::canViewAny());
+        $this->assertFalse(PersonResource::canCreate());
+    }
+
+    private function actingAsMemberWithTier(string $tier): User
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+
+        $owner->currentTeam->users()->attach($member, ['role' => $tier]);
+
+        $member = $member->fresh();
+        $this->actingAs($member);
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        return $member;
+    }
+
+    private function person(): Person
+    {
+        return Person::factory()->make(['team_id' => Filament::getTenant()?->getKey()]);
+    }
+}

--- a/tests/Feature/Tenancy/TeamMembersPageTest.php
+++ b/tests/Feature/Tenancy/TeamMembersPageTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Filament\App\Pages\TeamMembers;
+use App\Filament\App\Resources\PersonResource;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * The surface an owner uses to set a collaborator's tier.
+ *
+ * Enforcing the tiers made them matter; until this page there was nowhere to
+ * set one. Jetstream's team management views are not routed in this
+ * application, and the tenant profile page carries no member management, so a
+ * tier could only be changed in the database.
+ *
+ * The tiers themselves are Jetstream's, defined in the service provider and
+ * stored on the membership. This page deliberately does not create roles: SPEC
+ * §10 names a fixed set of four, and letting a team define its own would mean
+ * inventing a vocabulary the enforcement side does not understand.
+ */
+class TeamMembersPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_an_owner_can_change_a_members_tier(): void
+    {
+        [$owner, $member] = $this->teamWithMember('viewer');
+
+        Livewire::test(TeamMembers::class)
+            ->callAction('setTier', arguments: ['user' => $member->id], data: ['role' => 'editor'])
+            ->assertHasNoActionErrors();
+
+        $this->assertSame(
+            'editor',
+            $owner->currentTeam->fresh()->users->find($member->id)->membership->role,
+        );
+    }
+
+    /**
+     * The point of the whole exercise: the tier is not decoration, so changing
+     * it must change what the member may do.
+     */
+    public function test_changing_the_tier_changes_what_the_member_may_do(): void
+    {
+        [$owner, $member] = $this->teamWithMember('viewer');
+        $team = $owner->currentTeam;
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($team->fresh(), isQuiet: true);
+        $this->assertFalse(
+            PersonResource::canCreate(),
+            'Fixture is degenerate: the viewer could already create.',
+        );
+
+        $this->actingAs($owner);
+        Filament::setTenant($team, isQuiet: true);
+        Livewire::test(TeamMembers::class)
+            ->callAction('setTier', arguments: ['user' => $member->id], data: ['role' => 'editor']);
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($team->fresh(), isQuiet: true);
+
+        $this->assertTrue(
+            PersonResource::canCreate(),
+            'The member\'s rights did not follow the tier they were given.',
+        );
+    }
+
+    /**
+     * A tier is held per team. Promoting someone in one team must not promote
+     * them in another they happen to belong to.
+     */
+    public function test_a_tier_change_does_not_leak_into_another_team(): void
+    {
+        [$owner, $member] = $this->teamWithMember('viewer');
+
+        $otherOwner = User::factory()->withPersonalTeam()->create();
+        $otherTeam = $otherOwner->currentTeam;
+        $otherTeam->users()->attach($member, ['role' => 'viewer']);
+
+        Livewire::test(TeamMembers::class)
+            ->callAction('setTier', arguments: ['user' => $member->id], data: ['role' => 'editor']);
+
+        $this->assertSame(
+            'viewer',
+            $otherTeam->fresh()->users->find($member->id)->membership->role,
+            'Promoting a member in one team promoted them in another.',
+        );
+    }
+
+    public function test_a_member_who_is_not_the_owner_cannot_reach_the_page(): void
+    {
+        [, $member] = $this->teamWithMember('editor');
+
+        $this->actingAs($member->fresh());
+
+        $this->assertFalse(TeamMembers::canAccess(), 'A non-owner could reach team member management.');
+    }
+
+    /**
+     * The predicate above states the rule; this proves the page enforces it,
+     * since an action reachable by other means would make the predicate
+     * decorative.
+     */
+    public function test_a_non_owner_cannot_change_a_tier_through_the_action(): void
+    {
+        [$owner, $member] = $this->teamWithMember('editor');
+        $other = User::factory()->create();
+        $owner->currentTeam->users()->attach($other, ['role' => 'viewer']);
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        // The page refuses to mount for a non-owner, so the action cannot be
+        // reached through it at all. Asserting on the action's own response
+        // would be asserting against a component that never came up.
+        Livewire::test(TeamMembers::class)->assertForbidden();
+
+        $this->assertSame(
+            'viewer',
+            $owner->currentTeam->fresh()->users->find($other->id)->membership->role,
+            'A non-owner promoted another member.',
+        );
+    }
+
+    /**
+     * Ownership can be lost while the page sits open, and the change must stop
+     * working at that moment rather than at the next full page load.
+     *
+     * This holds because Filament re-runs canAccess() on every Livewire
+     * hydration, not only on mount. The page relies on that entirely — it
+     * carries no per-action authorisation — so this test is what pins the
+     * behaviour being relied on.
+     *
+     * It exists because the reverse was assumed first. The page did have a Gate
+     * check inside the action, and deleting it changed nothing: every test here
+     * still passed, because canAccess had already refused the request before
+     * the action ran. The check could not fire, so it went, and this took its
+     * place.
+     */
+    public function test_ownership_lost_after_the_page_is_open_stops_further_changes(): void
+    {
+        [$owner, $member] = $this->teamWithMember('viewer');
+        $team = $owner->currentTeam;
+
+        $page = Livewire::test(TeamMembers::class);
+
+        // The team is handed to someone else while the page sits open.
+        $usurper = User::factory()->create();
+        $team->forceFill(['user_id' => $usurper->id])->save();
+        Filament::setTenant($team->fresh(), isQuiet: true);
+
+        // Asserted on the outcome rather than the response: a component the
+        // former owner may no longer access does not re-hydrate, and Livewire's
+        // test harness surfaces that as a null instance rather than a 403. What
+        // matters is that the change does not happen.
+        try {
+            $page->callAction('setTier', arguments: ['user' => $member->id], data: ['role' => 'admin']);
+        } catch (\Throwable) {
+            // Refused, in whichever form.
+        }
+
+        $this->assertSame(
+            'viewer',
+            $team->fresh()->users->find($member->id)->membership->role,
+            'A former owner changed a tier through a page opened while they still owned the team.',
+        );
+    }
+
+    public function test_the_owner_is_listed_and_cannot_be_demoted(): void
+    {
+        [$owner] = $this->teamWithMember('viewer');
+
+        Livewire::test(TeamMembers::class)
+            ->callAction('setTier', arguments: ['user' => $owner->id], data: ['role' => 'viewer'])
+            ->assertForbidden();
+    }
+
+    /**
+     * @return array{0: User, 1: User}
+     */
+    private function teamWithMember(string $tier): array
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+
+        $owner->currentTeam->users()->attach($member, ['role' => $tier]);
+
+        $owner = $owner->fresh();
+        $this->actingAs($owner);
+        Filament::setTenant($owner->currentTeam, isQuiet: true);
+
+        return [$owner, $member];
+    }
+}

--- a/tests/Feature/Tenancy/TreePrivacyAuthorizationTest.php
+++ b/tests/Feature/Tenancy/TreePrivacyAuthorizationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Filament\App\Pages\TreePrivacy;
+use App\Models\Tree;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Publishing a family tree is the most consequential thing this application
+ * does — it puts records of living relatives on the public internet — and it
+ * was the action with the least protection in front of it.
+ *
+ * The page carried no access check and the toggle no permission check, so any
+ * member of a team could publish or unpublish all of its trees. A viewer,
+ * invited to look at one family's research and nothing more, could make the
+ * whole of it public.
+ *
+ * Custom pages are not resources, so the collaboration tiers AppResource
+ * enforces do not reach them on their own; the check has to be stated. Other
+ * pages in this directory still lack one — see the follow-up ticket — but this
+ * one is not left waiting for it.
+ */
+class TreePrivacyAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_viewer_cannot_publish_a_tree(): void
+    {
+        [$tree] = $this->teamWithTree('viewer');
+
+        $this->attemptToggle($tree->id);
+
+        $this->assertFalse(
+            (bool) $tree->fresh()->is_public,
+            'A read-only member published the team\'s family tree.',
+        );
+
+        $this->assertFalse(TreePrivacy::canAccess(), 'A viewer could reach the privacy page.');
+    }
+
+    public function test_a_contributor_cannot_publish_a_tree(): void
+    {
+        [$tree] = $this->teamWithTree('contributor');
+
+        $this->attemptToggle($tree->id);
+
+        $this->assertFalse(
+            (bool) $tree->fresh()->is_public,
+            'Publishing is a deletion-grade decision and must not sit below the delete tier.',
+        );
+    }
+
+    public function test_an_editor_can_publish_and_unpublish(): void
+    {
+        [$tree] = $this->teamWithTree('editor');
+
+        Livewire::test(TreePrivacy::class)->call('toggle', $tree->id);
+        $this->assertTrue((bool) $tree->fresh()->is_public, 'An editor could not publish.');
+
+        Livewire::test(TreePrivacy::class)->call('toggle', $tree->id);
+        $this->assertFalse((bool) $tree->fresh()->is_public, 'An editor could not make it private again.');
+    }
+
+    public function test_the_owner_can_publish(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($owner);
+        Filament::setTenant($owner->currentTeam, isQuiet: true);
+
+        $tree = Tree::factory()->create(['team_id' => $owner->current_team_id, 'is_public' => false]);
+
+        Livewire::test(TreePrivacy::class)->call('toggle', $tree->id);
+
+        $this->assertTrue((bool) $tree->fresh()->is_public);
+    }
+
+    /**
+     * A page the current user may not reach does not mount, so Livewire raises
+     * on the snapshot rather than returning a response to assert against. The
+     * assertion that matters is on the tree, not the transport: whatever shape
+     * the refusal takes, the tree must not have been published.
+     */
+    private function attemptToggle(int $treeId): void
+    {
+        try {
+            Livewire::test(TreePrivacy::class)->call('toggle', $treeId);
+        } catch (\Throwable) {
+            // Refused.
+        }
+    }
+
+    /**
+     * @return array{0: Tree, 1: User}
+     */
+    private function teamWithTree(string $tier): array
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => $tier]);
+
+        $tree = Tree::factory()->create(['team_id' => $owner->current_team_id, 'is_public' => false]);
+
+        $member = $member->fresh();
+        $this->actingAs($member);
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        return [$tree, $member];
+    }
+}


### PR DESCRIPTION
**The app panel had no authorisation.** `AppResource`, which all 44 of its resources extend, answered every authorisation question with `auth()->check()`. Any member of a team could do anything to any of its records.

Meanwhile the four tiers SPEC §10 asks for — viewer, contributor, editor, admin — were declared in the Jetstream service provider with explicit permissions, assigned to members as they joined a team, and **read by nothing**. Not one call to `hasTeamPermission` existed in the application. A viewer invited to look at one family's research could delete every person in it.

## The design decision

SPEC §10 names exactly those four tiers, and Jetstream already defines them with permissions, stored on the membership. So the set stays **fixed** rather than team-defined: they mean something only because `AppResource` knows what each permits, and a team inventing its own would produce a tier nothing could enforce.

That also dissolves the escalation risk the ticket worried about — the new page **assigns** roles and never **creates** one, so it cannot mint a team-less role.

Worth stating plainly: **this does not build on #05's Spatie team-scoped roles.** Two systems now serve two purposes — Jetstream tiers govern what a collaborator may do to one team's records; the permission library governs application-wide rights and the admin panel. Recorded in `AppResource`. #05 still stands on its own, since roles being global was a real hole.

## Two things worse than the ticket described

**`TreePrivacy` had no check of any kind.** Publishing a tree puts records of living relatives on the public internet, and any member — down to a viewer — could publish every tree a team held. Now gated at the **delete** tier rather than update, because publication cannot be taken back once the data has been seen or indexed.

**The tier column is nullable, and `UserSeeder` attached the admin with no tier.** Harmless while nothing read the column; a locked-out administrator on every fresh install once something did. The seeder names a tier, and a migration backfills existing rows to `viewer` — only an owner can set one, so an existing collaborator would otherwise have had no way back. Verified against a real cold `migrate --seed`.

## Corrections from adversarial review

- **The first draft's action mapping fell through to `read`** for any action it did not name, handing viewers `replicate`, `reorder`, `attach`, `detach`, `associate`, `dissociate`. Reproduced with a test, then fixed to **deny by default**.
- **Six of the ten authorisation hooks could be replaced with `return true`** without a single test failing. Now covered — and the mutations were re-run to confirm they fail.
- **A `Gate` check inside the tier-change action could never fire.** Filament re-runs `canAccess()` on every Livewire hydration, not just mount, so `canAccess` had always refused first. Removed rather than left as a branch that reads as a security boundary, with a test pinning the hydration behaviour now relied on.

## What this does NOT cover

Recorded in `AppResource`'s docblock and ticketed as tenant-isolation #11. All predate this change; none are made worse by it:

- **Relation managers** route authorisation to the model's policy unless they name a related resource, and none of the six do.
- **The remaining custom pages** are not resources, so nothing here reaches them.
- **Livewire components addressed directly**, and bare `->action()` closures on resources, mutate records without consulting any of this.

"The app panel is authorised now" is the conclusion a reader would otherwise draw, and it would be wrong.

## Verification

- 714 passed, 12 skipped. PHPStan clean with no baseline growth. Pint clean.
- Every claim above was reproduced as a failing test before being fixed.
- Mutation-tested: the review's three surviving mutations now fail.
