### PR TITLE
fix(tenancy): enforce collaboration tiers on relation managers [tenant-isolation #11]

### DIFF
--- a/app/Filament/App/Concerns/AuthorizesCollaborationTier.php
+++ b/app/Filament/App/Concerns/AuthorizesCollaborationTier.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Concerns;
+
+use Filament\Facades\Filament;
+
+/**
+ * Resolves an action against the collaboration tier the current user holds in
+ * the team being viewed.
+ *
+ * Shared by the app panel's resources and its relation managers because they
+ * must agree. They are separate authorisation surfaces in Filament — a resource
+ * answers can* hooks, a relation manager answers one response method — and if
+ * each carried its own list of which actions count as writing, the two would
+ * drift and a viewer would end up able to do through a relationship what they
+ * cannot do directly. That is precisely the gap this trait exists to close: the
+ * tiers were enforced on resources first, and relation managers went on
+ * resolving against model policies, several of which do not exist and therefore
+ * allow.
+ */
+trait AuthorizesCollaborationTier
+{
+    /**
+     * The permission an action requires, or null when the action is not one
+     * this application recognises.
+     *
+     * Reading is listed explicitly and everything else must be named. The
+     * default is null — refuse — rather than 'read', which is the arrangement
+     * that let a viewer replicate records and tear relationships apart: those
+     * action names had simply never been thought of. An action added later is
+     * far more likely to write than to read, and refusing it fails visibly,
+     * where allowing it fails silently.
+     */
+    protected static function permissionForCollaborationAction(string $action): ?string
+    {
+        return match ($action) {
+            'view', 'viewAny', 'read', 'access' => 'read',
+            'create', 'replicate' => 'create',
+            'update', 'edit', 'restore', 'restoreAny', 'reorder',
+            'attach', 'attachAny', 'associate', 'associateAny' => 'update',
+
+            // Detaching and dissociating destroy a link a researcher recorded.
+            // The record survives, but the relationship they established does
+            // not, so they sit with delete rather than with update.
+            'delete', 'deleteAny', 'forceDelete', 'forceDeleteAny',
+            'detach', 'detachAny', 'dissociate', 'dissociateAny' => 'delete',
+
+            default => null,
+        };
+    }
+
+    /**
+     * Whether the current user's tier in the team being viewed carries this
+     * permission.
+     *
+     * Denies when there is no authenticated user and when there is no tenant.
+     * The second matters most: console commands, queued jobs and anything
+     * outside the panel have no tenant, and falling through to "allowed" there
+     * would open every resource and relation manager at once while every test
+     * still passed. Jetstream answers true for the team's owner, who holds no
+     * membership row and so no tier.
+     */
+    protected static function collaborationTierPermits(string $permission): bool
+    {
+        $user = auth()->user();
+        $team = Filament::getTenant();
+
+        if (! $user || ! $team) {
+            return false;
+        }
+
+        return $user->hasTeamPermission($team, $permission);
+    }
+}

--- a/app/Filament/App/Resources/AppRelationManager.php
+++ b/app/Filament/App/Resources/AppRelationManager.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources;
+
+use App\Filament\App\Concerns\AuthorizesCollaborationTier;
+use Filament\Resources\RelationManagers\RelationManager;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Base for the app panel's relation managers, so a collaborator's tier governs
+ * what hangs off a record as well as the record itself.
+ *
+ * Filament routes a relation manager's authorisation to the related model's
+ * policy unless the manager names a related resource, and none of these did.
+ * Several of the models involved have no policy at all, which allows. So a
+ * viewer — who may legitimately open a person, because they hold read — could
+ * delete every photo, source and association attached to them. Being let in to
+ * the parent record is what made it reachable.
+ *
+ * Naming a related resource is the other way to fix this and was not taken: it
+ * also changes how Filament routes that manager's create and edit pages, which
+ * is a behavioural change bought for an authorisation problem.
+ *
+ * Every action funnels through the one method below, so unlike a resource there
+ * is no list of hooks to keep complete.
+ */
+abstract class AppRelationManager extends RelationManager
+{
+    use AuthorizesCollaborationTier;
+
+    #[\Override]
+    public function getAuthorizationResponse(string $action, ?Model $record = null): Response
+    {
+        $permission = static::permissionForCollaborationAction($action);
+
+        if ($permission === null) {
+            return Response::deny();
+        }
+
+        return static::collaborationTierPermits($permission)
+            ? Response::allow()
+            : Response::deny();
+    }
+}

--- a/app/Filament/App/Resources/AppResource.php
+++ b/app/Filament/App/Resources/AppResource.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\App\Resources;
 
-use Filament\Facades\Filament;
+use App\Filament\App\Concerns\AuthorizesCollaborationTier;
 use Filament\Resources\Resource;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;
@@ -34,79 +34,83 @@ use UnitEnum;
  * WHAT THIS DOES NOT COVER, because a base class for resources can only speak
  * for resources, and an unqualified claim here would be worse than none:
  *
- * - Relation managers. Filament routes their authorisation to the model's
- *   policy unless the manager names a related resource, and none of the six
- *   here do. A viewer who may open a record can still act on what hangs off it.
  * - Custom pages. Not resources, so nothing here applies; each needs its own
- *   check. TreePrivacy has one, since publishing a family tree is the most
- *   consequential thing in the application. The rest do not yet.
+ *   check. TreePrivacy has one, because publishing a family tree is the most
+ *   consequential thing in the application, and the GEDCOM export page is
+ *   confined to its own team's directory. The rest do not yet.
  * - Livewire components addressed directly, and bare ->action() closures on
  *   resources, which mutate records without consulting any of this.
  *
- * Those are older than this class's enforcement and are a separate ticket.
- * They are listed because "the app panel is authorised now" is the conclusion a
- * reader would otherwise draw, and it would be wrong.
+ * Relation managers used to head this list; AppRelationManager now answers for
+ * them, through the same shared trait, so the two cannot disagree about which
+ * actions write.
+ *
+ * The rest are older than this class's enforcement and remain open. They are
+ * listed because "the app panel is authorised now" is the conclusion a reader
+ * would otherwise draw, and it would still be wrong.
  */
 abstract class AppResource extends Resource
 {
+    use AuthorizesCollaborationTier;
+
     #[\Override]
     public static function canViewAny(): bool
     {
-        return static::tierPermits('read');
+        return static::collaborationTierPermits('read');
     }
 
     #[\Override]
     public static function canView(Model $record): bool
     {
-        return static::tierPermits('read');
+        return static::collaborationTierPermits('read');
     }
 
     #[\Override]
     public static function canCreate(): bool
     {
-        return static::tierPermits('create');
+        return static::collaborationTierPermits('create');
     }
 
     #[\Override]
     public static function canEdit(Model $record): bool
     {
-        return static::tierPermits('update');
+        return static::collaborationTierPermits('update');
     }
 
     #[\Override]
     public static function canDelete(Model $record): bool
     {
-        return static::tierPermits('delete');
+        return static::collaborationTierPermits('delete');
     }
 
     #[\Override]
     public static function canDeleteAny(): bool
     {
-        return static::tierPermits('delete');
+        return static::collaborationTierPermits('delete');
     }
 
     #[\Override]
     public static function canForceDelete(Model $record): bool
     {
-        return static::tierPermits('delete');
+        return static::collaborationTierPermits('delete');
     }
 
     #[\Override]
     public static function canForceDeleteAny(): bool
     {
-        return static::tierPermits('delete');
+        return static::collaborationTierPermits('delete');
     }
 
     #[\Override]
     public static function canRestore(Model $record): bool
     {
-        return static::tierPermits('update');
+        return static::collaborationTierPermits('update');
     }
 
     #[\Override]
     public static function canRestoreAny(): bool
     {
-        return static::tierPermits('update');
+        return static::collaborationTierPermits('update');
     }
 
     /**
@@ -117,65 +121,29 @@ abstract class AppResource extends Resource
     #[\Override]
     public static function canAccess(): bool
     {
-        return static::tierPermits('read');
+        return static::collaborationTierPermits('read');
     }
 
     /**
      * What Filament consults for actions that have no can* hook of their own.
      *
-     * Only reading is listed explicitly, and everything else needs a stated
-     * permission. An earlier version had it the other way round — a
-     * `default => 'read'` arm — which quietly handed a viewer every action
-     * nobody had thought to name. Filament passes replicate, reorder, attach,
-     * detach, associate and dissociate through here, so a viewer could
-     * duplicate records and pull relationships apart while holding read only.
-     *
-     * The default therefore denies. An unrecognised action is more likely to be
-     * one added later than one that is safe, and refusing it produces a visible
-     * failure and a line in this match, where allowing it produces neither.
+     * The mapping lives in the shared trait, because relation managers answer
+     * the same question through a different method and the two must not drift.
+     * An unrecognised action is refused there rather than treated as reading —
+     * an earlier version of this method did the latter and handed viewers
+     * replicate, reorder, attach, detach, associate and dissociate.
      */
     #[\Override]
     public static function getAuthorizationResponse(string|UnitEnum $action, ?Model $record = null): Response
     {
         $name = $action instanceof UnitEnum ? $action->name : (string) $action;
 
-        $permission = match ($name) {
-            'view', 'viewAny', 'read', 'access' => 'read',
-            'create', 'replicate' => 'create',
-            'update', 'edit', 'restore', 'restoreAny', 'reorder',
-            'attach', 'attachAny', 'detach', 'detachAny',
-            'associate', 'associateAny', 'dissociate', 'dissociateAny' => 'update',
-            'delete', 'deleteAny', 'forceDelete', 'forceDeleteAny' => 'delete',
-            default => null,
-        };
+        $permission = static::permissionForCollaborationAction($name);
 
         if ($permission === null) {
             return Response::deny();
         }
 
-        return static::tierPermits($permission) ? Response::allow() : Response::deny();
-    }
-
-    /**
-     * Whether the current user's tier in the team being viewed carries this
-     * permission.
-     *
-     * Denies when there is no authenticated user and when there is no tenant.
-     * The second is the one worth stating: console commands, queued jobs and
-     * any request outside the panel have no tenant, and a check that fell
-     * through to "allowed" there would leave all 44 resources open while every
-     * test still passed. Jetstream answers true for the team's owner, who holds
-     * no membership row and therefore no tier.
-     */
-    protected static function tierPermits(string $permission): bool
-    {
-        $user = auth()->user();
-        $team = Filament::getTenant();
-
-        if (! $user || ! $team) {
-            return false;
-        }
-
-        return $user->hasTeamPermission($team, $permission);
+        return static::collaborationTierPermits($permission) ? Response::allow() : Response::deny();
     }
 }

--- a/app/Filament/App/Resources/ChecklistTemplateResource/RelationManagers/TemplateItemsRelationManager.php
+++ b/app/Filament/App/Resources/ChecklistTemplateResource/RelationManagers/TemplateItemsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources\ChecklistTemplateResource\RelationManagers;
 
+use App\Filament\App\Resources\AppRelationManager;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -12,7 +13,6 @@ use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
-use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -21,7 +21,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 
-class TemplateItemsRelationManager extends RelationManager
+class TemplateItemsRelationManager extends AppRelationManager
 {
     #[\Override]
     protected static string $relationship = 'templateItems';

--- a/app/Filament/App/Resources/PersonResource/RelationManagers/AssociationsRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/AssociationsRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\App\Resources\PersonResource\RelationManagers;
 
 use App\Enums\AssociationType;
+use App\Filament\App\Resources\AppRelationManager;
 use App\Models\Person;
 use App\Models\PersonAsso;
 use Filament\Actions\BulkActionGroup;
@@ -13,7 +14,6 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
-use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -23,7 +23,7 @@ use Filament\Tables\Table;
  * family record expresses. `group` and `gid` are stamped by the `associations`
  * relation itself (see Person::associations), so neither appears in the form.
  */
-class AssociationsRelationManager extends RelationManager
+class AssociationsRelationManager extends AppRelationManager
 {
     #[\Override]
     protected static string $relationship = 'associations';

--- a/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources\PersonResource\RelationManagers;
 
+use App\Filament\App\Resources\AppRelationManager;
 use App\Models\PersonPhoto;
 use App\Services\FacialRecognitionService;
 use Filament\Actions\Action;
@@ -12,13 +13,12 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components;
 use Filament\Notifications\Notification;
-use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\Storage;
 
-class PhotosRelationManager extends RelationManager
+class PhotosRelationManager extends AppRelationManager
 {
     #[\Override]
     protected static string $relationship = 'photos';

--- a/app/Filament/App/Resources/PersonResource/RelationManagers/SourcesRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/SourcesRelationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\App\Resources\PersonResource\RelationManagers;
 
+use App\Filament\App\Resources\AppRelationManager;
 use App\Filament\App\Resources\SourceRefResource;
 use App\Models\SourceRef;
 use Filament\Actions\BulkActionGroup;
@@ -11,7 +12,6 @@ use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
-use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -24,7 +24,7 @@ use Filament\Tables\Table;
  * the finer-grained indi_name/indi_even/indi_asso/indi_lds — so this is the only
  * thing that populates the person half of CompletenessService::sourceCompleteness().
  */
-class SourcesRelationManager extends RelationManager
+class SourcesRelationManager extends AppRelationManager
 {
     #[\Override]
     protected static string $relationship = 'sourceRefs';

--- a/app/Filament/App/Resources/SourceResource/RelationManagers/CitationsRelationManager.php
+++ b/app/Filament/App/Resources/SourceResource/RelationManagers/CitationsRelationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\App\Resources\SourceResource\RelationManagers;
 
+use App\Filament\App\Resources\AppRelationManager;
 use Filament\Actions\AssociateAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
@@ -14,7 +15,6 @@ use Filament\Actions\DissociateBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
-use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -26,7 +26,7 @@ use Filament\Tables\Table;
  * Citation). There is no person_id/group-gid on the citations table, so
  * person↔citation cannot be expressed here; see EvidenceLinkingTest / report.
  */
-class CitationsRelationManager extends RelationManager
+class CitationsRelationManager extends AppRelationManager
 {
     #[\Override]
     protected static string $relationship = 'citations';

--- a/app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
+++ b/app/Filament/App/Resources/VirtualEventResource/RelationManagers/AttendeesRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources\VirtualEventResource\RelationManagers;
 
+use App\Filament\App\Resources\AppRelationManager;
 use App\Models\Person;
 use App\Models\User;
 use App\Models\VirtualEventAttendee;
@@ -19,7 +20,6 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
-use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
@@ -29,7 +29,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 
-class AttendeesRelationManager extends RelationManager
+class AttendeesRelationManager extends AppRelationManager
 {
     #[\Override]
     protected static string $relationship = 'attendees';

--- a/tests/Feature/Tenancy/RelationManagerTierEnforcementTest.php
+++ b/tests/Feature/Tenancy/RelationManagerTierEnforcementTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Filament\App\Resources\PersonResource\RelationManagers\PhotosRelationManager;
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A collaborator's tier has to govern what hangs off a record as well as the
+ * record itself.
+ *
+ * Enforcing the tiers on resources left this open. Filament sends a relation
+ * manager's authorisation to the related model's policy unless the manager
+ * names a related resource, and none of the six here did — so several resolved
+ * against a model with no policy at all, which allows. A viewer could
+ * legitimately open a person, because they hold read, and then delete every
+ * photo, source and association attached to them.
+ *
+ * The parent resource being authorised is exactly what makes this reachable:
+ * you have to be let in before you can act on what is inside.
+ */
+class RelationManagerTierEnforcementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_viewer_may_read_but_not_change_what_hangs_off_a_record(): void
+    {
+        $manager = $this->managerFor('viewer');
+
+        $this->assertTrue($manager->getAuthorizationResponse('view')->allowed(), 'A viewer could not read.');
+        $this->assertFalse($manager->getAuthorizationResponse('create')->allowed(), 'A viewer could attach records.');
+        $this->assertFalse($manager->getAuthorizationResponse('update')->allowed(), 'A viewer could edit them.');
+        $this->assertFalse($manager->getAuthorizationResponse('delete')->allowed(), 'A viewer could delete them.');
+    }
+
+    public function test_a_contributor_may_add_but_not_delete(): void
+    {
+        $manager = $this->managerFor('contributor');
+
+        $this->assertTrue($manager->getAuthorizationResponse('create')->allowed());
+        $this->assertTrue($manager->getAuthorizationResponse('update')->allowed());
+        $this->assertFalse($manager->getAuthorizationResponse('delete')->allowed());
+    }
+
+    public function test_an_editor_may_delete(): void
+    {
+        $this->assertTrue($this->managerFor('editor')->getAuthorizationResponse('delete')->allowed());
+    }
+
+    /**
+     * Detaching is how you remove a record from a relationship without deleting
+     * it, and dissociating is the same for a belongs-to. Both destroy the link
+     * a researcher recorded, so both belong with delete rather than with the
+     * update tier — and neither has a can* hook of its own, so an unnamed
+     * action falling through to something permissive is the failure mode.
+     */
+    public function test_a_contributor_cannot_detach_or_dissociate(): void
+    {
+        $manager = $this->managerFor('contributor');
+
+        foreach (['detach', 'detachAny', 'dissociate', 'dissociateAny'] as $action) {
+            $this->assertFalse(
+                $manager->getAuthorizationResponse($action)->allowed(),
+                "A contributor was allowed to {$action}.",
+            );
+        }
+    }
+
+    public function test_an_unrecognised_action_is_refused(): void
+    {
+        $this->assertFalse(
+            $this->managerFor('editor')->getAuthorizationResponse('somethingNobodyHasWrittenYet')->allowed(),
+            'An action nobody anticipated was allowed rather than refused.',
+        );
+    }
+
+    public function test_the_owner_may_do_everything(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($owner);
+        Filament::setTenant($owner->currentTeam, isQuiet: true);
+
+        $manager = new PhotosRelationManager;
+
+        $this->assertTrue($manager->getAuthorizationResponse('delete')->allowed());
+    }
+
+    public function test_without_a_tenant_nothing_is_authorised(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant(null, isQuiet: true);
+
+        $this->assertFalse((new PhotosRelationManager)->getAuthorizationResponse('view')->allowed());
+    }
+
+    private function managerFor(string $tier): PhotosRelationManager
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => $tier]);
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        Person::factory()->create(['team_id' => $owner->current_team_id]);
+
+        return new PhotosRelationManager;
+    }
+}


### PR DESCRIPTION
Second slice of tenant-isolation #11, after the export leak (#1542).

**Enforcing the collaboration tiers on resources left what hangs off a record unguarded.** Filament routes a relation manager's authorisation to the related model's policy unless the manager names a related resource — and none of the six did. Several of the models involved have no policy at all, which resolves to allow.

So a viewer could legitimately open a person, because they hold `read`, and then **delete every photo, source and association attached to them**. Being let in to the parent record is precisely what made it reachable.

## Shape of the fix

Every relation-manager action funnels through a single `getAuthorizationResponse()`, so these now extend a base class overriding that one method — no list of hooks to keep complete, unlike a resource.

**Naming a related resource is the other way to do this, and was not taken.** It works, but it also changes how Filament routes that manager's create and edit pages: a behavioural change bought to solve an authorisation problem.

## Why the mapping moved into a trait

Resources and relation managers answer the same question through different methods. Two copies of "which actions count as writing" would drift, and the first symptom would be a viewer doing through a relationship what they cannot do directly — the exact gap being closed here. So `AppResource` and `AppRelationManager` now share one mapping and cannot disagree.

`detach` and `dissociate` sit with **delete**, not update: the record survives, but the relationship a researcher recorded does not.

Unrecognised actions are refused, consistent with the fix in #1541.

## Verification

- 726 passed, 12 skipped. PHPStan clean, no baseline growth. Pint clean.
- **Mutation-tested**: gutting the new method to `return Response::allow()` fails five of the seven new tests, so they check the code rather than their own fixtures.

## Still open in #11

The remaining custom pages, Livewire components addressed directly, and bare `->action()` closures. `AppResource`'s docblock has been updated to drop relation managers from its list of gaps and keep the rest.
