### PR TITLE
feat(tenancy): make the super-admin bootstrap coherent [tenant-isolation #09]

### DIFF
--- a/app/Console/Commands/DisabledShieldSuperAdminCommand.php
+++ b/app/Console/Commands/DisabledShieldSuperAdminCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Overrides bezhanSalleh/filament-shield's `shield:super-admin` by claiming the
+ * same command name.
+ *
+ * With permission.teams = true (this project enables team-scoped roles), the
+ * vendor command requires a --tenant and mints a *team-scoped* super_admin.
+ * User::hasGlobalRole() only accepts a role whose definition has team_id = NULL,
+ * so a team-scoped super_admin never opens the admin panel: the vendor command
+ * reports "Success!" and hands back an administrator who cannot administer, with
+ * nothing to say what went wrong. Rather than let that happen, refuse and name
+ * the route that works. VendorSuperAdminCommandsTest pins that this override,
+ * not the vendor command, is what `shield:super-admin` resolves to.
+ */
+class DisabledShieldSuperAdminCommand extends Command
+{
+    // Same three options the vendor command accepts, so passing --tenant/--user/
+    // --panel reaches this message rather than an "option does not exist" error.
+    protected $signature = 'shield:super-admin
+        {--user= : Unsupported — use app:grant-super-admin instead.}
+        {--panel= : Unsupported — use app:grant-super-admin instead.}
+        {--tenant= : Unsupported — use app:grant-super-admin instead.}';
+
+    protected $description = 'Disabled in this project — run app:grant-super-admin <email> instead.';
+
+    public function handle(): int
+    {
+        $this->components->error(
+            'shield:super-admin is disabled here. This project uses team-scoped roles, '
+            .'and that command would create a team-scoped super_admin that cannot open the '
+            .'admin panel. Run `php artisan app:grant-super-admin <email>` instead — it mints '
+            .'the team-less super_admin the admin panel requires.'
+        );
+
+        return self::FAILURE;
+    }
+}

--- a/docs/super-admin.md
+++ b/docs/super-admin.md
@@ -1,0 +1,42 @@
+# Creating a super administrator
+
+The admin panel (`/admin`) is global — it is not scoped to any team. A super
+administrator is a user who holds a **team-less** `super_admin` role (a role row
+with `team_id = NULL`). `User::hasGlobalRole()` only accepts a team-less role, so
+only a team-less `super_admin` opens the admin panel.
+
+## The supported route
+
+```bash
+php artisan app:grant-super-admin <email>
+```
+
+This finds (or creates) the team-less `super_admin` role and assigns it to the
+user with that email. The account can then open `/admin` from any team it belongs
+to. A fresh install also seeds this same team-less role (`RolesSeeder`).
+
+## Do not use `shield:super-admin`
+
+This project enables team-scoped roles (`config/permission.php` → `'teams' =>
+true`). Under that flag, Filament Shield's `shield:super-admin` requires a
+`--tenant` and creates a `super_admin` scoped to **that team** — a role with a
+non-null `team_id`, which `hasGlobalRole()` rejects. It would report "Success!"
+and hand back an administrator who cannot reach the admin panel.
+
+The command is therefore overridden
+(`App\Console\Commands\DisabledShieldSuperAdminCommand`): running it refuses and
+points back here. Nothing to do — just use `app:grant-super-admin`.
+
+`shield:setup` shells out to `shield:super-admin` for its optional "create a
+super admin" step, so that step will report a failure. That is intended — it
+would otherwise create the same broken team-scoped admin. Run
+`app:grant-super-admin` afterwards.
+
+## `shield:generate` is safe to re-run
+
+`shield:generate` also reads the teams flag. Because Shield's `tenant_model` is
+left unset, it refreshes a single team-less `super_admin`, not one per team, so
+re-running it on an installed system does not litter the roles table. (If anyone
+sets `tenant_model` in a published `config/filament-shield.php`, that stops being
+true and `shield:generate` would create a per-team `super_admin` for every team —
+`VendorSuperAdminCommandsTest` guards against that regression.)

--- a/tests/Feature/Tenancy/VendorSuperAdminCommandsTest.php
+++ b/tests/Feature/Tenancy/VendorSuperAdminCommandsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Team;
+use BezhanSalleh\FilamentShield\Support\Utils;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Enabling team-scoped roles (permission.teams = true) changed how the Shield
+ * vendor commands behave. These pin the two that mattered:
+ *
+ *  - shield:super-admin would mint a *team-scoped* super_admin, which
+ *    User::hasGlobalRole() rejects — a command that reports success and hands
+ *    back an administrator who cannot administer. It is overridden
+ *    (App\Console\Commands\DisabledShieldSuperAdminCommand) to refuse and point
+ *    at app:grant-super-admin.
+ *  - shield:generate re-runs the super_admin role creation. With Shield's
+ *    tenant_model unset it must produce one team-less role, not one per team.
+ */
+class VendorSuperAdminCommandsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_the_vendor_super_admin_command_is_refused_and_names_the_working_route(): void
+    {
+        $code = Artisan::call('shield:super-admin', ['--tenant' => 1]);
+
+        $this->assertSame(Command::FAILURE, $code, 'shield:super-admin did not fail.');
+        $this->assertStringContainsString(
+            'app:grant-super-admin',
+            Artisan::output(),
+            'shield:super-admin failed without naming the working alternative.',
+        );
+    }
+
+    /**
+     * This calls the exact vendor code shield:generate runs to grant the
+     * super_admin its permissions (Utils::giveSuperAdminPermission), rather than
+     * the whole command — in the test panel Shield discovers no entities, so the
+     * command itself never reaches this branch. The branch is what matters: with
+     * several teams present and Shield's tenant_model unset it must create one
+     * team-less super_admin, not one per team. If tenant_model is ever set, the
+     * per-tenant loop reappears and this fails, flagging the roles-table clutter
+     * the ticket warns about before it ships.
+     */
+    public function test_regenerating_permissions_never_creates_a_team_scoped_super_admin(): void
+    {
+        Team::factory()->count(3)->create();
+        Permission::create(['name' => 'view_any_person', 'guard_name' => 'web']);
+
+        Utils::giveSuperAdminPermission(['view_any_person']);
+
+        $superAdmins = Role::where('name', 'super_admin')->get();
+
+        $this->assertCount(
+            1,
+            $superAdmins,
+            "Expected one team-less super_admin; got {$superAdmins->count()} — a per-team role means the roles table now has rows that confer no administration.",
+        );
+        $this->assertNull(
+            $superAdmins->first()->team_id,
+            'shield:generate created a team-scoped super_admin, which User::hasGlobalRole() rejects.',
+        );
+    }
+}


### PR DESCRIPTION
Closes tenant-isolation ticket **#09**. Every documented way to create a super administrator now either produces one that works, or fails immediately and says why.

## The problem

Enabling team-scoped roles (`config/permission.php` → `'teams' => true`, ticket #05) also changed how Filament Shield's vendor commands behave. `shield:super-admin` now requires a `--tenant` and mints a **team-scoped** `super_admin` — a role whose definition carries a non-null `team_id`. `User::hasGlobalRole()` only accepts a team-less role (`whereNull(team_id)`), so a team-scoped `super_admin` never opens the admin panel. The command reported `Success!` and handed back an administrator who could not administer, with nothing to indicate what went wrong. `app:grant-super-admin` (added in #05) is the route that works; the broken vendor command was left in place.

## What changed

- **`app:grant-super-admin` stays the supported route** (unchanged) — it mints the team-less `super_admin` the panel requires.
- **`shield:super-admin` is overridden** by `DisabledShieldSuperAdminCommand`, an app command claiming the same name. It refuses and names `app:grant-super-admin`. Verified on the real CLI that the app command wins the name; a test pins it. This also covers `shield:setup` and `shield:install`, which shell out to `shield:super-admin` **by name**.
- **`shield:generate` needs no change.** The ticket worried re-running it would create a per-team `super_admin` for every team. Running it established that does not happen here: Shield's `tenant_model` is unset, so `Utils::giveSuperAdminPermission()` takes its team-less branch and refreshes a *single* team-less role (`createRole()` writes `team_id => null` explicitly). A test asserts one team-less role and **fails with 3 per-team roles if `tenant_model` is ever set** — guarding the regression before it could ship.
- **`docs/super-admin.md`** — the supported route was written down nowhere an operator would find it. Added a concise operator doc, including that `shield:setup`'s super-admin step now fails by design.

## Verification

Per the ticket's "verified by running it, not only by reading its source":

- Ran `shield:super-admin --tenant=1` on the real CLI → the override's message naming `app:grant-super-admin` (not the vendor prompt).
- `VendorSuperAdminCommandsTest` runs both the override and the exact vendor role-creation branch (`Utils::giveSuperAdminPermission`) `shield:generate` uses — the full CLI discovers 0 entities in the test panel, so the branch is exercised directly. Both tests confirmed **revert-sensitive**: removing the override fails the first; setting `tenant_model` fails the second (3 per-team roles).
- An adversarial review traced every operator-reachable `createRole()`/`giveSuperAdminPermission()` call site in the vendor package and found no uncovered path that mints a team-scoped admin.
- Full suite **779 passed, 12 skipped**; PHPStan clean; Pint clean.