### PR TITLE
fix(tenancy): stop GrampsXML exports leaking between teams [tenant-isolation #11]

### DIFF
--- a/app/Filament/App/Pages/GrampsXmlExportPage.php
+++ b/app/Filament/App/Pages/GrampsXmlExportPage.php
@@ -6,6 +6,7 @@ namespace App\Filament\App\Pages;
 
 use App\Jobs\ExportGrampsXml;
 use Filament\Actions\Action;
+use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Support\Facades\Auth;
@@ -45,11 +46,22 @@ class GrampsXmlExportPage extends Page
         ];
     }
 
+    /**
+     * The team is required, not optional: the export is written into that
+     * team's directory and built from that team's records. Dispatched without
+     * one, the job produced a file from every team's data — the tenant scope is
+     * a global scope that no-ops when nobody is authenticated, which is every
+     * queued job.
+     */
     public function startExport(): void
     {
         $user = Auth::user();
+        $tenant = Filament::getTenant();
+
+        abort_unless($user && $tenant, 403);
+
         $fileName = now()->format('Y-m-d_His').'_family_tree.gramps';
-        ExportGrampsXml::dispatch($fileName, $user);
+        ExportGrampsXml::dispatch($fileName, $user, (int) $tenant->getKey());
 
         Notification::make()
             ->title('Export started')

--- a/app/Filament/App/Resources/GedcomResource.php
+++ b/app/Filament/App/Resources/GedcomResource.php
@@ -163,10 +163,15 @@ class GedcomResource extends AppResource
     public static function exportGrampsXml(): void
     {
         $user = auth()->user();
-        if (! $user) {
+        $tenant = Filament::getTenant();
+
+        // Same requirement as the GEDCOM export above: without a team the file
+        // has nowhere of its own to go, and nothing to scope its contents to.
+        if (! $user || ! $tenant) {
             return;
         }
+
         $fileName = now()->format('Y-m-d_His').'_family_tree.gramps';
-        ExportGrampsXml::dispatch($fileName, $user);
+        ExportGrampsXml::dispatch($fileName, $user, (int) $tenant->getKey());
     }
 }

--- a/app/Jobs/Concerns/ExportsForTeam.php
+++ b/app/Jobs/Concerns/ExportsForTeam.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Concerns;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Shared by the export jobs, which both have to solve the same two problems.
+ *
+ * Where the file goes. Exports were written to the root of the shared private
+ * disk under timestamped names, and the export page listed everything there, so
+ * every team was shown every other team's exported tree. They live under the
+ * team that produced them now, and the page looks no further than its own
+ * directory. Both jobs take that path from here so they cannot disagree about
+ * it — a second copy drifting is how a file ends up somewhere nothing lists, or
+ * somewhere everything does.
+ *
+ * What goes in it. The generators query through the Person and Family models,
+ * whose tenant scope is a global scope that returns early when nobody is
+ * authenticated — and nothing is authenticated inside a queued job. So an
+ * export walked every team's records into one file. Authenticating the
+ * requesting user, pinned to the team being exported, puts the scope back in
+ * play for the duration.
+ *
+ * That second part is a local answer to a general problem: no job in this
+ * application establishes a tenant, and the rest are scoped by luck or not at
+ * all. Tenant-isolation #08 is where that gets solved properly.
+ */
+trait ExportsForTeam
+{
+    /**
+     * Where a team's exports live. Also the boundary the export page trusts.
+     */
+    public static function directoryFor(int $teamId): string
+    {
+        return "exports/{$teamId}";
+    }
+
+    /**
+     * Run a callback with the exporting user authenticated against the team
+     * being exported, restoring whatever the worker had before.
+     *
+     * @template T
+     *
+     * @param  callable(): T  $callback
+     * @return T
+     */
+    protected function asTeamMember(User $user, int $teamId, callable $callback): mixed
+    {
+        $previous = Auth::user();
+
+        // The tenant scope reads the current team, and a user can belong to
+        // several — so exporting while they happen to be working elsewhere
+        // would produce the wrong family's records under this team's directory.
+        // Only this job's copy is adjusted; nothing is saved.
+        $scoped = $user->replicate();
+        $scoped->id = $user->id;
+        $scoped->exists = true;
+        $scoped->current_team_id = $teamId;
+
+        Auth::login($scoped);
+
+        try {
+            return $callback();
+        } finally {
+            // A worker serves many jobs in one process; leaving this set would
+            // scope the next job to whoever ran this one.
+            Auth::logout();
+
+            if ($previous) {
+                Auth::login($previous);
+            }
+        }
+    }
+}

--- a/app/Jobs/ExportGedCom.php
+++ b/app/Jobs/ExportGedCom.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Jobs\Concerns\ExportsForTeam;
 use App\Models\Family;
 use App\Models\Person;
 use App\Models\User;
@@ -13,14 +14,13 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Throwable;
 
 final class ExportGedCom implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, ExportsForTeam, InteractsWithQueue, Queueable, SerializesModels;
 
     public function __construct(
         private readonly string $file,
@@ -56,26 +56,14 @@ final class ExportGedCom implements ShouldQueue
     public function handle(): void
     {
         try {
-            $previous = Auth::user();
-
-            Auth::login($this->exportingUser());
-
-            try {
+            $content = $this->asTeamMember($this->user, $this->teamId, function (): string {
                 $people = Person::count();
                 $families = Family::count();
 
                 Log::info("Exporting {$people} people and {$families} families for team {$this->teamId}.");
 
-                $content = (new GedcomService)->generateGedcomContent();
-            } finally {
-                // A worker serves many jobs in one process; leaving this set
-                // would scope the next job to whoever ran this one.
-                Auth::logout();
-
-                if ($previous) {
-                    Auth::login($previous);
-                }
-            }
+                return (new GedcomService)->generateGedcomContent();
+            });
 
             Storage::disk('private')->put($this->path(), $content);
 
@@ -86,36 +74,8 @@ final class ExportGedCom implements ShouldQueue
         }
     }
 
-    /**
-     * Where this team's exports live. Also the boundary the export page trusts,
-     * so it is defined here rather than assembled at each call site.
-     */
-    public static function directoryFor(int $teamId): string
-    {
-        return "exports/{$teamId}";
-    }
-
     private function path(): string
     {
         return self::directoryFor($this->teamId).'/'.$this->file;
-    }
-
-    /**
-     * The requesting user, with their current team pinned to the team being
-     * exported.
-     *
-     * The tenant scope reads the current team, and a user can belong to several
-     * — so exporting while they happen to be working elsewhere would otherwise
-     * produce a file full of the wrong family's records under this team's
-     * directory. The instance is not saved; only this job's copy is adjusted.
-     */
-    private function exportingUser(): User
-    {
-        $user = $this->user->replicate();
-        $user->id = $this->user->id;
-        $user->exists = true;
-        $user->current_team_id = $this->teamId;
-
-        return $user;
     }
 }

--- a/app/Jobs/ExportGrampsXml.php
+++ b/app/Jobs/ExportGrampsXml.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Jobs\Concerns\ExportsForTeam;
 use App\Models\Family;
 use App\Models\Person;
 use App\Models\User;
@@ -19,25 +20,32 @@ use Throwable;
 
 final class ExportGrampsXml implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, ExportsForTeam, InteractsWithQueue, Queueable, SerializesModels;
 
     public function __construct(
         private string $file,
         private User $user,
+        private int $teamId,
     ) {}
 
+    /**
+     * Exports one team's tree, into that team's own directory. The reasoning is
+     * in ExportsForTeam; the leak was plainer here than in the GEDCOM export,
+     * since Person::all() is handed straight to the generator.
+     */
     public function handle(): void
     {
         try {
-            $people = Person::all();
-            $families = Family::all();
+            $content = $this->asTeamMember($this->user, $this->teamId, function (): string {
+                $people = Person::all();
+                $families = Family::all();
 
-            Log::info("Exporting {$people->count()} people and {$families->count()} families to GrampsXML.");
+                Log::info("Exporting {$people->count()} people and {$families->count()} families to GrampsXML for team {$this->teamId}.");
 
-            $grampsXmlService = new GrampsXmlService;
-            $content = $grampsXmlService->generateGrampsXmlContent($people, $families);
+                return (new GrampsXmlService)->generateGrampsXmlContent($people, $families);
+            });
 
-            Storage::disk('private')->put($this->file, $content);
+            Storage::disk('private')->put(self::directoryFor($this->teamId).'/'.$this->file, $content);
 
             Log::info('GrampsXML file generated and stored successfully.');
         } catch (Throwable $e) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -427,12 +427,6 @@ parameters:
 			path: app/Jobs/DnaMatching.php
 
 		-
-			message: '#^Property App\\Jobs\\ExportGrampsXml\:\:\$user is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: app/Jobs/ExportGrampsXml.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1

--- a/tests/Feature/Tenancy/GedcomExportIsolationTest.php
+++ b/tests/Feature/Tenancy/GedcomExportIsolationTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Tenancy;
 
 use App\Filament\App\Pages\GedcomExportPage;
 use App\Jobs\ExportGedCom;
+use App\Jobs\ExportGrampsXml;
 use App\Models\Family;
 use App\Models\Person;
 use App\Models\User;
@@ -124,6 +125,49 @@ class GedcomExportIsolationTest extends TestCase
 
         $this->assertStringNotContainsString(
             "HUSB @{$theirs}@",
+            $content,
+            'The exported tree contained another team\'s people.',
+        );
+    }
+
+    /**
+     * The GrampsXML export had the same two faults as the GEDCOM one and was
+     * fixed alongside it, so it is pinned the same way. The leak was plainer
+     * here: Person::all() is handed straight to the generator, and in a job
+     * nothing is authenticated, so the tenant scope no-ops and returns every
+     * team's people.
+     *
+     * No page lists these files, which is the only reason this was not also a
+     * download of other teams' trees.
+     */
+    public function test_an_exported_gramps_tree_contains_only_its_own_teams_people(): void
+    {
+        Storage::fake('private');
+
+        $owner = $this->actAsOwnerOfTeam();
+        $ours = $this->treeFor($owner->current_team_id);
+        $theirs = $this->treeFor($this->otherTeamId());
+
+        $user = $owner->fresh();
+
+        Auth::logout();
+        Filament::setTenant(null, isQuiet: true);
+
+        (new ExportGrampsXml('export.gramps', $user, $owner->current_team_id))->handle();
+
+        $content = Storage::disk('private')->get($this->pathFor($owner->current_team_id, 'export.gramps'));
+
+        // The person handle, not the bare id: a lone digit turns up in the
+        // DTD version and the timestamps, so asserting on it would pass or fail
+        // for reasons having nothing to do with whose tree this is.
+        $this->assertStringContainsString(
+            "person_{$ours}",
+            $content,
+            'The export did not contain the team\'s own people, so it proves nothing about the rest.',
+        );
+
+        $this->assertStringNotContainsString(
+            "person_{$theirs}",
             $content,
             'The exported tree contained another team\'s people.',
         );


### PR DESCRIPTION
The GrampsXML export had the **same two faults** as the GEDCOM export fixed in #1542, and was left behind because its symptoms were quieter.

Its page lists no files, so it was never a way to *download* another team's tree the way the GEDCOM page was. But the file it produced was still built from **every team's records**: `Person::all()` handed straight to the generator, in a queued job where nothing is authenticated, so the tenant global scope no-ops and returns everyone.

## The fix

Authenticate the requesting user against the team being exported, and write into that team's directory — identical to what the GEDCOM job now does.

The where-it-goes and how-it-is-scoped logic **moved into one `ExportsForTeam` trait** rather than being copied into both jobs. Two copies are exactly how they would drift — until one writes somewhere the page does not list, or scopes where the other does not. This refactors the already-merged `ExportGedCom` onto the shared trait; its behaviour is unchanged and its tests still pass.

Removed one `phpstan-baseline.neon` entry that claimed `ExportGrampsXml::$user` is never read. It is read now, and the baseline is a ratchet to shrink.

## Verification

- 720 passed, 12 skipped. PHPStan clean, Pint clean.
- The isolation test asserts in **both directions** and is revert-sensitive: disabling the scoping fails both the GEDCOM and the GrampsXML case. Confirmed independently, not just reported.
- The Gramps assertion keys on a distinctive `person_{id}` handle rather than a bare id — a bare id also appears in the Gramps DTD version string, which would let the test pass for the wrong reason.

## Scope

Local to the two export jobs. The general "no job establishes a tenant" problem is tenant-isolation #08 and is untouched here.
