### PR TITLE
feat(ui): collapse app-panel navigation groups by default

### DIFF
--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -131,29 +131,41 @@ class AppPanelProvider extends PanelProvider
                 NavigationGroup::make()
                     ->label('🏠 Dashboard'),
                 NavigationGroup::make()
-                    ->label('👥 Family Tree'),
+                    ->label('👥 Family Tree')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📊 Charts & Visualizations'),
+                    ->label('📊 Charts & Visualizations')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📄 Reports'),
+                    ->label('📄 Reports')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('🔍 Research & Analysis'),
+                    ->label('🔍 Research & Analysis')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📋 Research Management'),
+                    ->label('📋 Research Management')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('🧬 DNA & Genetics'),
+                    ->label('🧬 DNA & Genetics')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📁 Media & Documents'),
+                    ->label('📁 Media & Documents')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('🛠️ Data Management'),
+                    ->label('🛠️ Data Management')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('👥 Family Reunions'),
+                    ->label('👥 Family Reunions')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('🎮 Gamification'),
+                    ->label('🎮 Gamification')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('⚙️ System Settings'),
+                    ->label('⚙️ System Settings')
+                    ->collapsed(),
                 NavigationGroup::make()
-                    ->label('👤 Account & Settings'),
+                    ->label('👤 Account & Settings')
+                    ->collapsed(),
             ])
             ->userMenuItems([
                 Action::make('profile')


### PR DESCRIPTION
The app panel's sidebar opened with all 13 navigation groups expanded — around 60 items visible at once, which is what prompted the "hard to navigate" note.

## What this does

`->collapsed()` on each group except Dashboard. Native Filament: the groups stay expandable, and Filament persists a user's expand/collapse choice per session, so anyone who prefers a group open gets it open on their next visit. Dashboard is left open because it is a single home link — collapsing it would only add a click to reach home.

Verified against the booted panel: `groups=13 collapsed=12`, Dashboard the one open.

## What this deliberately does NOT do

You also asked about reorganising the menu. I left that out on purpose, because it is a taxonomy decision rather than a mechanical one — and the panel's real navigation problem is not the order, it's **duplicate groups**:

- `📋 Research Management` (5 items) and `🔍 Research & Analysis` (14) are two separate groups covering the same ground.
- `👥 Family Reunions` (1 item) and `👥 Family Tree` (18) both carry the `👥` prefix and read as one group split in two.

Merging those means rewriting the `$navigationGroup` string on ~44 resource and page files, and *which* groups should exist is your call, not a guess. Say what the target grouping should be and it's a straightforward follow-up.

## Scope

One file, UI only. No behavioural change, so no test seam; Pint clean.
