### PR TITLE
test(tenancy): pin the team profile page as owner-only [tenant-isolation #04]

### DIFF
--- a/app/Filament/App/Pages/EditTeam.php
+++ b/app/Filament/App/Pages/EditTeam.php
@@ -12,6 +12,22 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Override;
 
+/**
+ * The team profile editor.
+ *
+ * Authorization is owner-only, and it is inherited — do not add a member with
+ * an editor or admin tier to this form expecting them to be able to save it.
+ * EditTenantProfile::canView() runs authorize('update', $team), which routes
+ * through TeamPolicy::update (ownership), and it is enforced on mount and
+ * re-checked on every Livewire hydration. So any field added below is already
+ * behind the ownership gate — save() is only reachable after canView passes
+ * again. There is deliberately no canView override here; adding one that reads
+ * ownsTeam() directly would bypass the policy this relies on.
+ *
+ * Owner-only rather than admin-tier is a decision, not an accident: editing the
+ * team's identity and subscription is an owner/billing concern, not the
+ * research a collaborator does. EditTeamAuthorizationTest pins it.
+ */
 class EditTeam extends EditTenantProfile
 {
     #[Override]

--- a/tests/Feature/Tenancy/EditTeamAuthorizationTest.php
+++ b/tests/Feature/Tenancy/EditTeamAuthorizationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Filament\App\Pages\EditTeam;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Editing a team's profile is owner-only, and this pins it.
+ *
+ * The page carries no authorization of its own — and does not need to. It
+ * extends Filament's EditTenantProfile, whose canView() runs authorize('update')
+ * against the tenant, which routes through TeamPolicy::update (ownership). That
+ * check is enforced on mount and re-run on every Livewire hydration, so a
+ * non-owner cannot reach the page or its save path.
+ *
+ * There is no code to add here, which is exactly why this test exists. The page
+ * is a trap in waiting: its form fields are all commented out, so nothing is
+ * exploitable today, and the next person to add a field has no reason to suspect
+ * authorization is anywhere but where every other panel page keeps it. This
+ * fails the moment that inherited gate stops covering the page — a Filament
+ * upgrade that renames the hook, an override that forgets it, a policy change.
+ *
+ * Ownership, not an admin tier, is deliberate. Editing the team profile is the
+ * team's identity and, per the commented-out form, its subscription — an
+ * owner/billing concern, like team membership (TeamMembers is likewise
+ * owner-only), not the day-to-day research a collaborator does (TreePrivacy,
+ * which is tier-gated). An admin-tier genealogy collaborator should not be able
+ * to rename the team or touch its billing. The admin-tier-refused case below is
+ * what encodes that decision.
+ */
+class EditTeamAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_the_owner_may_edit_the_team_profile(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($owner);
+        Filament::setTenant($owner->currentTeam, isQuiet: true);
+
+        $this->assertTrue(EditTeam::canView($owner->currentTeam));
+    }
+
+    /**
+     * Even the highest collaboration tier is not ownership. A member granted
+     * admin in the team still cannot edit its profile — the point of gating on
+     * ownership rather than a tier.
+     */
+    public function test_an_admin_tier_member_may_not_edit_the_team_profile(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $member = User::factory()->withPersonalTeam()->create();
+        $owner->currentTeam->users()->attach($member, ['role' => 'admin']);
+
+        $member = $member->fresh();
+        $this->actingAs($member);
+        Filament::setTenant($owner->currentTeam->fresh(), isQuiet: true);
+
+        $this->assertFalse(
+            EditTeam::canView($owner->currentTeam),
+            'An admin-tier member could edit the team profile; it is meant to be owner-only.',
+        );
+    }
+
+    public function test_an_outsider_may_not_edit_a_team_profile(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $outsider = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($outsider);
+        Filament::setTenant($owner->currentTeam, isQuiet: true);
+
+        $this->assertFalse(EditTeam::canView($owner->currentTeam));
+    }
+}


### PR DESCRIPTION
The ticket expected a hole to close. There isn't one in this Filament version — so this pins the behaviour that's already correct and documents why, rather than adding a redundant (and subtly dangerous) override.

## What the investigation found

`EditTeam` extends Filament's `EditTenantProfile`, whose `canView()` runs `authorize('update', $team)` → `TeamPolicy::update` (ownership), enforced on **mount and every Livewire hydration**. A non-owner already cannot reach the page or its save path. The ticket's premise ("no authorization of its own, relies on tenant access") predates this Filament version.

## Why a test + comment, not a `canView` override

Adding an override would only restate the parent — and the obvious future "cleanup" of it (`return $user->ownsTeam($tenant)`) would **bypass the policy** the page depends on. That's precisely the regression this series exists to prevent. So:

- A **docblock on `EditTeam`**, where the next person to add a field will read it: authorization is inherited and owner-only; any field added is already behind the gate because `save()` is only reachable after `canView` passes again.
- A **regression test** that fails the moment that inherited gate stops covering the page (a Filament upgrade renaming the hook, an override that forgets it, a policy change).

## The decision it records

Owner-only, not admin-tier. Editing the team's identity and subscription is an owner/billing concern — like team membership (`TeamMembers` is owner-only) — not the research a collaborator does (`TreePrivacy`, which is tier-gated). The test's **admin-tier-refused** case is what encodes that: even the highest collaboration tier is not ownership.

## Verification

Owner allowed, admin-tier member refused, outsider refused. Confirmed revert-sensitive: overriding the inherited `canView` to always-true fails the two refusal cases. 756 passed, 12 skipped. PHPStan clean, Pint clean.
