### PR TITLE
chore(deps): bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -22,7 +22,7 @@ jobs:
         tools: composer:v2
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build the production image
         run: docker build -f Dockerfile -t genalogy-prod:smoke .
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -119,11 +119,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: liberu/genealogy
           tags: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
     name: Dependency Security Audit
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -42,7 +42,7 @@ jobs:
     name: Copy-Paste Detection
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload coverage report
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage.xml


### PR DESCRIPTION
Final piece of the dependency-update pass — the CI-only GitHub Actions bumps, bundled so the overlapping workflow-file edits don't conflict as separate PRs.

| Action | From | To | Files |
|---|---|---|---|
| actions/checkout | v4 | v6 | all workflows (8 uses) |
| actions/setup-node | v4 | v6 | install.yml |
| actions/upload-artifact | v4 | v7 | tests.yml |
| docker/metadata-action | v5 | v6 | main.yml |
| docker/setup-buildx-action | v3 | v4 | main.yml |

Left untouched (already current, no dependabot PR): `actions/cache@v4`, `docker/build-push-action@v6`, `docker/login-action@v3`, `shivammathur/setup-php@v2`.

The `upload-artifact` and `metadata-action` steps pass only standard inputs (`name`/`path`/`retention-days`; `images`/`tags`) that are unchanged across these major versions. Being workflow-only, these are validated by the workflows running on this PR.

Supersedes dependabot PRs #1352, #1376, #1495, #1496, #1499.