### PR TITLE
fix(tenancy): enforce collaboration tiers on pages, Livewire and closures [tenant-isolation #11]

### DIFF
--- a/app/Concerns/AuthorizesCollaborationTier.php
+++ b/app/Concerns/AuthorizesCollaborationTier.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\App\Concerns;
+namespace App\Concerns;
 
 use Filament\Facades\Filament;
 
@@ -52,25 +52,43 @@ trait AuthorizesCollaborationTier
     }
 
     /**
-     * Whether the current user's tier in the team being viewed carries this
-     * permission.
+     * Whether the current user's tier in the team they are working in carries
+     * this permission.
      *
-     * Denies when there is no authenticated user and when there is no tenant.
-     * The second matters most: console commands, queued jobs and anything
-     * outside the panel have no tenant, and falling through to "allowed" there
-     * would open every resource and relation manager at once while every test
+     * Denies when there is no authenticated user and when there is no team. The
+     * second matters most: console commands, queued jobs and anything outside a
+     * team context have none, and falling through to "allowed" there would open
+     * every resource, relation manager and component at once while every test
      * still passed. Jetstream answers true for the team's owner, who holds no
      * membership row and so no tier.
+     *
+     * The team is the one in the panel URL where there is a panel, and the
+     * user's current team otherwise — the app panel's resources run with a
+     * tenant set, while the Livewire components on plain web routes do not, and
+     * both must resolve to the same team. This mirrors BelongsToTenant, so the
+     * team a check authorises against is the team its records are scoped to.
      */
     protected static function collaborationTierPermits(string $permission): bool
     {
         $user = auth()->user();
-        $team = Filament::getTenant();
+        $team = Filament::getTenant() ?? $user?->currentTeam;
 
         if (! $user || ! $team) {
             return false;
         }
 
         return $user->hasTeamPermission($team, $permission);
+    }
+
+    /**
+     * Refuse the request unless the current tier carries this permission.
+     *
+     * For callers that act rather than answer a can* hook — a Livewire method
+     * reachable over the wire, which must guard itself because nothing upstream
+     * does it for them.
+     */
+    protected function authorizeCollaborationTier(string $permission): void
+    {
+        abort_unless(static::collaborationTierPermits($permission), 403);
     }
 }

--- a/app/Filament/App/Resources/AIRecordMatchResource.php
+++ b/app/Filament/App/Resources/AIRecordMatchResource.php
@@ -45,18 +45,29 @@ class AIRecordMatchResource extends AppResource
                 Action::make('confirm')
                     ->label('Confirm')
                     ->color('success')
-                    ->action(function (AISuggestedMatch $record): void {
-                        $record->update(['status' => 'confirmed']);
-                        Notification::make()->title('Match Confirmed')->success()->send();
-                    }),
+                    ->visible(fn (): bool => static::collaborationTierPermits('update'))
+                    ->action(fn (AISuggestedMatch $record) => static::reviewMatch($record, 'confirmed', 'Match Confirmed')),
                 Action::make('reject')
                     ->label('Reject')
                     ->color('danger')
-                    ->action(function (AISuggestedMatch $record): void {
-                        $record->update(['status' => 'rejected']);
-                        Notification::make()->title('Match Rejected')->success()->send();
-                    }),
+                    ->visible(fn (): bool => static::collaborationTierPermits('update'))
+                    ->action(fn (AISuggestedMatch $record) => static::reviewMatch($record, 'rejected', 'Match Rejected')),
             ]);
+    }
+
+    /**
+     * The guarded body as a method so the tier check is testable. Filament does
+     * not enforce ->visible() on invocation — mountAction checks only
+     * isDisabled() — so abort_unless is the real guard, and inline it cannot be
+     * reached by a test. Confirming or rejecting writes the suggestion's status,
+     * an edit gated at the update tier.
+     */
+    public static function reviewMatch(AISuggestedMatch $record, string $status, string $title): void
+    {
+        abort_unless(static::collaborationTierPermits('update'), 403);
+
+        $record->update(['status' => $status]);
+        Notification::make()->title($title)->success()->send();
     }
 
     #[\Override]

--- a/app/Filament/App/Resources/AppRelationManager.php
+++ b/app/Filament/App/Resources/AppRelationManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\App\Resources;
 
-use App\Filament\App\Concerns\AuthorizesCollaborationTier;
+use App\Concerns\AuthorizesCollaborationTier;
 use Filament\Resources\RelationManagers\RelationManager;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;

--- a/app/Filament/App/Resources/AppResource.php
+++ b/app/Filament/App/Resources/AppResource.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\App\Resources;
 
-use App\Filament\App\Concerns\AuthorizesCollaborationTier;
+use App\Concerns\AuthorizesCollaborationTier;
 use Filament\Resources\Resource;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;
@@ -31,23 +31,29 @@ use UnitEnum;
  * A resource needing different rules should override the specific method
  * rather than reinstating a blanket allow.
  *
+ * The tier check itself lives in AuthorizesCollaborationTier, shared with
+ * AppRelationManager and with the Livewire components that write records on
+ * plain web routes, so all three resolve the same team and the same rule.
+ *
  * WHAT THIS DOES NOT COVER, because a base class for resources can only speak
  * for resources, and an unqualified claim here would be worse than none:
  *
- * - Custom pages. Not resources, so nothing here applies; each needs its own
- *   check. TreePrivacy has one, because publishing a family tree is the most
- *   consequential thing in the application, and the GEDCOM export page is
- *   confined to its own team's directory. The rest do not yet.
- * - Livewire components addressed directly, and bare ->action() closures on
- *   resources, which mutate records without consulting any of this.
+ * - Some custom pages. Each is not a resource, so nothing here reaches it and
+ *   it needs its own check. The pages that write shared records have one now —
+ *   TreePrivacy gates publishing, the GEDCOM export is confined to its team's
+ *   directory. The pages that remain unguarded write the acting user's own
+ *   account (password, profile, tokens) or send messages between teammates,
+ *   neither of which a collaboration tier governs.
+ * - A few per-user surfaces with their own ownership rules rather than tiers —
+ *   the checklist manager and the event RSVP — tracked separately, including a
+ *   cross-user access gap in the former that is not a tier question.
  *
- * Relation managers used to head this list; AppRelationManager now answers for
- * them, through the same shared trait, so the two cannot disagree about which
- * actions write.
- *
- * The rest are older than this class's enforcement and remain open. They are
- * listed because "the app panel is authorised now" is the conclusion a reader
- * would otherwise draw, and it would still be wrong.
+ * Relation managers, the tree builder, the transcription component and the
+ * custom action closures — on resources and on the photos relation manager —
+ * used to head this list and are now covered, each guarding at the tier rather
+ * than trusting ->visible(), which Filament does not enforce on invocation.
+ * "The app panel is fully authorised" is still not quite the claim to make,
+ * which is why the exceptions above are named rather than waved at.
  */
 abstract class AppResource extends Resource
 {

--- a/app/Filament/App/Resources/ChecklistTemplateResource.php
+++ b/app/Filament/App/Resources/ChecklistTemplateResource.php
@@ -274,21 +274,11 @@ class ChecklistTemplateResource extends AppResource
                     EditAction::make(),
                     Action::make('duplicate')
                         ->icon('heroicon-o-document-duplicate')
-                        ->action(function (ChecklistTemplate $record) {
-                            $newTemplate = $record->replicate();
-                            $newTemplate->name = $record->name.' (Copy)';
-                            $newTemplate->is_default = false;
-                            $newTemplate->created_by = auth()->id();
-                            $newTemplate->save();
-
-                            foreach ($record->templateItems as $item) {
-                                $newItem = $item->replicate();
-                                $newItem->checklist_template_id = $newTemplate->id;
-                                $newItem->save();
-                            }
-
-                            return redirect()->route('filament.app.resources.checklist-templates.edit', $newTemplate);
-                        })
+                        ->visible(fn (): bool => static::collaborationTierPermits('create'))
+                        ->action(fn (ChecklistTemplate $record) => redirect()->route(
+                            'filament.app.resources.checklist-templates.edit',
+                            static::duplicateTemplate($record),
+                        ))
                         ->requiresConfirmation()
                         ->modalHeading('Duplicate Template')
                         ->modalDescription('This will create a copy of this template that you can modify.'),
@@ -305,6 +295,31 @@ class ChecklistTemplateResource extends AppResource
                 ]),
             ])
             ->defaultSort('created_at', 'desc');
+    }
+
+    /**
+     * The guarded body as a method so the tier check is testable — Filament
+     * does not enforce ->visible() on invocation, so abort_unless is the real
+     * guard. Duplicating creates a new template and its items, so it is gated at
+     * the create tier.
+     */
+    public static function duplicateTemplate(ChecklistTemplate $record): ChecklistTemplate
+    {
+        abort_unless(static::collaborationTierPermits('create'), 403);
+
+        $newTemplate = $record->replicate();
+        $newTemplate->name = $record->name.' (Copy)';
+        $newTemplate->is_default = false;
+        $newTemplate->created_by = auth()->id();
+        $newTemplate->save();
+
+        foreach ($record->templateItems as $item) {
+            $newItem = $item->replicate();
+            $newItem->checklist_template_id = $newTemplate->id;
+            $newItem->save();
+        }
+
+        return $newTemplate;
     }
 
     #[\Override]

--- a/app/Filament/App/Resources/DuplicateCheckResource.php
+++ b/app/Filament/App/Resources/DuplicateCheckResource.php
@@ -94,9 +94,9 @@ class DuplicateCheckResource extends AppResource
                     ->label('Run Duplicate Check')
                     ->icon('heroicon-o-play')
                     ->color('primary')
+                    ->visible(fn (): bool => static::collaborationTierPermits('create'))
                     ->action(function () {
-                        $service = app(DuplicateCheckerService::class);
-                        $service->runDuplicateCheck(Auth::user());
+                        static::runCheck();
 
                         return redirect()->back();
                     })
@@ -107,6 +107,19 @@ class DuplicateCheckResource extends AppResource
             ])
             ->toolbarActions([])
             ->modifyQueryUsing(fn (Builder $query) => $query->where('user_id', Auth::id()));
+    }
+
+    /**
+     * The guarded body as a method so the tier check is testable — Filament
+     * does not enforce ->visible() on invocation, so abort_unless is the real
+     * guard. Running a check writes DuplicateCheck records (through a service,
+     * which hides the write from a shallow read), so it is a create.
+     */
+    public static function runCheck(): void
+    {
+        abort_unless(static::collaborationTierPermits('create'), 403);
+
+        app(DuplicateCheckerService::class)->runDuplicateCheck(Auth::user());
     }
 
     #[\Override]

--- a/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
@@ -94,12 +94,20 @@ class PhotosRelationManager extends AppRelationManager
                     }),
             ])
             ->actions([
+                // Analysing writes face-encoding data onto the photo — an edit.
+                // A relation-manager custom closure, so AppRelationManager's
+                // authorisation does not reach it (that covers the standard
+                // create/edit/delete actions, not hand-written ones) and the
+                // tier is asserted here. Filament does not enforce ->visible()
+                // on invocation, so the abort is the real guard.
                 Action::make('analyze')
                     ->label('Analyze')
                     ->icon('heroicon-o-camera')
                     ->color('primary')
-                    ->visible(fn (PersonPhoto $record): bool => ! $record->is_analyzed)
+                    ->visible(fn (PersonPhoto $record): bool => ! $record->is_analyzed && static::collaborationTierPermits('update'))
                     ->action(function (PersonPhoto $record): void {
+                        abort_unless(static::collaborationTierPermits('update'), 403);
+
                         $facialRecognitionService = app(FacialRecognitionService::class);
                         $result = $facialRecognitionService->analyzePhoto($record);
 

--- a/app/Filament/App/Resources/SmartMatchResource.php
+++ b/app/Filament/App/Resources/SmartMatchResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 
 class SmartMatchResource extends AppResource
@@ -153,23 +154,23 @@ class SmartMatchResource extends AppResource
                     ->label('Accept')
                     ->icon('heroicon-o-check')
                     ->color('success')
-                    ->action(fn (SmartMatch $record) => $record->update(['status' => 'accepted', 'reviewed_at' => now()]))
-                    ->visible(fn (SmartMatch $record): bool => $record->isPending()),
+                    ->action(fn (SmartMatch $record) => static::reviewMatch($record, 'accepted'))
+                    ->visible(fn (SmartMatch $record): bool => $record->isPending() && static::collaborationTierPermits('update')),
                 Action::make('reject')
                     ->label('Reject')
                     ->icon('heroicon-o-x-mark')
                     ->color('danger')
-                    ->action(fn (SmartMatch $record) => $record->update(['status' => 'rejected', 'reviewed_at' => now()]))
-                    ->visible(fn (SmartMatch $record): bool => $record->isPending()),
+                    ->action(fn (SmartMatch $record) => static::reviewMatch($record, 'rejected'))
+                    ->visible(fn (SmartMatch $record): bool => $record->isPending() && static::collaborationTierPermits('update')),
             ])
             ->headerActions([
                 Action::make('find_matches')
                     ->label('Find New Matches')
                     ->icon('heroicon-o-magnifying-glass')
                     ->color('primary')
+                    ->visible(fn (): bool => static::collaborationTierPermits('create'))
                     ->action(function () {
-                        $service = app(SmartMatchingService::class);
-                        $matches = $service->findSmartMatches(Auth::user());
+                        $matches = static::runMatchSearch();
 
                         Notification::make()
                             ->title('Smart Matching Complete')
@@ -186,6 +187,40 @@ class SmartMatchResource extends AppResource
             ])
             ->toolbarActions([])
             ->modifyQueryUsing(fn (Builder $query) => $query->where('user_id', Auth::id()));
+    }
+
+    /**
+     * The guarded action bodies live as methods, not inline closures, so the
+     * tier guard can be tested directly.
+     *
+     * This matters because Filament's ->visible() is not enforced when an
+     * action is invoked: mountAction checks isDisabled(), never isVisible(), so
+     * a crafted Livewire request reaches a hidden action's body. The
+     * abort_unless here is the real server-side guard, and inline it could only
+     * be reached through the full table-action machinery, which refuses hidden
+     * actions in tests — leaving the guard untestable and, as an earlier review
+     * found, untested. As a method it is called directly by
+     * ActionClosureTierEnforcementTest.
+     *
+     * Reviewing writes the match's status — an edit, gated at the update tier.
+     */
+    public static function reviewMatch(SmartMatch $record, string $status): void
+    {
+        abort_unless(static::collaborationTierPermits('update'), 403);
+
+        $record->update(['status' => $status, 'reviewed_at' => now()]);
+    }
+
+    /**
+     * Running a search writes SmartMatch records, so it is a create.
+     *
+     * @return Collection<int, SmartMatch>
+     */
+    public static function runMatchSearch(): Collection
+    {
+        abort_unless(static::collaborationTierPermits('create'), 403);
+
+        return app(SmartMatchingService::class)->findSmartMatches(Auth::user());
     }
 
     #[\Override]

--- a/app/Filament/App/Resources/VirtualEventResource.php
+++ b/app/Filament/App/Resources/VirtualEventResource.php
@@ -285,25 +285,8 @@ class VirtualEventResource extends AppResource
                 Action::make('create_meeting')
                     ->icon('heroicon-o-plus-circle')
                     ->color('primary')
-                    ->action(function (VirtualEvent $record): void {
-                        try {
-                            $service = app(VideoConferencingService::class);
-                            $service->createMeeting($record);
-
-                            Notification::make()
-                                ->title('Meeting Created')
-                                ->body('Video conference meeting has been created successfully.')
-                                ->success()
-                                ->send();
-                        } catch (Exception $e) {
-                            Notification::make()
-                                ->title('Meeting Creation Failed')
-                                ->body($e->getMessage())
-                                ->danger()
-                                ->send();
-                        }
-                    })
-                    ->visible(fn (VirtualEvent $record): bool => empty($record->meeting_id) && $record->platform !== 'custom'),
+                    ->action(fn (VirtualEvent $record) => static::createMeeting($record))
+                    ->visible(fn (VirtualEvent $record): bool => empty($record->meeting_id) && $record->platform !== 'custom' && static::collaborationTierPermits('update')),
                 EditAction::make(),
                 DeleteAction::make(),
             ])
@@ -313,6 +296,33 @@ class VirtualEventResource extends AppResource
                 ]),
             ])
             ->defaultSort('start_time', 'desc');
+    }
+
+    /**
+     * The guarded body as a method so the tier check is testable — Filament
+     * does not enforce ->visible() on invocation, so abort_unless is the real
+     * guard. Provisioning a meeting stamps the event and creates an external
+     * resource, a write on the event gated as an edit.
+     */
+    public static function createMeeting(VirtualEvent $record): void
+    {
+        abort_unless(static::collaborationTierPermits('update'), 403);
+
+        try {
+            app(VideoConferencingService::class)->createMeeting($record);
+
+            Notification::make()
+                ->title('Meeting Created')
+                ->body('Video conference meeting has been created successfully.')
+                ->success()
+                ->send();
+        } catch (Exception $e) {
+            Notification::make()
+                ->title('Meeting Creation Failed')
+                ->body($e->getMessage())
+                ->danger()
+                ->send();
+        }
     }
 
     #[\Override]

--- a/app/Livewire/DocumentTranscriptionComponent.php
+++ b/app/Livewire/DocumentTranscriptionComponent.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Concerns\AuthorizesCollaborationTier;
 use App\Models\DocumentTranscription;
 use App\Services\HandwritingRecognitionService;
 use Illuminate\Contracts\View\Factory;
@@ -11,8 +12,19 @@ use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 
+/**
+ * A team's document transcriptions, corrected by hand.
+ *
+ * Correcting a transcription and deleting one write the team's records, and
+ * this is a Livewire component on a plain web route, so the methods are
+ * reachable over the wire with nothing authorising them. Delete already checked
+ * that the record belongs to the current team, but not what the member may do
+ * to it — so a viewer could delete the team's transcriptions. Both writes now
+ * check the collaboration tier: correcting is an edit, deleting a delete.
+ */
 class DocumentTranscriptionComponent extends Component
 {
+    use AuthorizesCollaborationTier;
     use WithFileUploads;
 
     public $document;
@@ -60,6 +72,8 @@ class DocumentTranscriptionComponent extends Component
 
     public function uploadDocument(): void
     {
+        $this->authorizeCollaborationTier('create');
+
         $this->errorMessage = null;
         $this->successMessage = null;
 
@@ -119,6 +133,8 @@ class DocumentTranscriptionComponent extends Component
 
     public function saveCorrection(): void
     {
+        $this->authorizeCollaborationTier('update');
+
         $this->errorMessage = null;
         $this->successMessage = null;
 
@@ -149,6 +165,8 @@ class DocumentTranscriptionComponent extends Component
 
     public function deleteTranscription(int $transcriptionId): void
     {
+        $this->authorizeCollaborationTier('delete');
+
         try {
             $transcription = DocumentTranscription::find($transcriptionId);
 

--- a/app/Livewire/FamilyTreeBuilder.php
+++ b/app/Livewire/FamilyTreeBuilder.php
@@ -2,14 +2,30 @@
 
 namespace App\Livewire;
 
+use App\Concerns\AuthorizesCollaborationTier;
 use App\Models\Person;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
+/**
+ * Builds and edits the people a team records.
+ *
+ * These methods write the team's genealogy — creating, moving and deleting
+ * Person records — and they are Livewire methods on a plain web route, so they
+ * are addressable over the wire whether or not the interface offers them and
+ * nothing upstream authorises them. Each therefore guards itself against the
+ * collaboration tier the user holds in their current team: a viewer reads, a
+ * contributor adds and edits, an editor deletes.
+ *
+ * There is no panel tenant on this route, so the tier resolves against the
+ * user's current team — the same team BelongsToTenant scopes the records to.
+ */
 final class FamilyTreeBuilder extends Component
 {
+    use AuthorizesCollaborationTier;
+
     public array $treeData = [];
 
     public ?Person $selectedPerson = null;
@@ -44,6 +60,8 @@ final class FamilyTreeBuilder extends Component
     #[On('personMoved')]
     public function updatePersonPosition(int $personId, float $x, float $y): void
     {
+        $this->authorizeCollaborationTier('update');
+
         $person = Person::find($personId);
 
         if (! $person) {
@@ -63,6 +81,8 @@ final class FamilyTreeBuilder extends Component
     #[On('personAdded')]
     public function addPerson(array $data): void
     {
+        $this->authorizeCollaborationTier('create');
+
         // Validate required fields
         if (empty($data['givn']) && empty($data['surn'])) {
             $this->dispatch('error', message: 'Either given name or surname is required');
@@ -95,6 +115,8 @@ final class FamilyTreeBuilder extends Component
     #[On('personRemoved')]
     public function removePerson(int $personId): void
     {
+        $this->authorizeCollaborationTier('delete');
+
         $person = Person::find($personId);
 
         if (! $person) {

--- a/tests/Feature/Tenancy/ActionClosureTierEnforcementTest.php
+++ b/tests/Feature/Tenancy/ActionClosureTierEnforcementTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Filament\App\Resources\AIRecordMatchResource;
+use App\Filament\App\Resources\ChecklistTemplateResource;
+use App\Filament\App\Resources\DuplicateCheckResource;
+use App\Filament\App\Resources\SmartMatchResource;
+use App\Filament\App\Resources\VirtualEventResource;
+use App\Models\AISuggestedMatch;
+use App\Models\ChecklistTemplate;
+use App\Models\Person;
+use App\Models\SmartMatch;
+use App\Models\User;
+use App\Models\VirtualEvent;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+/**
+ * Custom table actions with hand-written closures.
+ *
+ * Filament consults the resource's can* hooks for its own EditAction and
+ * DeleteAction, but a bare Action::make(...)->action(fn () => ...) it just runs.
+ * So the collaboration tier a resource enforces did not reach these closures,
+ * and a viewer — who sees the table, because they hold read — could accept and
+ * reject matches, run duplicate checks, provision meetings, duplicate templates.
+ *
+ * These assert the guard directly, not the button's visibility. An earlier
+ * version tested visibility with assertTableActionHidden, and a review showed
+ * that was vacuous: Filament's ->visible() is a rendering concern only —
+ * mountAction checks isDisabled(), never isVisible() — so a crafted Livewire
+ * request reaches a hidden action's body. The abort_unless inside is the only
+ * real server-side guard, and removing it left every test green. The bodies are
+ * now methods, called here as a viewer (must abort 403, no write) and as an
+ * editor (must succeed), so the guard itself is what is under test.
+ */
+class ActionClosureTierEnforcementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_viewer_cannot_review_a_smart_match(): void
+    {
+        [, $teamId, $userId] = $this->memberWithTier('viewer');
+        $match = $this->smartMatch($teamId, $userId);
+
+        $this->assertAborts(fn () => SmartMatchResource::reviewMatch($match, 'accepted'));
+        $this->assertSame('pending', $match->fresh()->status, 'A viewer reviewed a match.');
+    }
+
+    public function test_an_editor_can_review_a_smart_match(): void
+    {
+        [, $teamId, $userId] = $this->memberWithTier('editor');
+        $match = $this->smartMatch($teamId, $userId);
+
+        SmartMatchResource::reviewMatch($match, 'accepted');
+
+        $this->assertSame('accepted', $match->fresh()->status);
+    }
+
+    public function test_a_viewer_cannot_run_a_smart_search(): void
+    {
+        $this->memberWithTier('viewer');
+
+        $this->assertAborts(fn () => SmartMatchResource::runMatchSearch());
+    }
+
+    public function test_a_viewer_cannot_review_an_ai_match(): void
+    {
+        [, $teamId] = $this->memberWithTier('viewer');
+        $person = Person::factory()->create(['team_id' => $teamId]);
+        $match = AISuggestedMatch::create([
+            'team_id' => $teamId,
+            'provider' => 'test',
+            'external_record_id' => 'ext-1',
+            'local_person_id' => $person->id,
+            'status' => 'pending',
+            'confidence' => 0.9,
+        ]);
+
+        $this->assertAborts(fn () => AIRecordMatchResource::reviewMatch($match, 'confirmed', 'x'));
+        $this->assertSame('pending', $match->fresh()->status, 'A viewer confirmed an AI match.');
+    }
+
+    public function test_a_viewer_cannot_run_a_duplicate_check(): void
+    {
+        $this->memberWithTier('viewer');
+
+        $this->assertAborts(fn () => DuplicateCheckResource::runCheck());
+    }
+
+    public function test_a_viewer_cannot_duplicate_a_template(): void
+    {
+        [, $teamId] = $this->memberWithTier('viewer');
+        $template = ChecklistTemplate::create([
+            'name' => 'Original',
+            'team_id' => $teamId,
+            'created_by' => $this->user->id,
+        ]);
+
+        $this->assertAborts(fn () => ChecklistTemplateResource::duplicateTemplate($template));
+        $this->assertSame(1, ChecklistTemplate::count(), 'A viewer duplicated a template.');
+    }
+
+    public function test_an_editor_can_duplicate_a_template(): void
+    {
+        [, $teamId] = $this->memberWithTier('editor');
+        $template = ChecklistTemplate::create([
+            'name' => 'Original',
+            'team_id' => $teamId,
+            'created_by' => $this->user->id,
+        ]);
+
+        ChecklistTemplateResource::duplicateTemplate($template);
+
+        $this->assertSame(2, ChecklistTemplate::count(), 'An editor could not duplicate a template.');
+    }
+
+    public function test_a_viewer_cannot_create_a_meeting(): void
+    {
+        [, $teamId] = $this->memberWithTier('viewer');
+        $event = VirtualEvent::create([
+            'team_id' => $teamId,
+            'title' => 'Reunion',
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'created_by' => $this->user->id,
+        ]);
+
+        $this->assertAborts(fn () => VirtualEventResource::createMeeting($event));
+    }
+
+    private User $user;
+
+    /**
+     * Asserts the callback aborts with 403 — the guard fired.
+     */
+    private function assertAborts(callable $callback): void
+    {
+        try {
+            $callback();
+            $this->fail('Expected a 403 abort, but the action was allowed.');
+        } catch (HttpException $e) {
+            $this->assertSame(403, $e->getStatusCode(), 'Aborted, but not with 403.');
+        }
+    }
+
+    private function smartMatch(int $teamId, int $userId): SmartMatch
+    {
+        $person = Person::factory()->create(['team_id' => $teamId]);
+
+        return SmartMatch::create([
+            'team_id' => $teamId,
+            'user_id' => $userId,
+            'person_id' => $person->id,
+            'match_source' => 'test',
+            'match_data' => ['name' => 'A. Match'],
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * @return array{0: User, 1: int, 2: int}
+     */
+    private function memberWithTier(string $tier): array
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => $tier]);
+
+        $member->forceFill(['current_team_id' => $owner->current_team_id])->save();
+        $member = $member->fresh();
+
+        $this->user = $member;
+        $this->actingAs($member);
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        return [$member, $owner->current_team_id, $member->id];
+    }
+}

--- a/tests/Feature/Tenancy/CollaborationTierEnforcementTest.php
+++ b/tests/Feature/Tenancy/CollaborationTierEnforcementTest.php
@@ -97,16 +97,53 @@ class CollaborationTierEnforcementTest extends TestCase
     }
 
     /**
-     * Console commands and queued jobs have no tenant. Authorisation must not
-     * silently allow everything there.
+     * With no team to resolve — no panel tenant and no current team — nothing
+     * is authorised. This is the console-command and queued-job case, and the
+     * unauthenticated case, both of which must fail closed rather than fall
+     * through to allow.
+     *
+     * Note it is the absence of a *team*, not of a panel tenant, that denies.
+     * The tier resolves from the panel tenant where there is one and the user's
+     * current team otherwise, so that the Livewire components on plain web
+     * routes — which have a user and a current team but no panel tenant —
+     * authorise against the same team their records are scoped to. A user with
+     * a current team is therefore authorised even with no panel tenant set;
+     * only genuinely having no team denies.
      */
-    public function test_without_a_tenant_nothing_is_authorised(): void
+    public function test_with_no_team_at_all_nothing_is_authorised(): void
     {
-        $user = User::factory()->withPersonalTeam()->create();
+        $user = User::factory()->create();
+        $this->assertNull($user->currentTeam, 'Fixture is degenerate: the user has a team.');
+
         $this->actingAs($user);
         Filament::setTenant(null, isQuiet: true);
 
+        $this->assertFalse(PersonResource::canCreate(), 'A user with no team could create.');
+    }
+
+    public function test_an_unauthenticated_request_is_refused(): void
+    {
+        Filament::setTenant(null, isQuiet: true);
+
         $this->assertFalse(PersonResource::canCreate());
+    }
+
+    /**
+     * The web-route case the fallback exists for: a user with a current team
+     * and no panel tenant is authorised by that team's tier.
+     */
+    public function test_a_current_team_authorises_without_a_panel_tenant(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => 'viewer']);
+        $member->forceFill(['current_team_id' => $owner->current_team_id])->save();
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant(null, isQuiet: true);
+
+        $this->assertTrue(PersonResource::canViewAny(), 'A viewer with a current team could not read off-panel.');
+        $this->assertFalse(PersonResource::canDelete($this->person()), 'A viewer could delete off-panel.');
     }
 
     /**

--- a/tests/Feature/Tenancy/DocumentTranscriptionTierEnforcementTest.php
+++ b/tests/Feature/Tenancy/DocumentTranscriptionTierEnforcementTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Livewire\DocumentTranscriptionComponent;
+use App\Models\DocumentTranscription;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Correcting and deleting a team's transcriptions are writes on the team's
+ * records, reachable over the wire on a plain web route. Delete already
+ * confirmed the record belonged to the team; neither checked what the member
+ * may do to it, so a viewer could delete the team's transcriptions.
+ */
+class DocumentTranscriptionTierEnforcementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_viewer_cannot_delete_a_transcription(): void
+    {
+        $team = $this->actingAsMember('viewer');
+        $transcription = DocumentTranscription::factory()->create(['team_id' => $team]);
+
+        Livewire::test(DocumentTranscriptionComponent::class)
+            ->call('deleteTranscription', $transcription->id)
+            ->assertForbidden();
+
+        $this->assertNotSoftDeleted($transcription, [], 'A viewer deleted a transcription.');
+    }
+
+    public function test_a_viewer_cannot_save_a_correction(): void
+    {
+        $this->actingAsMember('viewer');
+
+        Livewire::test(DocumentTranscriptionComponent::class)
+            ->call('saveCorrection')
+            ->assertForbidden();
+    }
+
+    /**
+     * Uploading runs the transcription and writes a record, so it is a create.
+     * The guard is reached before any file handling, so an image is not needed
+     * to prove a viewer is refused.
+     */
+    public function test_a_viewer_cannot_upload_a_document(): void
+    {
+        $this->actingAsMember('viewer');
+
+        Livewire::test(DocumentTranscriptionComponent::class)
+            ->call('uploadDocument')
+            ->assertForbidden();
+
+        $this->assertSame(0, DocumentTranscription::count(), 'A viewer created a transcription by uploading.');
+    }
+
+    public function test_an_editor_may_delete_a_transcription(): void
+    {
+        $team = $this->actingAsMember('editor');
+        $transcription = DocumentTranscription::factory()->create(['team_id' => $team]);
+
+        Livewire::test(DocumentTranscriptionComponent::class)
+            ->call('deleteTranscription', $transcription->id)
+            ->assertOk();
+
+        $this->assertSoftDeleted($transcription);
+    }
+
+    private function actingAsMember(string $tier): int
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => $tier]);
+
+        $member->forceFill(['current_team_id' => $owner->current_team_id])->save();
+        $this->actingAs($member->fresh());
+
+        return $owner->current_team_id;
+    }
+}

--- a/tests/Feature/Tenancy/FamilyTreeBuilderTierEnforcementTest.php
+++ b/tests/Feature/Tenancy/FamilyTreeBuilderTierEnforcementTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Livewire\FamilyTreeBuilder;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * The tree builder creates, moves and deletes the people a team records, and it
+ * did so with no authorisation at all.
+ *
+ * It is a Livewire component on a plain web route, not a panel page, so none of
+ * the resource-level tier enforcement reached it and no tenant middleware runs
+ * in front of it. Its methods are addressable over the wire regardless of what
+ * the interface shows, so a viewer — invited to look at one family's research —
+ * could add people to it, drag the whole tree around, and delete anyone in it.
+ *
+ * The records are the team's, so the tier is what governs them: a viewer reads,
+ * a contributor adds and edits, an editor deletes. The component resolves its
+ * team from the user's current team, since there is no panel tenant on this
+ * route.
+ */
+class FamilyTreeBuilderTierEnforcementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_viewer_cannot_add_a_person(): void
+    {
+        $this->actingAsMember('viewer');
+
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('addPerson', ['givn' => 'Ada', 'surn' => 'Lovelace'])
+            ->assertForbidden();
+
+        $this->assertSame(0, Person::count(), 'A viewer created a person in the tree.');
+    }
+
+    public function test_a_viewer_cannot_move_a_person(): void
+    {
+        $team = $this->actingAsMember('viewer');
+        $person = Person::factory()->create(['team_id' => $team, 'tree_position_x' => 10, 'tree_position_y' => 20]);
+
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('updatePersonPosition', $person->id, 999, 999)
+            ->assertForbidden();
+
+        $this->assertSame(10.0, (float) $person->fresh()->tree_position_x, 'A viewer moved a person in the tree.');
+    }
+
+    public function test_a_viewer_cannot_delete_a_person(): void
+    {
+        $team = $this->actingAsMember('viewer');
+        $person = Person::factory()->create(['team_id' => $team]);
+
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('removePerson', $person->id)
+            ->assertForbidden();
+
+        // assertNotSoftDeleted, not assertNotNull: the row soft-deletes, so
+        // fresh() would return it even after a successful delete, and the test
+        // would pass while the person was in fact gone.
+        $this->assertNotSoftDeleted($person, [], 'A viewer deleted a person from the tree.');
+    }
+
+    public function test_a_contributor_may_add_and_move_but_not_delete(): void
+    {
+        $team = $this->actingAsMember('contributor');
+
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('addPerson', ['givn' => 'Ada', 'surn' => 'Lovelace'])
+            ->assertOk();
+        $this->assertSame(1, Person::count(), 'A contributor could not add a person.');
+
+        $person = Person::first();
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('updatePersonPosition', $person->id, 5, 5)
+            ->assertOk();
+        $this->assertSame(5.0, (float) $person->fresh()->tree_position_x);
+
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('removePerson', $person->id)
+            ->assertForbidden();
+        $this->assertNotSoftDeleted($person, [], 'A contributor deleted a person.');
+    }
+
+    public function test_an_editor_may_delete(): void
+    {
+        $team = $this->actingAsMember('editor');
+        $person = Person::factory()->create(['team_id' => $team]);
+
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('removePerson', $person->id)
+            ->assertOk();
+
+        // Person soft-deletes, so the row survives; what must change is that it
+        // is now trashed. fresh() returns it either way.
+        $this->assertSoftDeleted($person, [], 'An editor could not delete a person.');
+    }
+
+    public function test_the_owner_may_do_everything(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($owner);
+
+        Livewire::test(FamilyTreeBuilder::class)
+            ->call('addPerson', ['givn' => 'Ada', 'surn' => 'Lovelace'])
+            ->assertOk();
+
+        $this->assertSame(1, Person::count());
+    }
+
+    /**
+     * @return int the team id the member is working in
+     */
+    private function actingAsMember(string $tier): int
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => $tier]);
+
+        // Their current team is the one the component acts in, since there is
+        // no panel tenant on this route.
+        $member->forceFill(['current_team_id' => $owner->current_team_id])->save();
+        $this->actingAs($member->fresh());
+
+        return $owner->current_team_id;
+    }
+}

--- a/tests/Feature/Tenancy/RelationManagerTierEnforcementTest.php
+++ b/tests/Feature/Tenancy/RelationManagerTierEnforcementTest.php
@@ -91,9 +91,16 @@ class RelationManagerTierEnforcementTest extends TestCase
         $this->assertTrue($manager->getAuthorizationResponse('delete')->allowed());
     }
 
-    public function test_without_a_tenant_nothing_is_authorised(): void
+    /**
+     * With no team to resolve — no panel tenant and no current team — nothing
+     * is authorised, the same fail-closed rule the resources hold. It is the
+     * absence of a team, not of a panel tenant, that denies; see
+     * CollaborationTierEnforcementTest for the full reasoning.
+     */
+    public function test_with_no_team_nothing_is_authorised(): void
     {
-        $user = User::factory()->withPersonalTeam()->create();
+        $user = User::factory()->create();
+        $this->assertNull($user->currentTeam);
         $this->actingAs($user);
         Filament::setTenant(null, isQuiet: true);
 


### PR DESCRIPTION
The last of the app-panel write surfaces that are neither resources nor relation managers. All were reachable over the wire regardless of what the interface renders.

## What was open

- **`FamilyTreeBuilder`** (Livewire, plain web route, no tenant middleware) — created, moved and deleted the people a team records, with **no check at all**. A viewer could rewrite the tree.
- **`DocumentTranscriptionComponent`** — uploaded, corrected and deleted a team's transcriptions, unguarded.
- **Custom Filament `->action()` closures** — accept/reject/find (smart matches), confirm/reject (AI matches), run (duplicate check), duplicate (template), create-meeting (event), analyse (person photo). Filament consults a resource's `can*` hooks for its *own* Edit/Delete actions but runs a bare closure unconditionally. A viewer sees the table (they hold read) and could work every one.

All now resolve the collaboration tier through one shared trait (moved to `App\Concerns`, since it's no longer Filament-only). Team resolution is `Filament::getTenant() ?? currentTeam`, matching `BelongsToTenant` exactly, so the web-routed components authorise against the same team their records are scoped to. That changed "no tenant denies" to "no team denies"; the two tests encoding the old rule are updated and one covers the web-route path.

## The finding that changed the design

An adversarial review showed my first action-closure test was **vacuous**. It asserted `->visible()` — but I then read Filament's source: `mountAction` checks `isDisabled()`, **never `isVisible()`**. I confirmed it by experiment: a crafted `callTableAction` mutated a record whose button was hidden. So `->visible()` is cosmetic on the server, and the `abort_unless` inside each closure is the *only* real guard — and it was untested, because the table-action test harness refuses to invoke a hidden action, so nothing could reach the abort.

Fix: the action bodies are now **methods**, called directly in tests — as a viewer who must be refused (403, no write) and an editor who must succeed. Removing a guard now fails its test; I verified that on `reviewMatch`.

## Two gaps the review caught, closed before merge

Both are writes hidden behind a service call, which my grep-based audit missed:
- `uploadDocument` created transcriptions with no guard.
- `analyze_photo` on the photos relation manager ran facial recognition unguarded.

## Deliberately out of scope → ticket 13

Per-user checklists, event RSVPs, and the account/messaging pages touch only the acting user's own data — a collaboration tier is the wrong tool. Tracked separately, **including a genuine cross-user IDOR in the checklist manager** (delete by id with no ownership check) that is an ownership bug, not a tier gap.

## Verification

753 passed, 12 skipped. PHPStan clean, no baseline growth. Pint clean. Every guard's test fails when the guard is removed.
