### PR TITLE
fix(tenancy): make background work tenant-safe [tenant-isolation #08]

### DIFF
--- a/app/Console/Commands/ModuleCommand.php
+++ b/app/Console/Commands/ModuleCommand.php
@@ -7,6 +7,12 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
+/**
+ * Scaffolds module boilerplate on disk — global, no tenant.
+ *
+ * A developer tool that writes files, not team-scoped records, so it needs no
+ * tenant context.
+ */
 class ModuleCommand extends Command
 {
     /**

--- a/app/Console/Commands/RunRecordMatcher.php
+++ b/app/Console/Commands/RunRecordMatcher.php
@@ -5,6 +5,14 @@ namespace App\Console\Commands;
 use App\Jobs\RunRecordMatchingJob;
 use Illuminate\Console\Command;
 
+/**
+ * Runs record matching across every team — global by design.
+ *
+ * It dispatches RunRecordMatchingJob, which reads people from all teams and
+ * writes each suggestion stamped with the team of the person it is about (see
+ * the job). This command establishes no tenant of its own, and should not: it
+ * is the scheduled entry point for the whole application, not one team's action.
+ */
 class RunRecordMatcher extends Command
 {
     #[\Override]

--- a/app/Console/Commands/SetupGamificationCommand.php
+++ b/app/Console/Commands/SetupGamificationCommand.php
@@ -7,6 +7,12 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 
+/**
+ * Seeds gamification reference data (achievements, levels) — global, no tenant.
+ *
+ * It touches no team-scoped records, so it establishes no team. Documented here
+ * so the absence is a decision, not an oversight.
+ */
 class SetupGamificationCommand extends Command
 {
     /**

--- a/app/Jobs/Concerns/EstablishesTeam.php
+++ b/app/Jobs/Concerns/EstablishesTeam.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Concerns;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * Runs a job body as a member of a specific team, so tenant scoping is active.
+ *
+ * The tenant scope (BelongsToTenant) reads the authenticated user's current
+ * team and returns early when nobody is authenticated. A queue worker has no
+ * authenticated user, so a job sees every team's rows and stamps new rows with
+ * no team at all. This authenticates the job's user, pinned to the team the
+ * work belongs to, for the duration of the callback and restores whatever the
+ * worker had before.
+ *
+ * For SINGLE-TEAM jobs — an import or export that belongs to one team. The
+ * cross-team analytical jobs (DNA matching, record matching, dedupe) must read
+ * across every team and must NOT use this; they stamp team_id per written row
+ * from the owning entity instead.
+ *
+ * Extracted from ExportsForTeam, which now uses it. The permission-registrar
+ * handling below is new: it belongs with establishing the team, not with where
+ * an export file goes.
+ */
+trait EstablishesTeam
+{
+    /**
+     * Run a callback authenticated as the given user, pinned to the given team,
+     * restoring the worker's previous auth and permission-team afterwards.
+     *
+     * @template T
+     *
+     * @param  callable(): T  $callback
+     * @return T
+     */
+    protected function asTeamMember(User $user, int $teamId, callable $callback): mixed
+    {
+        $previousUser = Auth::user();
+        $registrar = app(PermissionRegistrar::class);
+        $previousTeam = $registrar->getPermissionsTeamId();
+
+        // A user can belong to several teams, so a copy pinned to this team is
+        // used rather than the user as-is — otherwise a job would scope to
+        // whatever team the user last worked in. Only this copy is adjusted;
+        // nothing is saved.
+        $scoped = $user->replicate();
+        $scoped->id = $user->id;
+        $scoped->exists = true;
+        $scoped->current_team_id = $teamId;
+
+        Auth::login($scoped);
+
+        // The permission library also holds the current team, on a singleton
+        // that a queue worker never resets (its only reset listener is
+        // Octane-only). Set it here so any role or permission check inside the
+        // job resolves against this team, and restore it below so the value
+        // does not leak into the next job in the same worker.
+        $registrar->setPermissionsTeamId($teamId);
+
+        try {
+            return $callback();
+        } finally {
+            Auth::logout();
+            $registrar->setPermissionsTeamId($previousTeam);
+
+            if ($previousUser) {
+                Auth::login($previousUser);
+            }
+        }
+    }
+}

--- a/app/Jobs/Concerns/ExportsForTeam.php
+++ b/app/Jobs/Concerns/ExportsForTeam.php
@@ -4,75 +4,28 @@ declare(strict_types=1);
 
 namespace App\Jobs\Concerns;
 
-use App\Models\User;
-use Illuminate\Support\Facades\Auth;
-
 /**
- * Shared by the export jobs, which both have to solve the same two problems.
+ * The export jobs' shared knowledge of where a team's exports live.
  *
- * Where the file goes. Exports were written to the root of the shared private
- * disk under timestamped names, and the export page listed everything there, so
- * every team was shown every other team's exported tree. They live under the
- * team that produced them now, and the page looks no further than its own
- * directory. Both jobs take that path from here so they cannot disagree about
- * it — a second copy drifting is how a file ends up somewhere nothing lists, or
- * somewhere everything does.
+ * Exports were written to the root of the shared private disk under timestamped
+ * names, and the export page listed everything there, so every team was shown
+ * every other team's exported tree. They live under the team that produced them
+ * now, and the page looks no further than its own directory. Both jobs take
+ * that path from here so they cannot disagree about it — a second copy drifting
+ * is how a file ends up somewhere nothing lists, or somewhere everything does.
  *
- * What goes in it. The generators query through the Person and Family models,
- * whose tenant scope is a global scope that returns early when nobody is
- * authenticated — and nothing is authenticated inside a queued job. So an
- * export walked every team's records into one file. Authenticating the
- * requesting user, pinned to the team being exported, puts the scope back in
- * play for the duration.
- *
- * That second part is a local answer to a general problem: no job in this
- * application establishes a tenant, and the rest are scoped by luck or not at
- * all. Tenant-isolation #08 is where that gets solved properly.
+ * The "run as a member of the team" half moved to EstablishesTeam, which this
+ * pulls in, because it is not export-specific — every single-team job needs it.
  */
 trait ExportsForTeam
 {
+    use EstablishesTeam;
+
     /**
      * Where a team's exports live. Also the boundary the export page trusts.
      */
     public static function directoryFor(int $teamId): string
     {
         return "exports/{$teamId}";
-    }
-
-    /**
-     * Run a callback with the exporting user authenticated against the team
-     * being exported, restoring whatever the worker had before.
-     *
-     * @template T
-     *
-     * @param  callable(): T  $callback
-     * @return T
-     */
-    protected function asTeamMember(User $user, int $teamId, callable $callback): mixed
-    {
-        $previous = Auth::user();
-
-        // The tenant scope reads the current team, and a user can belong to
-        // several — so exporting while they happen to be working elsewhere
-        // would produce the wrong family's records under this team's directory.
-        // Only this job's copy is adjusted; nothing is saved.
-        $scoped = $user->replicate();
-        $scoped->id = $user->id;
-        $scoped->exists = true;
-        $scoped->current_team_id = $teamId;
-
-        Auth::login($scoped);
-
-        try {
-            return $callback();
-        } finally {
-            // A worker serves many jobs in one process; leaving this set would
-            // scope the next job to whoever ran this one.
-            Auth::logout();
-
-            if ($previous) {
-                Auth::login($previous);
-            }
-        }
     }
 }

--- a/app/Jobs/DnaMatching.php
+++ b/app/Jobs/DnaMatching.php
@@ -90,6 +90,12 @@ class DnaMatching implements ShouldQueue
                 // Create DNA matching record for current user
                 $dm = new DM;
                 $dm->user_id = $user->id;
+                // Stamped per row from the owning user, not from an established
+                // tenant: this job reads DNA kits ACROSS every team on purpose —
+                // that is what matching is — so it must not run scoped. But the
+                // record it writes belongs to one team, the owner's, and in a
+                // worker with no auth the creating hook would leave it null.
+                $dm->team_id = $user->current_team_id;
                 $dm->match_id = $dna->user_id;
                 $dm->match_name = $match_name;
                 // ponytail: no plot/CSV output is generated yet (real php-dna export is TODO C7),
@@ -114,10 +120,14 @@ class DnaMatching implements ShouldQueue
 
                 // Create reciprocal record for the matched user (if different)
                 if ($dna->user_id !== $user->id) {
+                    $matchedUser = User::find($dna->user_id);
                     $current_name = User::find($user->id)?->name ?? 'Unknown';
 
                     $dm2 = new DM;
                     $dm2->user_id = $dna->user_id;
+                    // The reciprocal record belongs to the matched kit's owner,
+                    // so it carries THEIR team, not this user's.
+                    $dm2->team_id = $matchedUser?->current_team_id;
                     $dm2->match_id = $user->id;
                     $dm2->match_name = $current_name;
                     // ponytail: same as above - no output files generated yet (TODO C7).

--- a/app/Jobs/ImportGedcom.php
+++ b/app/Jobs/ImportGedcom.php
@@ -20,6 +20,7 @@ use Throwable;
 
 class ImportGedcom implements ShouldQueue
 {
+    use Concerns\EstablishesTeam;
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
@@ -31,7 +32,29 @@ class ImportGedcom implements ShouldQueue
 
     public function __construct(protected User $user, protected string $filePath, public ?string $slug = null) {}
 
+    /**
+     * Runs as a member of the importing user's team, so the ImportJob row the
+     * import creates carries that team.
+     *
+     * The tree records were already stamped — the vendor parser takes an
+     * explicit team_id below — but the ImportJob row itself was created in a
+     * worker with no authenticated user, so it landed team_id null and was
+     * invisible in the panel. Establishing the team makes its creating hook
+     * stamp it. If the user somehow has no current team the import still runs,
+     * unscoped, rather than failing.
+     */
     public function handle(): int
+    {
+        $team = $this->user->currentTeam;
+
+        if ($team === null) {
+            return $this->runImport();
+        }
+
+        return $this->asTeamMember($this->user, (int) $team->getKey(), fn (): int => $this->runImport());
+    }
+
+    private function runImport(): int
     {
         Log::info('ImportGedcom job started', [
             'file_path' => $this->filePath,

--- a/app/Jobs/ImportGrampsXml.php
+++ b/app/Jobs/ImportGrampsXml.php
@@ -20,6 +20,7 @@ use Throwable;
 
 class ImportGrampsXml implements ShouldQueue
 {
+    use Concerns\EstablishesTeam;
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
@@ -31,7 +32,22 @@ class ImportGrampsXml implements ShouldQueue
 
     public function __construct(protected User $user, protected string $filePath, public ?string $slug = null) {}
 
+    /**
+     * Runs as a member of the importing user's team, so the ImportJob row lands
+     * with that team rather than null. Same shape as ImportGedcom.
+     */
     public function handle(): int
+    {
+        $team = $this->user->currentTeam;
+
+        if ($team === null) {
+            return $this->runImport();
+        }
+
+        return $this->asTeamMember($this->user, (int) $team->getKey(), fn (): int => $this->runImport());
+    }
+
+    private function runImport(): int
     {
         // Find or create the ImportJob record
         $slug = $this->slug ?? (string) Str::uuid();

--- a/app/Jobs/RunRecordMatchingJob.php
+++ b/app/Jobs/RunRecordMatchingJob.php
@@ -79,7 +79,8 @@ class RunRecordMatchingJob implements ShouldQueue
                                 $person->id,
                                 new ReflectionClass($provider)->getShortName(),
                                 $candidate,
-                                $score
+                                $score,
+                                $person->team_id,
                             );
                             $totalMatches++;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,8 +7,10 @@ use App\Models\Person;
 use App\Modules\ModuleManager;
 use App\Modules\ModuleServiceProvider;
 use Exception;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\ServiceProvider;
 use Log;
+use Spatie\Permission\PermissionRegistrar;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -63,6 +65,47 @@ class AppServiceProvider extends ServiceProvider
 
         // Enable default modules on first boot
         $this->enableDefaultModules();
+
+        $this->resetPermissionTeamBetweenJobs();
+    }
+
+    /**
+     * Give every queued job a clean permission-team context, and hand back
+     * whatever was there before once it finishes.
+     *
+     * PermissionRegistrar holds the current team on the app singleton, and its
+     * only reset is registered for Octane — which a plain queue worker never
+     * hits. So a long-lived worker would carry one job's team into the next, and
+     * a role check in job B could resolve against team A. Each job therefore
+     * starts from null; jobs that establish a team (EstablishesTeam) set their
+     * own from there.
+     *
+     * The team held before the job is saved and restored afterwards rather than
+     * simply nulled, because on the sync queue — which .env.example and the test
+     * config both use — a job runs inside the web request that dispatched it.
+     * Nulling and not restoring would leave the rest of that request with no
+     * permission team. The save/restore is a stack so nested dispatches unwind
+     * correctly.
+     */
+    private function resetPermissionTeamBetweenJobs(): void
+    {
+        $teamStack = [];
+
+        Queue::before(function () use (&$teamStack): void {
+            $registrar = app(PermissionRegistrar::class);
+            $teamStack[] = $registrar->getPermissionsTeamId();
+            $registrar->setPermissionsTeamId(null);
+        });
+
+        $restore = function () use (&$teamStack): void {
+            if ($teamStack === []) {
+                return;
+            }
+            app(PermissionRegistrar::class)->setPermissionsTeamId(array_pop($teamStack));
+        };
+
+        Queue::after($restore);
+        Queue::failing($restore);
     }
 
     /**

--- a/app/Services/DnaImportService.php
+++ b/app/Services/DnaImportService.php
@@ -81,9 +81,17 @@ class DnaImportService
         $varName = $this->generateUniqueVarName();
 
         // Create DNA record
+        // Resolved up front: the kit needs the owner's team, and the dispatch
+        // below needs the user anyway. In a queued or CLI import there is no
+        // authenticated user, so the tenant hook would leave the kit team_id
+        // null — and this service is the shared path for the web import too, so
+        // stamping here fixes every caller.
+        $user = User::find($userId);
+
         $dna = new Dna;
         $dna->name = 'DNA Kit for user '.$userId.' ('.basename($filePath).')';
         $dna->user_id = $userId;
+        $dna->team_id = $user?->current_team_id;
         $dna->variable_name = $varName;
         $dna->file_name = $filePath;
         if ($consentGiven) {
@@ -94,7 +102,6 @@ class DnaImportService
 
         // Dispatch matching only for a consented kit — never match DNA without consent.
         if ($autoMatch && $dna->hasConsent()) {
-            $user = User::find($userId);
             if ($user) {
                 DnaMatching::dispatch($user, $varName, $filePath);
                 Log::info("DNA matching job dispatched for kit {$varName}");

--- a/app/Services/DuplicateDetectionService.php
+++ b/app/Services/DuplicateDetectionService.php
@@ -21,7 +21,14 @@ class DuplicateDetectionService
     {
         $created = collect();
 
-        $persons = Person::select(['id', 'givn', 'surn', 'name', 'email', 'phone', 'birthday'])->get();
+        // team_id is selected because duplicate detection must stay within a
+        // team. This scan runs as a scheduled job with no authenticated user,
+        // so the tenant scope is inactive and every team's people are loaded
+        // together — which is correct for one global pass, but means a pair
+        // must be rejected unless both people belong to the same team.
+        // Otherwise the scan would surface one team's person as a "duplicate" of
+        // another's: a cross-tenant disclosure, not merely an unstamped row.
+        $persons = Person::select(['id', 'givn', 'surn', 'name', 'email', 'phone', 'birthday', 'team_id'])->get();
 
         // Index persons by email and phone for cheap exact matches
         $emailIndex = $persons->filter(fn ($p) => $p->email)->groupBy(fn ($p) => Str::lower($p->email));
@@ -34,7 +41,7 @@ class DuplicateDetectionService
             if ($primary->email) {
                 $email = Str::lower($primary->email);
                 foreach ($emailIndex->get($email, []) as $p) {
-                    if ($p->id === $primary->id) {
+                    if ($p->id === $primary->id || empty($p->team_id) || $p->team_id !== $primary->team_id) {
                         continue;
                     }
                     $score = 0.95;
@@ -46,7 +53,7 @@ class DuplicateDetectionService
             if ($primary->phone) {
                 $phone = preg_replace('/\D+/', '', (string) $primary->phone);
                 foreach ($phoneIndex->get($phone, []) as $p) {
-                    if ($p->id === $primary->id) {
+                    if ($p->id === $primary->id || empty($p->team_id) || $p->team_id !== $primary->team_id) {
                         continue;
                     }
                     $score = 0.93;
@@ -56,7 +63,7 @@ class DuplicateDetectionService
 
             // naive pass comparing birthdays and name similarity (O(n^2) but acceptable for small/medium datasets)
             foreach ($persons as $other) {
-                if ($other->id === $primary->id) {
+                if ($other->id === $primary->id || empty($other->team_id) || $other->team_id !== $primary->team_id) {
                     continue;
                 }
 
@@ -97,6 +104,12 @@ class DuplicateDetectionService
                     'primary_person_id' => $primaryKey,
                     'duplicate_person_id' => $duplicateKey,
                 ]);
+
+                // Both people share a non-null team by the guards above (a null
+                // team is skipped rather than paired with another null), so the
+                // match belongs to that team. Set explicitly — the job is
+                // unauthenticated, so the tenant hook would leave it null.
+                $record->team_id = $primary->team_id;
 
                 // If new or confidence improved, store
                 $existing = $record->exists ? (float) $record->confidence_score : 0.0;

--- a/app/Services/RecordMatcher/RecordMatcherService.php
+++ b/app/Services/RecordMatcher/RecordMatcherService.php
@@ -132,8 +132,12 @@ class RecordMatcherService
     /**
      * Persist suggestions into DB (upsert).
      */
-    public function persistSuggestion(int $localPersonId, string $provider, array $candidate, float $confidence): AISuggestedMatch
+    public function persistSuggestion(int $localPersonId, string $provider, array $candidate, float $confidence, ?int $teamId = null): AISuggestedMatch
     {
+        // team_id is passed in, not left to the tenant hook. Record matching is
+        // a scheduled job that reads people across every team by design, so it
+        // runs unauthenticated and the hook would stamp null. The suggestion
+        // belongs to the team of the person it is about; the caller passes that.
         return AISuggestedMatch::updateOrCreate(
             [
                 'provider' => $provider,
@@ -144,6 +148,7 @@ class RecordMatcherService
                 'candidate_data' => $candidate,
                 'confidence' => $confidence,
                 'status' => 'pending',
+                'team_id' => $teamId,
             ]
         );
     }

--- a/tests/Feature/Tenancy/BackgroundJobTeamStampingTest.php
+++ b/tests/Feature/Tenancy/BackgroundJobTeamStampingTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Jobs\DnaMatching;
+use App\Models\Dna;
+use App\Models\DnaMatching as DnaMatch;
+use App\Models\User;
+use App\Services\RecordMatcher\RecordMatcherService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * A trivial job that records the permission team it saw when it ran, so a test
+ * can prove the boundary reset fired before it.
+ */
+class TeamProbeJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public static int|string|null $seenTeamId = 'unset';
+
+    public function handle(): void
+    {
+        self::$seenTeamId = app(PermissionRegistrar::class)->getPermissionsTeamId();
+    }
+}
+
+/**
+ * The analytical jobs read across every team on purpose — that is what matching
+ * and deduplication are — so they cannot run scoped to one team. Instead each
+ * row they write is stamped with the team it belongs to, taken from the owning
+ * entity. In a worker with no authenticated user the tenant hook would leave
+ * that team null, so the stamp is explicit.
+ *
+ * These run the code the way a worker does: unauthenticated.
+ */
+class BackgroundJobTeamStampingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dna_matching_stamps_each_row_with_its_owners_team(): void
+    {
+        Storage::fake('private');
+        $kit = $this->buildKit();
+        Storage::disk('private')->put('kit_a.txt', $kit);
+        Storage::disk('private')->put('kit_b.txt', $kit);
+
+        $userA = User::factory()->withPersonalTeam()->create();
+        $userB = User::factory()->withPersonalTeam()->create();
+
+        $this->kit($userA, 'kit_a', 'kit_a.txt');
+        $this->kit($userB, 'kit_b', 'kit_b.txt');
+
+        // As a worker: no authenticated user, no tenant.
+        Auth::logout();
+        (new DnaMatching($userA, 'kit_a', 'kit_a.txt'))->handle();
+
+        // The primary record belongs to A; the reciprocal, to B.
+        $primary = DnaMatch::withoutGlobalScopes()->where('user_id', $userA->id)->first();
+        $reciprocal = DnaMatch::withoutGlobalScopes()->where('user_id', $userB->id)->first();
+
+        $this->assertNotNull($primary, 'No primary match row was written.');
+        $this->assertSame($userA->current_team_id, $primary->team_id, 'The primary row did not carry the owner\'s team.');
+
+        $this->assertNotNull($reciprocal, 'No reciprocal match row was written.');
+        $this->assertSame(
+            $userB->current_team_id,
+            $reciprocal->team_id,
+            'The reciprocal row carried the wrong team — it belongs to the matched kit\'s owner.',
+        );
+    }
+
+    public function test_a_record_match_suggestion_carries_the_persons_team(): void
+    {
+        $team = User::factory()->withPersonalTeam()->create()->current_team_id;
+
+        $suggestion = app(RecordMatcherService::class)->persistSuggestion(
+            localPersonId: 1,
+            provider: 'test',
+            candidate: ['id' => 'ext-1', 'name' => 'A Match'],
+            confidence: 0.9,
+            teamId: $team,
+        );
+
+        $this->assertSame($team, $suggestion->team_id, 'A record-match suggestion was not stamped with its team.');
+    }
+
+    public function test_a_job_starts_with_a_clean_permission_team(): void
+    {
+        // A previous job in this worker left its team set.
+        app(PermissionRegistrar::class)->setPermissionsTeamId(999999);
+
+        // The next job runs. On the sync queue, dispatching fires the same
+        // JobProcessing event a worker fires, so the Queue::before listener runs
+        // before the job body — and the job records the team it saw.
+        TeamProbeJob::$seenTeamId = 'unset';
+        dispatch(new TeamProbeJob);
+
+        $this->assertNull(
+            TeamProbeJob::$seenTeamId,
+            'A job ran with the previous job\'s permission team still set.',
+        );
+    }
+
+    /**
+     * On the sync queue a job runs inside the request that dispatched it, so the
+     * request's permission team must survive the job — the reset gives the job a
+     * clean start but must not leave the surrounding request with no team.
+     */
+    public function test_the_dispatching_requests_permission_team_survives_the_job(): void
+    {
+        $requestTeam = 4242;
+        app(PermissionRegistrar::class)->setPermissionsTeamId($requestTeam);
+
+        dispatch(new TeamProbeJob);
+
+        $this->assertSame(
+            $requestTeam,
+            app(PermissionRegistrar::class)->getPermissionsTeamId(),
+            'The job cleared the dispatching request\'s permission team and never restored it.',
+        );
+    }
+
+    private function kit(User $user, string $varName, string $fileName): Dna
+    {
+        return Dna::create([
+            'name' => $varName,
+            'variable_name' => $varName,
+            'file_name' => $fileName,
+            'user_id' => $user->id,
+            'consent_given' => true,
+            'consent_given_at' => now(),
+        ]);
+    }
+
+    private function buildKit(): string
+    {
+        $lines = [
+            '# This data file generated by 23andMe',
+            "rsid\tchromosome\tposition\tgenotype",
+        ];
+
+        for ($i = 0; $i < 600; $i++) {
+            $pos = 1_000_000 + $i * 30_000;
+            $lines[] = "rs{$i}\t1\t{$pos}\tAG";
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+}

--- a/tests/Feature/Tenancy/DuplicateScanIsolationTest.php
+++ b/tests/Feature/Tenancy/DuplicateScanIsolationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Person;
+use App\Models\User;
+use App\Services\DuplicateDetectionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+/**
+ * The duplicate scanner must never pair one team's person with another's.
+ *
+ * It runs as a scheduled job with no authenticated user, so the tenant scope is
+ * inactive and it loads every team's people together — correct for one global
+ * pass. But it then compared every person against every other regardless of
+ * team, so two people with the same name on different teams became a
+ * DuplicateMatch. That surfaces one team's record inside another's dedupe
+ * queue: a cross-tenant disclosure, not just an unstamped row.
+ *
+ * The scan is invoked here exactly as the job does — unauthenticated — so the
+ * isolation comes from the code, not from a tenant the test happens to set.
+ */
+class DuplicateScanIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_people_on_different_teams_are_never_matched(): void
+    {
+        $teamA = $this->teamId();
+        $teamB = $this->teamId();
+
+        // The same distinctive name on two teams — an exact-ish match the fuzzy
+        // pass would pair if it ignored the team.
+        $this->person($teamA, 'Archibald', 'Fitzgerald');
+        $this->person($teamB, 'Archibald', 'Fitzgerald');
+
+        Auth::logout();
+        $matches = app(DuplicateDetectionService::class)->scan(0.5);
+
+        $this->assertCount(0, $matches, 'The scanner paired people across two teams.');
+    }
+
+    public function test_people_on_the_same_team_are_still_matched(): void
+    {
+        $team = $this->teamId();
+
+        $this->person($team, 'Archibald', 'Fitzgerald');
+        $this->person($team, 'Archibald', 'Fitzgerald');
+
+        Auth::logout();
+        $matches = app(DuplicateDetectionService::class)->scan(0.5);
+
+        $this->assertGreaterThan(0, $matches->count(), 'The scanner missed a real same-team duplicate.');
+        $this->assertSame(
+            $team,
+            (int) $matches->first()->team_id,
+            'A duplicate match was not stamped with its team.',
+        );
+    }
+
+    /**
+     * The exact-phone path scores 0.93 and has its own guard, separate from the
+     * fuzzy-name loop. It is the highest-scoring reachable contact match: email
+     * is a globally unique column, so two people can never share one and that
+     * path is unreachable, but phone is not unique. Distinct names here so the
+     * fuzzy path scores below threshold — the two people are the "same" only by
+     * phone, which is exactly what this guard must catch across teams.
+     */
+    public function test_the_same_phone_on_different_teams_is_never_matched(): void
+    {
+        $teamA = $this->teamId();
+        $teamB = $this->teamId();
+
+        $this->person($teamA, 'Bartholomew', 'Aardvark', phone: '+1-555-0100');
+        $this->person($teamB, 'Cornelius', 'Zylberschlag', phone: '+1-555-0100');
+
+        Auth::logout();
+        $matches = app(DuplicateDetectionService::class)->scan(0.5);
+
+        $this->assertCount(0, $matches, 'The scanner paired people across teams by phone.');
+    }
+
+    public function test_the_same_phone_on_the_same_team_is_still_matched(): void
+    {
+        $team = $this->teamId();
+
+        // Names differ, so only the phone path can pair them — proving that path
+        // still works within a team, not just that fuzzy names do.
+        $this->person($team, 'Bartholomew', 'Aardvark', phone: '+1-555-0100');
+        $this->person($team, 'Cornelius', 'Zylberschlag', phone: '+1-555-0100');
+
+        Auth::logout();
+        $matches = app(DuplicateDetectionService::class)->scan(0.5);
+
+        $this->assertGreaterThan(0, $matches->count(), 'The scanner missed a same-team phone duplicate.');
+    }
+
+    private function teamId(): int
+    {
+        return User::factory()->withPersonalTeam()->create()->current_team_id;
+    }
+
+    private function person(int $teamId, string $givn, string $surn, ?string $email = null, ?string $phone = null): Person
+    {
+        // Stamped directly: created without auth here, as the scan itself runs.
+        $person = Person::factory()->create([
+            'givn' => $givn,
+            'surn' => $surn,
+            'name' => "{$givn} {$surn}",
+            'email' => $email,
+            'phone' => $phone,
+        ]);
+        $person->forceFill(['team_id' => $teamId])->save();
+
+        return $person;
+    }
+}

--- a/tests/Feature/Tenancy/EstablishesTeamTest.php
+++ b/tests/Feature/Tenancy/EstablishesTeamTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Jobs\Concerns\EstablishesTeam;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use RuntimeException;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * The mechanism single-team jobs use to run with a tenant established.
+ *
+ * These call it the way a worker does — no authenticated user, sometimes a
+ * permission team left over from a previous job — and check that it both
+ * establishes the right team for the duration and leaves nothing behind. The
+ * leak this guards against only appears across jobs in one long-lived process,
+ * which is why the checks run two calls in the same test rather than relying on
+ * separate methods the framework would reset between.
+ */
+class EstablishesTeamTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private object $runner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // A throwaway object that uses the trait, standing in for a job.
+        $this->runner = new class
+        {
+            use EstablishesTeam;
+
+            public function run(User $user, int $teamId, callable $callback): mixed
+            {
+                return $this->asTeamMember($user, $teamId, $callback);
+            }
+        };
+    }
+
+    public function test_the_callback_runs_scoped_to_the_given_team(): void
+    {
+        $owner = User::factory()->withPersonalTeam()->create();
+        Auth::logout();
+
+        // A person the tenant scope would only show to that team.
+        $this->runner->run($owner, $owner->current_team_id, function () use ($owner): void {
+            Person::factory()->create();
+
+            $this->assertSame($owner->current_team_id, auth()->user()?->current_team_id);
+        });
+
+        $this->assertSame(
+            $owner->current_team_id,
+            Person::withoutGlobalScopes()->latest('id')->first()->team_id,
+            'The row a scoped job created did not carry the team.',
+        );
+    }
+
+    public function test_auth_and_permission_team_are_restored_even_when_the_callback_throws(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Auth::logout();
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+
+        try {
+            $this->runner->run($user, $user->current_team_id, function (): void {
+                throw new RuntimeException('boom');
+            });
+            $this->fail('The callback should have thrown.');
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        $this->assertNull(Auth::user(), 'A failed job left its user authenticated in the worker.');
+        $this->assertNull(
+            app(PermissionRegistrar::class)->getPermissionsTeamId(),
+            'A failed job left its permission team set for the next job.',
+        );
+    }
+
+    public function test_two_teams_in_one_process_do_not_cross_contaminate(): void
+    {
+        $userA = User::factory()->withPersonalTeam()->create();
+        $userB = User::factory()->withPersonalTeam()->create();
+        Auth::logout();
+
+        // Simulate the worker having last served team A.
+        app(PermissionRegistrar::class)->setPermissionsTeamId($userA->current_team_id);
+
+        $this->runner->run($userB, $userB->current_team_id, function () use ($userB): void {
+            Person::factory()->create();
+            $this->assertSame($userB->current_team_id, auth()->user()?->current_team_id, 'Job B inherited job A\'s user.');
+        });
+
+        // The row is B's, and the permission team is back to what it was before
+        // B ran — not B's, and not leaked onward.
+        $this->assertSame($userB->current_team_id, Person::withoutGlobalScopes()->latest('id')->first()->team_id);
+        $this->assertSame(
+            $userA->current_team_id,
+            app(PermissionRegistrar::class)->getPermissionsTeamId(),
+            'Job B did not restore the permission team it found.',
+        );
+    }
+}


### PR DESCRIPTION
Background jobs run with no authenticated user, so `BelongsToTenant`'s scope and creating-hook both no-op: a job sees every team's rows and stamps new rows with null team. This was the root cause behind both export leaks fixed earlier. Two categories of job need **opposite** fixes.

## Single-team jobs (imports) → establish the team

`ImportGedcom` / `ImportGrampsXml` now run as a member of the importing user's team, via a new `EstablishesTeam` trait extracted from the export jobs' `ExportsForTeam`. The tree records were already stamped (explicit parser arg); the **`ImportJob` row itself** was created unscoped and landed null, invisible in the panel. Running under the established team fixes it.

## Cross-team analytical jobs → stamp per row

DNA matching, record matching and the duplicate scanner **must** read across every team — that's what they are — so they can't be scoped. Instead each row is stamped from the owning entity: DNA matching stamps the primary row to the requester's team and the reciprocal to the matched kit owner's; record-match suggestions carry the matched person's team; the DNA kit is stamped in `DnaImportService` (fixing the web path too).

## The cross-tenant exposure (the security headline)

The duplicate scanner compared every person against every other **regardless of team**, so two people with the same phone on different teams became a `DuplicateMatch` — one team's record and contact details surfaced inside another's dedupe queue. Now rejected unless both share a non-null team, on all three candidate paths, and stamped with that team.

## The permission-team leak

`PermissionRegistrar` holds the team on a singleton a worker never resets. A `Queue::before` clears it before each job; a `Queue::after`/`failing` pair **restores what the request had** — because on the sync queue (which `.env.example` and the test config use) a job runs inside the dispatching request, and nulling-without-restore would strip that request's team for the rest of its life.

## The review earned its keep

An adversarial pass, run against the working tree, found two real problems I fixed before this PR:

1. **The email/phone same-team guards were untested** — my fixtures only set names, so only the fuzzy path was exercised; removing the email+phone guards left the test green. Investigating, the **email path is unreachable** (email is a globally unique column, so two people can't share one) — but **phone is not unique**, so it's a live path. It now has coverage that fails when the guard is removed.
2. **The `Queue::before` reset leaked out** into sync-queue web requests (no restore). Fixed with the save/restore stack above, with a test that fails without the restore.

It also flagged two low-severity null-stamp corners I left as the ticket frames them ("a job needing no team still runs rather than fails"): a teamless import stamps `ImportJob` null, and a DNA reciprocal row for a deleted kit owner stamps null. Neither is a cross-tenant leak.

## Verification

764 passed, 12 skipped. PHPStan clean (used `getKey()` rather than growing the baseline when a refactor added a `Model::$id` access). Pint clean. Every guard's test fails when the guard is removed; the two-teams-in-one-process test proves the trait doesn't cross-contaminate; the sync-request test proves the reset doesn't leak out.
