### PR TITLE
fix(tenancy): scope per-user checklists and gate event invites [tenant-isolation #13]

### DIFF
--- a/app/Livewire/UserChecklistManager.php
+++ b/app/Livewire/UserChecklistManager.php
@@ -184,9 +184,42 @@ class UserChecklistManager extends Component
         session()->flash('message', 'Checklist created successfully!');
     }
 
+    /**
+     * A checklist the acting user owns, or a 404.
+     *
+     * Research checklists belong to a user. The checklist table is tenant-scoped
+     * so another team's rows are already invisible, but that left the cross-user
+     * case within one team open — every method below loaded straight from a
+     * request id with no owner check, so a member could edit or delete a
+     * teammate's private checklist by guessing its id. Ownership is the rule
+     * here, not a collaboration tier, so it is a where clause rather than the
+     * tier trait. Loading through here on every by-id path is what closes it;
+     * guarding only the edit entry point would miss updateChecklist, which acts
+     * on a hydrated property a crafted request controls.
+     */
+    private function ownedChecklist($checklistId): UserChecklist
+    {
+        return UserChecklist::where('user_id', Auth::id())->findOrFail($checklistId);
+    }
+
+    /**
+     * An item on a checklist the acting user owns, or a 404.
+     *
+     * Items carry no team and no user of their own — unlike the checklist, the
+     * item table is not tenant-scoped — so an item id was reachable across both
+     * team and user. Ownership is proven through the parent checklist.
+     */
+    private function ownedItem($itemId): UserChecklistItem
+    {
+        return UserChecklistItem::whereHas(
+            'userChecklist',
+            fn ($query) => $query->where('user_id', Auth::id()),
+        )->findOrFail($itemId);
+    }
+
     public function editChecklist($checklistId): void
     {
-        $this->selectedChecklist = UserChecklist::findOrFail($checklistId);
+        $this->selectedChecklist = $this->ownedChecklist($checklistId);
         $this->name = $this->selectedChecklist->name;
         $this->description = $this->selectedChecklist->description;
         $this->subject_type = $this->selectedChecklist->subject_type;
@@ -201,7 +234,13 @@ class UserChecklistManager extends Component
     {
         $this->validate();
 
-        $this->selectedChecklist->update([
+        // Re-resolved through the ownership check rather than trusting the
+        // hydrated property: Livewire re-queries selectedChecklist by key on
+        // every round-trip with no scope, so a crafted request could point it
+        // at a teammate's checklist between edit and update.
+        $checklist = $this->ownedChecklist($this->selectedChecklist->id);
+
+        $checklist->update([
             'name' => $this->name,
             'description' => $this->description,
             'subject_type' => $this->subject_type ?: null,
@@ -219,14 +258,14 @@ class UserChecklistManager extends Component
 
     public function deleteChecklist($checklistId): void
     {
-        UserChecklist::findOrFail($checklistId)->delete();
+        $this->ownedChecklist($checklistId)->delete();
         $this->dispatch('checklist-deleted');
         session()->flash('message', 'Checklist deleted successfully!');
     }
 
     public function toggleItemCompletion($itemId): void
     {
-        $item = UserChecklistItem::findOrFail($itemId);
+        $item = $this->ownedItem($itemId);
 
         if ($item->is_completed) {
             $item->markAsIncomplete();
@@ -239,7 +278,7 @@ class UserChecklistManager extends Component
 
     public function editItem($itemId): void
     {
-        $this->selectedItem = UserChecklistItem::findOrFail($itemId);
+        $this->selectedItem = $this->ownedItem($itemId);
         $this->item_title = $this->selectedItem->title;
         $this->item_description = $this->selectedItem->description;
         $this->item_notes = $this->selectedItem->notes;
@@ -252,7 +291,11 @@ class UserChecklistManager extends Component
     {
         $this->validate($this->itemRules);
 
-        $this->selectedItem->update([
+        // Re-resolved through ownership, not trusting the hydrated property —
+        // see updateChecklist.
+        $item = $this->ownedItem($this->selectedItem->id);
+
+        $item->update([
             'title' => $this->item_title,
             'description' => $this->item_description,
             'notes' => $this->item_notes,
@@ -268,7 +311,7 @@ class UserChecklistManager extends Component
 
     public function addCustomItem($checklistId): void
     {
-        $checklist = UserChecklist::findOrFail($checklistId);
+        $checklist = $this->ownedChecklist($checklistId);
         $maxOrder = $checklist->items()->max('order') ?? 0;
 
         UserChecklistItem::create([

--- a/app/Livewire/VirtualEventRsvp.php
+++ b/app/Livewire/VirtualEventRsvp.php
@@ -247,6 +247,14 @@ class VirtualEventRsvp extends Component
 
     public function invitePerson(): void
     {
+        // Inviting is an organiser action, not the self-service RSVP the rest of
+        // this component handles. canInvite already models who may do it — the
+        // event's creator, host or moderator — but only drove the UI; the write
+        // ran for any member. It is a per-event rule (host/moderator on this
+        // event) rather than a team-wide tier, which is the finer of the two and
+        // the one already designed here.
+        abort_unless($this->canInvite(), 403);
+
         if (! $this->invite_person_id) {
             return;
         }
@@ -284,13 +292,11 @@ class VirtualEventRsvp extends Component
 
     public function sendInvitations(): void
     {
+        // Organiser-only, same as invitePerson — this created attendee rows for
+        // arbitrary emails on nothing more than being logged in.
+        abort_unless($this->canInvite(), 403);
+
         $this->validate($this->inviteRules);
-
-        if (! Auth::check()) {
-            session()->flash('error', 'You must be logged in to send invitations.');
-
-            return;
-        }
 
         $sent = 0;
         $errors = [];

--- a/tests/Feature/Livewire/UserChecklistManagerAccessTest.php
+++ b/tests/Feature/Livewire/UserChecklistManagerAccessTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\UserChecklistManager;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\UserChecklist;
+use App\Models\UserChecklistItem;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Research checklists belong to a user, not a team, and one user must not be
+ * able to touch another's.
+ *
+ * The component loaded checklists and items straight from a request id with no
+ * check that the id belonged to the acting user. The tenant scope on the
+ * checklist table blocked the cross-team case, but not the cross-user case
+ * within one team — and the item table is not tenant-scoped at all, so an item
+ * id was reachable across both boundaries.
+ *
+ * Both users are deliberately on the SAME team here. On different teams the
+ * tenant scope alone would refuse the checklist and the per-user fix would go
+ * untested; same-team isolates the ownership check that is the actual subject.
+ *
+ * A refused load throws ModelNotFoundException — in production the HTTP handler
+ * turns that into a 404, and the mutation never runs. The Livewire test harness
+ * lets it propagate, so these catch it and assert on the outcome: the teammate's
+ * record is untouched. The checklist soft-deletes, so a deleted row still
+ * returns from find(); the assertions use assertNotSoftDeleted / the database,
+ * never assertNotNull, which would pass on a row that had in fact been deleted.
+ */
+class UserChecklistManagerAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $owner;
+
+    private User $attacker;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->team = Team::factory()->create();
+        $this->owner = User::factory()->create(['current_team_id' => $this->team->id]);
+        $this->attacker = User::factory()->create(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach([$this->owner->id => ['role' => 'editor'], $this->attacker->id => ['role' => 'editor']]);
+    }
+
+    public function test_a_user_cannot_delete_another_users_checklist(): void
+    {
+        $checklist = $this->checklistFor($this->owner);
+
+        $this->refused(fn () => Livewire::actingAs($this->attacker)
+            ->test(UserChecklistManager::class)
+            ->call('deleteChecklist', $checklist->id));
+
+        $this->assertNotSoftDeleted($checklist, [], 'A user deleted another user\'s checklist.');
+    }
+
+    public function test_a_user_cannot_open_another_users_checklist_for_editing(): void
+    {
+        $checklist = $this->checklistFor($this->owner);
+
+        $component = null;
+        $this->refused(function () use ($checklist, &$component) {
+            $component = Livewire::actingAs($this->attacker)->test(UserChecklistManager::class);
+            $component->call('editChecklist', $checklist->id);
+        });
+
+        // The form must not have been populated with the other user's data.
+        $component?->assertSet('selectedChecklist', null);
+    }
+
+    public function test_a_user_cannot_add_items_to_another_users_checklist(): void
+    {
+        $checklist = $this->checklistFor($this->owner);
+
+        $this->refused(fn () => Livewire::actingAs($this->attacker)
+            ->test(UserChecklistManager::class)
+            ->call('addCustomItem', $checklist->id));
+
+        $this->assertSame(0, $checklist->items()->count(), 'A user added an item to another user\'s checklist.');
+    }
+
+    public function test_a_user_cannot_toggle_another_users_item(): void
+    {
+        $item = $this->itemFor($this->checklistFor($this->owner));
+
+        $this->refused(fn () => Livewire::actingAs($this->attacker)
+            ->test(UserChecklistManager::class)
+            ->call('toggleItemCompletion', $item->id));
+
+        $this->assertFalse((bool) $item->fresh()->is_completed, 'A user toggled another user\'s item.');
+    }
+
+    public function test_a_user_cannot_edit_another_users_item(): void
+    {
+        $item = $this->itemFor($this->checklistFor($this->owner));
+
+        $component = null;
+        $this->refused(function () use ($item, &$component) {
+            $component = Livewire::actingAs($this->attacker)->test(UserChecklistManager::class);
+            $component->call('editItem', $item->id);
+        });
+
+        $component?->assertSet('selectedItem', null);
+    }
+
+    public function test_the_owner_can_still_manage_their_own_checklist(): void
+    {
+        $checklist = $this->checklistFor($this->owner);
+
+        Livewire::actingAs($this->owner)
+            ->test(UserChecklistManager::class)
+            ->call('addCustomItem', $checklist->id)
+            ->assertOk();
+        $this->assertSame(1, $checklist->items()->count(), 'The owner could not add an item to their own checklist.');
+
+        Livewire::actingAs($this->owner)
+            ->test(UserChecklistManager::class)
+            ->call('deleteChecklist', $checklist->id)
+            ->assertOk();
+        $this->assertSoftDeleted($checklist, [], 'The owner could not delete their own checklist.');
+    }
+
+    /**
+     * Runs a call expected to be refused by the ownership scope, and asserts it
+     * was — a load that finds nothing throws ModelNotFoundException. Anything
+     * else (a successful call, a different error) fails the test.
+     */
+    private function refused(callable $call): void
+    {
+        try {
+            $call();
+            $this->fail('Expected the action to be refused, but it was allowed.');
+        } catch (ModelNotFoundException) {
+            // The scoped findOrFail matched nothing — refused, as intended.
+        }
+    }
+
+    private function checklistFor(User $user): UserChecklist
+    {
+        $checklist = UserChecklist::create([
+            'user_id' => $user->id,
+            'name' => 'Private research',
+            'status' => 'in_progress',
+            'priority' => 'medium',
+        ]);
+
+        // The tenant scope makes an unstamped row invisible even to its owner,
+        // so set the team as the real create path (running authenticated) would.
+        $checklist->forceFill(['team_id' => $this->team->id])->save();
+
+        return $checklist->fresh();
+    }
+
+    private function itemFor(UserChecklist $checklist): UserChecklistItem
+    {
+        return UserChecklistItem::create([
+            'user_checklist_id' => $checklist->id,
+            'title' => 'A task',
+            'order' => 1,
+            'is_completed' => false,
+        ]);
+    }
+}

--- a/tests/Feature/Livewire/VirtualEventRsvpInviteTest.php
+++ b/tests/Feature/Livewire/VirtualEventRsvpInviteTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\VirtualEventRsvp;
+use App\Models\Person;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\VirtualEvent;
+use App\Models\VirtualEventAttendee;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * RSVPing to an event is self-service — any member says whether they are
+ * coming. Inviting others is an organiser action, and the two were not
+ * distinguished: creating an attendee row for someone else ran on nothing more
+ * than being logged in, so any member could invite arbitrary people to any
+ * event in their team.
+ *
+ * The organiser rule already existed as canInvite (the event's creator, host or
+ * moderator) but only drove which buttons rendered. It now gates the writes.
+ * That is a per-event rule rather than a team-wide collaboration tier — a host
+ * of one event is not thereby an organiser of another — which is the finer, and
+ * already-modelled, of the two.
+ */
+class VirtualEventRsvpInviteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private VirtualEvent $event;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->team = Team::factory()->create();
+        $creator = User::factory()->create(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($creator, ['role' => 'editor']);
+
+        // Created while authenticated as the creator so the tenant trait stamps
+        // team_id (NOT NULL), as the real create path does. The tests below
+        // re-authenticate as their own actors.
+        $this->actingAs($creator);
+        $this->event = VirtualEvent::create([
+            'title' => 'Family Reunion',
+            // Published and future, so canUserRsvp() lets a member respond —
+            // otherwise the self-service test would fail on event state, not on
+            // anything this change touches.
+            'status' => 'published',
+            'start_time' => now()->addWeek(),
+            'end_time' => now()->addWeek()->addHours(2),
+            'created_by' => $creator->id,
+        ]);
+    }
+
+    public function test_a_plain_member_cannot_invite_a_person(): void
+    {
+        $member = $this->member();
+
+        Livewire::actingAs($member)
+            ->test(VirtualEventRsvp::class, ['event' => $this->event])
+            ->set('invite_person_id', $this->personWithEmail()->id)
+            ->call('invitePerson')
+            ->assertForbidden();
+
+        $this->assertSame(0, $this->event->attendees()->count(), 'A plain member created an invitation.');
+    }
+
+    public function test_a_plain_member_cannot_send_invitations(): void
+    {
+        $member = $this->member();
+
+        Livewire::actingAs($member)
+            ->test(VirtualEventRsvp::class, ['event' => $this->event])
+            ->set('invite_emails', 'someone@example.com')
+            ->call('sendInvitations')
+            ->assertForbidden();
+
+        $this->assertSame(0, $this->event->attendees()->count());
+    }
+
+    public function test_a_moderator_can_invite(): void
+    {
+        $moderator = $this->member();
+        VirtualEventAttendee::create([
+            'virtual_event_id' => $this->event->id,
+            'user_id' => $moderator->id,
+            'rsvp_status' => 'accepted',
+            'is_moderator' => true,
+        ]);
+
+        Livewire::actingAs($moderator)
+            ->test(VirtualEventRsvp::class, ['event' => $this->event])
+            ->set('invite_person_id', $this->personWithEmail()->id)
+            ->call('invitePerson')
+            ->assertOk();
+
+        $this->assertSame(1, $this->event->attendees()->where('person_id', '!=', null)->count(), 'A moderator could not invite.');
+    }
+
+    /**
+     * RSVPing is self-service and must stay open to any member — the guard is on
+     * inviting, not on responding.
+     */
+    public function test_a_plain_member_can_still_rsvp_for_themselves(): void
+    {
+        $member = $this->member();
+
+        Livewire::actingAs($member)
+            ->test(VirtualEventRsvp::class, ['event' => $this->event])
+            ->set('rsvp_status', 'accepted')
+            ->call('submitRsvp')
+            ->assertOk();
+
+        $this->assertSame(
+            1,
+            $this->event->attendees()->where('user_id', $member->id)->count(),
+            'A member could not RSVP for themselves.',
+        );
+    }
+
+    private function member(): User
+    {
+        $user = User::factory()->create(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($user, ['role' => 'editor']);
+
+        return $user;
+    }
+
+    private function personWithEmail(): Person
+    {
+        return Person::factory()->create([
+            'team_id' => $this->team->id,
+            'email' => 'invitee@example.com',
+        ]);
+    }
+}


### PR DESCRIPTION
The two per-user surfaces ticket 11 deliberately left out — where a collaboration tier is the wrong tool because the data is per-user or per-event, and the rule is ownership.

## The checklist cross-user IDOR (primary)

`UserChecklistManager` loaded checklists and items straight from a request id with **no check they belonged to the acting user**. Checklists are tenant-scoped, so another *team*'s rows were already invisible — but the live hole was **cross-user within one team**: a member could open, edit, delete, or add items to a teammate's private research checklist by its id. Items are worse — the item table isn't tenant-scoped at all, so an item id was reachable across both team and user.

Every by-id load now routes through an ownership scope. Guarding the entry points wasn't enough: `updateChecklist` and `updateItem` act on a **hydrated property a crafted request controls**, so they re-resolve through the scope rather than trust it. That's the subtle half — a fix that only guarded `editChecklist` would have looked complete and left the update path open.

## The event-invite gap

RSVPing is self-service (any member). But **inviting** others — creating attendee rows for people or arbitrary emails — ran on nothing more than being logged in. `canInvite()` already modelled the organiser rule (event creator / host / moderator) but only drove the UI; it now gates both write methods. A per-event rule, deliberately, not a team-wide tier — a host of one event isn't an organiser of another.

## Ticket premise corrected

The ticket said `user_checklists` has no `team_id`. It does now (`BelongsToTenant`), so cross-*team* was already closed. The real subject is strictly cross-*user*, plus the un-scoped item table. Private messaging was investigated and needs no change — it sends as `Auth::id()` and gates recipients to teammates.

## Test notes (two traps this codebase keeps springing)

- Both users are on **one team**, so the tenant scope can't mask the per-user check.
- The checklist **soft-deletes**, so `find()` returns a deleted row — assertions use `assertNotSoftDeleted` / the database, never `assertNotNull`.
- Livewire handles the two refusals differently: a scoped `findOrFail` throws `ModelNotFoundException` (caught in-test, asserted on outcome), while `abort(403)` is caught by Livewire and surfaced as a response (`assertForbidden`). Both verified revert-sensitive.

764 passed, 12 skipped. PHPStan clean, no baseline growth. Pint clean.
