### PR TITLE
refactor(nav): consolidate app-panel navigation into 9 coherent groups

### DIFF
--- a/app/Filament/App/Pages/DabovilleReportPage.php
+++ b/app/Filament/App/Pages/DabovilleReportPage.php
@@ -22,7 +22,7 @@ class DabovilleReportPage extends Page
     protected static ?string $navigationLabel = 'DAboville Report';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📄 Reports';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 
     public function mount(): void
     {

--- a/app/Filament/App/Pages/DeVilliersReportPage.php
+++ b/app/Filament/App/Pages/DeVilliersReportPage.php
@@ -27,7 +27,7 @@ class DeVilliersReportPage extends Page
     protected static ?string $navigationLabel = 'De Villiers Report';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📄 Reports';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
     // {
     //     Livewire::mount('DeVilliersReportWidget');
     // }

--- a/app/Filament/App/Pages/DescendantChartPage.php
+++ b/app/Filament/App/Pages/DescendantChartPage.php
@@ -15,7 +15,7 @@ class DescendantChartPage extends Page
     protected static ?string $navigationLabel = 'Descendant Chart';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Visualizations';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 
     #[\Override]
     protected static ?int $navigationSort = 3;

--- a/app/Filament/App/Pages/DnaTriangulationPage.php
+++ b/app/Filament/App/Pages/DnaTriangulationPage.php
@@ -25,7 +25,7 @@ class DnaTriangulationPage extends Page implements HasForms
     protected string $view = 'filament.app.pages.dna-triangulation-page';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Genetics';
+    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Matching';
 
     #[\Override]
     protected static ?string $navigationLabel = 'DNA Triangulation';

--- a/app/Filament/App/Pages/FacialRecognitionReviewPage.php
+++ b/app/Filament/App/Pages/FacialRecognitionReviewPage.php
@@ -21,7 +21,7 @@ class FacialRecognitionReviewPage extends Page
     protected static ?string $title = 'Review Facial Recognition Tags';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Workspace';
 
     #[\Override]
     protected static ?int $navigationSort = 5;

--- a/app/Filament/App/Pages/FanChartPage.php
+++ b/app/Filament/App/Pages/FanChartPage.php
@@ -15,7 +15,7 @@ class FanChartPage extends Page
     protected string $view = 'filament.app.pages.fan-chart-page';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Visualizations';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 
     #[\Override]
     protected static ?string $title = 'Fan Chart';

--- a/app/Filament/App/Pages/GamificationPage.php
+++ b/app/Filament/App/Pages/GamificationPage.php
@@ -15,7 +15,7 @@ class GamificationPage extends Page
     protected string $view = 'filament.app.pages.gamification-page';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🎮 Gamification';
+    protected static string|\UnitEnum|null $navigationGroup = '🎉 Community';
 
     #[\Override]
     protected static ?string $title = 'Achievements & Progress';

--- a/app/Filament/App/Pages/GedcomExportPage.php
+++ b/app/Filament/App/Pages/GedcomExportPage.php
@@ -20,7 +20,7 @@ class GedcomExportPage extends Page
     protected static ?string $navigationLabel = 'GEDCOM Export';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[\Override]
     protected static ?int $navigationSort = 2;

--- a/app/Filament/App/Pages/GlobalSearchPage.php
+++ b/app/Filament/App/Pages/GlobalSearchPage.php
@@ -14,7 +14,7 @@ class GlobalSearchPage extends Page
     protected string $view = 'filament.app.pages.global-search-page';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
 
     #[\Override]
     protected static ?string $navigationLabel = 'Global Search';

--- a/app/Filament/App/Pages/GrampsXmlExportPage.php
+++ b/app/Filament/App/Pages/GrampsXmlExportPage.php
@@ -20,7 +20,7 @@ class GrampsXmlExportPage extends Page
     protected static ?string $navigationLabel = 'GrampsXML Export';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[\Override]
     protected static ?int $navigationSort = 3;

--- a/app/Filament/App/Pages/HenryReportPage.php
+++ b/app/Filament/App/Pages/HenryReportPage.php
@@ -21,5 +21,5 @@ class HenryReportPage extends Page
     protected static ?string $navigationLabel = 'Henry Report';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📄 Reports';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 }

--- a/app/Filament/App/Pages/PedigreeChartPage.php
+++ b/app/Filament/App/Pages/PedigreeChartPage.php
@@ -15,7 +15,7 @@ class PedigreeChartPage extends Page
     protected static ?string $navigationLabel = 'Pedigree Chart';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Visualizations';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 
     #[\Override]
     protected static ?int $navigationSort = 1;

--- a/app/Filament/App/Pages/RelationshipCalculatorReport.php
+++ b/app/Filament/App/Pages/RelationshipCalculatorReport.php
@@ -30,7 +30,7 @@ class RelationshipCalculatorReport extends Page implements HasForms
     protected static ?string $navigationLabel = 'Relationship Calculator';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📄 Reports';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 
     public ?array $data = [];
 

--- a/app/Filament/App/Pages/ResearchDashboardPage.php
+++ b/app/Filament/App/Pages/ResearchDashboardPage.php
@@ -17,7 +17,7 @@ class ResearchDashboardPage extends Page
     protected static ?string $navigationLabel = 'Research Dashboard';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Management';
+    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Workspace';
 
     #[\Override]
     protected static ?int $navigationSort = 3;

--- a/app/Filament/App/Pages/SourceCompletenessReport.php
+++ b/app/Filament/App/Pages/SourceCompletenessReport.php
@@ -22,7 +22,7 @@ class SourceCompletenessReport extends Page
     protected static ?string $navigationLabel = 'Source Completeness';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📄 Reports';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 
     /**
      * Source-coverage stats for the current tenant.

--- a/app/Filament/App/Pages/TreeCompletenessReport.php
+++ b/app/Filament/App/Pages/TreeCompletenessReport.php
@@ -23,7 +23,7 @@ class TreeCompletenessReport extends Page
     protected static ?string $navigationLabel = 'Tree Completeness';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📄 Reports';
+    protected static string|\UnitEnum|null $navigationGroup = '📊 Charts & Reports';
 
     /**
      * Completeness stats for every tree in the current tenant.

--- a/app/Filament/App/Pages/TreePrivacy.php
+++ b/app/Filament/App/Pages/TreePrivacy.php
@@ -25,7 +25,7 @@ class TreePrivacy extends Page
     protected static ?string $title = 'Tree Privacy';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Management';
+    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Workspace';
 
     /**
      * The current tenant's trees (BelongsToTenant scopes this to the active team).

--- a/app/Filament/App/Pages/UserChecklistsPage.php
+++ b/app/Filament/App/Pages/UserChecklistsPage.php
@@ -17,7 +17,7 @@ class UserChecklistsPage extends Page
     protected static ?string $navigationLabel = 'My Checklists';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Management';
+    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Workspace';
 
     #[\Override]
     protected static ?int $navigationSort = 2;

--- a/app/Filament/App/Resources/AIRecordMatchResource.php
+++ b/app/Filament/App/Resources/AIRecordMatchResource.php
@@ -23,7 +23,7 @@ class AIRecordMatchResource extends AppResource
     protected static ?string $navigationLabel = 'AI Record Matches';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Matching';
 
     #[\Override]
     public static function table(Table $table): Table

--- a/app/Filament/App/Resources/AddrResource.php
+++ b/app/Filament/App/Resources/AddrResource.php
@@ -27,7 +27,7 @@ class AddrResource extends AppResource
     protected static ?string $navigationLabel = 'Address';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     public static function canCreate(): bool

--- a/app/Filament/App/Resources/AuthorResource.php
+++ b/app/Filament/App/Resources/AuthorResource.php
@@ -26,7 +26,7 @@ class AuthorResource extends AppResource
     protected static ?string $navigationLabel = 'Author';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[\Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/ChanResource.php
+++ b/app/Filament/App/Resources/ChanResource.php
@@ -24,7 +24,7 @@ class ChanResource extends AppResource
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clock';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     protected static ?string $navigationLabel = 'Chan';

--- a/app/Filament/App/Resources/ChecklistTemplateResource.php
+++ b/app/Filament/App/Resources/ChecklistTemplateResource.php
@@ -50,7 +50,7 @@ class ChecklistTemplateResource extends AppResource
     protected static ?string $navigationLabel = 'Checklist Templates';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Management';
+    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Workspace';
 
     #[\Override]
     protected static ?int $navigationSort = 1;

--- a/app/Filament/App/Resources/CitationResource.php
+++ b/app/Filament/App/Resources/CitationResource.php
@@ -31,7 +31,7 @@ class CitationResource extends AppResource
     protected static ?string $navigationLabel = 'Citation';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/DatabaseResource.php
+++ b/app/Filament/App/Resources/DatabaseResource.php
@@ -32,7 +32,7 @@ class DatabaseResource extends AppResource
     protected static ?string $navigationLabel = 'Databases';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[Override]
     protected static ?int $navigationSort = 1;

--- a/app/Filament/App/Resources/DnaMatchingResource.php
+++ b/app/Filament/App/Resources/DnaMatchingResource.php
@@ -38,7 +38,7 @@ class DnaMatchingResource extends AppResource
     protected static ?string $navigationLabel = 'DNA Matches';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Genetics';
+    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Matching';
 
     #[\Override]
     protected static ?int $navigationSort = 2;

--- a/app/Filament/App/Resources/DnaResource.php
+++ b/app/Filament/App/Resources/DnaResource.php
@@ -32,7 +32,7 @@ class DnaResource extends AppResource
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-beaker';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Genetics';
+    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Matching';
 
     #[Override]
     protected static ?int $navigationSort = 1;

--- a/app/Filament/App/Resources/DuplicateCheckResource.php
+++ b/app/Filament/App/Resources/DuplicateCheckResource.php
@@ -26,7 +26,7 @@ class DuplicateCheckResource extends AppResource
     protected static ?string $navigationLabel = 'Duplicate Checker';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Matching';
 
     #[\Override]
     protected static ?int $navigationSort = 3;

--- a/app/Filament/App/Resources/FamilySlgsResource.php
+++ b/app/Filament/App/Resources/FamilySlgsResource.php
@@ -29,7 +29,7 @@ class FamilySlgsResource extends AppResource
     protected static ?string $navigationLabel = 'Family Slugs';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/GedcomResource.php
+++ b/app/Filament/App/Resources/GedcomResource.php
@@ -43,7 +43,7 @@ class GedcomResource extends AppResource
     protected static bool $shouldRegisterNavigation = true;
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[Override]
     public static function canCreate(): bool

--- a/app/Filament/App/Resources/ImportJobResource.php
+++ b/app/Filament/App/Resources/ImportJobResource.php
@@ -21,7 +21,7 @@ class ImportJobResource extends AppResource
     protected static ?string $navigationLabel = 'Import Logs';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[Override]
     protected static ?int $navigationSort = 11;

--- a/app/Filament/App/Resources/MediaObjectResource.php
+++ b/app/Filament/App/Resources/MediaObjectResource.php
@@ -32,7 +32,7 @@ class MediaObjectResource extends AppResource
     protected static ?string $navigationLabel = 'Photos & Documents';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📁 Media & Documents';
+    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Workspace';
 
     #[Override]
     protected static ?int $navigationSort = 1;

--- a/app/Filament/App/Resources/PersonAliaResource.php
+++ b/app/Filament/App/Resources/PersonAliaResource.php
@@ -29,7 +29,7 @@ class PersonAliaResource extends AppResource
     protected static ?string $navigationLabel = 'Person Alia';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/PersonAnciResource.php
+++ b/app/Filament/App/Resources/PersonAnciResource.php
@@ -29,7 +29,7 @@ class PersonAnciResource extends AppResource
     protected static ?string $navigationLabel = 'Person Anci';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/PersonNameFoneResource.php
+++ b/app/Filament/App/Resources/PersonNameFoneResource.php
@@ -29,7 +29,7 @@ class PersonNameFoneResource extends AppResource
     protected static ?string $navigationLabel = 'Phonetic Names';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/PersonNameRomnResource.php
+++ b/app/Filament/App/Resources/PersonNameRomnResource.php
@@ -29,7 +29,7 @@ class PersonNameRomnResource extends AppResource
     protected static ?string $navigationLabel = 'Romanized Names';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/PersonSubmResource.php
+++ b/app/Filament/App/Resources/PersonSubmResource.php
@@ -29,7 +29,7 @@ class PersonSubmResource extends AppResource
     protected static ?string $navigationLabel = 'Person Submissions';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Tree';
+    protected static string|\UnitEnum|null $navigationGroup = '🗂️ GEDCOM Detail';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/PublicationResource.php
+++ b/app/Filament/App/Resources/PublicationResource.php
@@ -29,7 +29,7 @@ class PublicationResource extends AppResource
     protected static ?string $navigationLabel = 'Publications';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/RecordTypeResource.php
+++ b/app/Filament/App/Resources/RecordTypeResource.php
@@ -35,7 +35,7 @@ class RecordTypeResource extends AppResource
     protected static ?string $navigationLabel = 'Record Types';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '⚙️ System Settings';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[\Override]
     protected static ?int $navigationSort = 90;

--- a/app/Filament/App/Resources/RefnResource.php
+++ b/app/Filament/App/Resources/RefnResource.php
@@ -29,7 +29,7 @@ class RefnResource extends AppResource
     protected static ?string $navigationLabel = 'Reference Numbers';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[Override]
     protected static ?int $navigationSort = 3;

--- a/app/Filament/App/Resources/RepositoryResource.php
+++ b/app/Filament/App/Resources/RepositoryResource.php
@@ -29,7 +29,7 @@ final class RepositoryResource extends AppResource
     protected static ?string $navigationLabel = 'Repository';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-building-library';

--- a/app/Filament/App/Resources/ResearchSpaceResource.php
+++ b/app/Filament/App/Resources/ResearchSpaceResource.php
@@ -25,7 +25,7 @@ class ResearchSpaceResource extends AppResource
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-users';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Management';
+    protected static string|\UnitEnum|null $navigationGroup = '📋 Research Workspace';
 
     #[\Override]
     protected static ?string $navigationLabel = 'Research Spaces';

--- a/app/Filament/App/Resources/SmartMatchResource.php
+++ b/app/Filament/App/Resources/SmartMatchResource.php
@@ -29,7 +29,7 @@ class SmartMatchResource extends AppResource
     protected static ?string $navigationLabel = 'Smart Matches';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '🧬 DNA & Matching';
 
     #[\Override]
     protected static ?int $navigationSort = 4;

--- a/app/Filament/App/Resources/SourceDataEvenResource.php
+++ b/app/Filament/App/Resources/SourceDataEvenResource.php
@@ -29,7 +29,7 @@ class SourceDataEvenResource extends AppResource
     protected static ?string $navigationLabel = 'Source Data Events';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/SourceDataResource.php
+++ b/app/Filament/App/Resources/SourceDataResource.php
@@ -29,7 +29,7 @@ class SourceDataResource extends AppResource
     protected static ?string $navigationLabel = 'Source Data';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/SourceRefEvenResource.php
+++ b/app/Filament/App/Resources/SourceRefEvenResource.php
@@ -29,7 +29,7 @@ class SourceRefEvenResource extends AppResource
     protected static ?string $navigationLabel = 'Source Reference Events';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/SourceRefResource.php
+++ b/app/Filament/App/Resources/SourceRefResource.php
@@ -43,7 +43,7 @@ class SourceRefResource extends AppResource
     protected static ?string $navigationLabel = 'Source References';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/SourceRepoResource.php
+++ b/app/Filament/App/Resources/SourceRepoResource.php
@@ -30,7 +30,7 @@ final class SourceRepoResource extends AppResource
     protected static ?string $navigationLabel = 'Source Repositories';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/SourceResource.php
+++ b/app/Filament/App/Resources/SourceResource.php
@@ -31,7 +31,7 @@ class SourceResource extends AppResource
     protected static ?string $navigationLabel = 'Sources';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🔍 Research & Analysis';
+    protected static string|\UnitEnum|null $navigationGroup = '📚 Sources & Citations';
 
     #[Override]
     protected static ?int $navigationSort = 1;

--- a/app/Filament/App/Resources/SubmResource.php
+++ b/app/Filament/App/Resources/SubmResource.php
@@ -29,7 +29,7 @@ class SubmResource extends AppResource
     protected static ?string $navigationLabel = 'Submitters';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/SubnResource.php
+++ b/app/Filament/App/Resources/SubnResource.php
@@ -29,7 +29,7 @@ class SubnResource extends AppResource
     protected static ?string $navigationLabel = 'Submissions';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/TypeResource.php
+++ b/app/Filament/App/Resources/TypeResource.php
@@ -29,7 +29,7 @@ class TypeResource extends AppResource
     protected static ?string $navigationLabel = 'Types';
 
     #[Override]
-    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data Management';
+    protected static string|\UnitEnum|null $navigationGroup = '🛠️ Data & Import';
 
     #[Override]
     public static function form(Schema $schema): Schema

--- a/app/Filament/App/Resources/VirtualEventResource.php
+++ b/app/Filament/App/Resources/VirtualEventResource.php
@@ -46,7 +46,7 @@ class VirtualEventResource extends AppResource
     protected static ?string $navigationLabel = 'Virtual Events';
 
     #[\Override]
-    protected static string|\UnitEnum|null $navigationGroup = '👥 Family Reunions';
+    protected static string|\UnitEnum|null $navigationGroup = '🎉 Community';
 
     #[\Override]
     protected static ?int $navigationSort = 1;

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -134,34 +134,25 @@ class AppPanelProvider extends PanelProvider
                     ->label('👥 Family Tree')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📊 Charts & Visualizations')
+                    ->label('🗂️ GEDCOM Detail')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📄 Reports')
+                    ->label('📚 Sources & Citations')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('🔍 Research & Analysis')
+                    ->label('🧬 DNA & Matching')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📋 Research Management')
+                    ->label('📊 Charts & Reports')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('🧬 DNA & Genetics')
+                    ->label('📋 Research Workspace')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('📁 Media & Documents')
+                    ->label('🛠️ Data & Import')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('🛠️ Data Management')
-                    ->collapsed(),
-                NavigationGroup::make()
-                    ->label('👥 Family Reunions')
-                    ->collapsed(),
-                NavigationGroup::make()
-                    ->label('🎮 Gamification')
-                    ->collapsed(),
-                NavigationGroup::make()
-                    ->label('⚙️ System Settings')
+                    ->label('🎉 Community')
                     ->collapsed(),
                 NavigationGroup::make()
                     ->label('👤 Account & Settings')

--- a/tests/Feature/Filament/Resources/ImportJobResourceTest.php
+++ b/tests/Feature/Filament/Resources/ImportJobResourceTest.php
@@ -100,9 +100,9 @@ class ImportJobResourceTest extends TestCase
         $this->assertEquals($this->user->id, $results->first()->user_id);
     }
 
-    public function test_navigation_group_is_data_management(): void
+    public function test_navigation_group_is_data_and_import(): void
     {
-        $this->assertStringContainsString('Data Management', ImportJobResource::getNavigationGroup());
+        $this->assertStringContainsString('Data & Import', ImportJobResource::getNavigationGroup());
     }
 
     public function test_list_page_class_resolves_correctly(): void


### PR DESCRIPTION
Reorganises the App panel's sidebar from **13 navigation groups → 9** (plus the Dashboard), addressing the navigation cleanup the user asked for. Groups were already declared `->collapsed()`, which is kept — only Dashboard opens by default.

## Why

The 13-group layout had concrete problems:
- **Two 👥 groups** — "Family Tree" and "Family Reunions".
- **Two overlapping "Research" groups** — "Research & Analysis" and "Research Management", with no obvious distinction from their names.
- **Four single-item groups** — a collapsed group hiding one link is worse than a plain link (Media & Documents, Family Reunions, Gamification, System Settings).
- **An 18-item Family Tree** bloated with obscure GEDCOM-tag tables (Address, Chan, Family Slugs, Person Alia/Anci/Subm, Phonetic/Romanized Names) most users never open directly.

## The new taxonomy

| Group | Items | Notes |
|---|---|---|
| 🏠 Dashboard | 1 | opens by default |
| 👥 Family Tree | 10 | 9 core records + Global Search |
| 🗂️ GEDCOM Detail | 8 | the tag tables pulled out of Family Tree |
| 📚 Sources & Citations | 10 | was "Research & Analysis", minus the matching tools |
| 🧬 DNA & Matching | 6 | DNA + AI/Smart/Duplicate matching (pulled out of the sources group) |
| 📊 Charts & Reports | 9 | merges "Charts & Visualizations" with "Reports" |
| 📋 Research Workspace | 7 | was "Research Management" + Media + facial-recognition review |
| 🛠️ Data & Import | 10 | Data Management + Record Types + GEDCOM/Gramps export |
| 🎉 Community | 2 | Virtual Events + Achievements (were two singletons) |
| 👤 Account & Settings | 8 | unchanged |

Design decisions (each chosen by the user): the obscure tag tables go to their own **GEDCOM Detail** group rather than being hidden or left in place; **Charts** and **Reports** merge; the two singleton engagement features merge into **Community**.

## Scope & safety

Purely navigation metadata — each resource/page's `$navigationGroup` string plus the provider's group list. **No behaviour, policy, tenancy, or query changes.**

- Verified the label set used by resources/pages **exactly matches** the groups the provider declares (byte-for-byte, emoji included), so Filament creates no orphan/duplicate groups.
- Updated the one test that pinned an old label (`ImportJobResourceTest`).
- Full suite **779 passed, 12 skipped**; PHPStan and Pint clean.