### PR TITLE
fix(tenancy): scope DocumentTranscription to its team

### DIFF
--- a/app/Models/DocumentTranscription.php
+++ b/app/Models/DocumentTranscription.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,6 +11,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DocumentTranscription extends Model
 {
+    use BelongsToTenant;
     use HasFactory;
     use SoftDeletes;
 
@@ -31,11 +33,6 @@ class DocumentTranscription extends Model
         'metadata' => 'array',
         'processed_at' => 'datetime',
     ];
-
-    public function team(): BelongsTo
-    {
-        return $this->belongsTo(Team::class);
-    }
 
     public function user(): BelongsTo
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,6 +13,12 @@ parameters:
 			path: app/Actions/Jetstream/RemoveTeamMember.php
 
 		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/DocumentTranscription.php
+
+		-
 			message: '#^Access to an undefined property Laravel\\Socialite\\Contracts\\User\:\:\$token\.$#'
 			identifier: property.notFound
 			count: 1

--- a/tests/Feature/Tenancy/DocumentTranscriptionTenantIsolationTest.php
+++ b/tests/Feature/Tenancy/DocumentTranscriptionTenantIsolationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Livewire\DocumentTranscriptionComponent;
+use App\Models\DocumentTranscription;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * A transcription belongs to a team, but the model carried no tenant scope, so
+ * selectTranscription() loaded any team's row by raw id and saveCorrection()
+ * then wrote to it — a cross-team read and write reachable over the wire on a
+ * plain web route. These guard that the tenant boundary holds on both.
+ */
+class DocumentTranscriptionTenantIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_member_cannot_read_another_teams_transcription(): void
+    {
+        $this->actingAs(User::factory()->withPersonalTeam()->create());
+
+        $othersTranscription = DocumentTranscription::factory()->create([
+            'team_id' => Team::factory(),
+            'raw_transcription' => 'SECRET other-team parish record',
+        ]);
+
+        Livewire::test(DocumentTranscriptionComponent::class)
+            ->call('selectTranscription', $othersTranscription->id)
+            ->assertSet('transcriptionText', '')
+            ->assertSet('currentTranscription', null);
+    }
+
+    public function test_a_member_cannot_overwrite_another_teams_transcription(): void
+    {
+        // Owner of their own team → passes the update-tier gate, so the tenant
+        // boundary is the only thing that can stop the write.
+        $this->actingAs(User::factory()->withPersonalTeam()->create());
+
+        $othersTranscription = DocumentTranscription::factory()->create([
+            'team_id' => Team::factory(),
+            'raw_transcription' => 'original other-team text',
+            'corrected_transcription' => null,
+        ]);
+
+        Livewire::test(DocumentTranscriptionComponent::class)
+            ->set('transcriptionText', 'HACKED by another team')
+            ->call('selectTranscription', $othersTranscription->id)
+            ->call('saveCorrection');
+
+        $this->assertNull(
+            $othersTranscription->fresh()->corrected_transcription,
+            'A member of another team overwrote a transcription.'
+        );
+    }
+}


### PR DESCRIPTION
## Cross-tenant read + write of document transcriptions (HIGH)

Found during an adversarial re-audit of the tenant-isolation surface (two independent auditors flagged it).

### The leak
`DocumentTranscription` has a `team_id` FK but **did not use `BelongsToTenant`**, so it had no tenant global scope. The Livewire component hand-rolled a team check in `loadTranscriptions()` and `deleteTranscription()` — but **`selectTranscription()` does a raw `::find($id)`** with no check, and **`saveCorrection()`** writes with only a subscription-tier check.

Both are public Livewire actions, invokable from the client with any id. A member of Team A could:
- `selectTranscription(teamB_id)` → Team B's transcribed document text is returned in the public `transcriptionText` property (**cross-tenant read**), and
- `saveCorrection()` → overwrite Team B's transcription (**cross-tenant write**).

This is the fragile per-method pattern the global scope exists to avoid; ticket 11 (#1547) added the delete/save-tier guards but missed `selectTranscription` and left the model unscoped.

### The fix
- Add `use BelongsToTenant;` to the model — closes select/save/delete **and** Livewire model-rehydration uniformly, since a cross-team `find()` now returns `null`.
- Remove the now-redundant `team()` relation (the trait provides an identical one).
- Add a per-model `phpstan-baseline` entry for the trait's config-driven `currentTeam` typing — identical to the entry every other `BelongsToTenant` model already carries.

Creation is unaffected: `HandwritingRecognitionService::processDocument()` sets `team_id` explicitly, so the trait's `creating` hook short-circuits.

### Tests
`DocumentTranscriptionTenantIsolationTest` covers both read and write, and is revert-sensitive — both fail if the trait is removed.

Gates green locally: PHPStan 0, Pint (1107 files), full suite 781 passed.