### PR TITLE
fix(models): repair Person::children() broken UNION

### DIFF
--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -223,7 +223,18 @@ class Person extends Model
 
     public function children()
     {
-        return $this->hasManyThrough(Person::class, Family::class, 'husband_id', 'child_in_family_id')->union($this->hasManyThrough(Person::class, Family::class, 'wife_id', 'child_in_family_id'));
+        // Children link upward via child_in_family_id, so a person's children are
+        // the offspring of every family they head — as husband OR wife. Two
+        // hasManyThrough legs unioned. get() auto-appends `laravel_through_key`
+        // (people.*, families.husband_id) to the OUTER leg only; the inner union
+        // subquery must select the SAME column count or the UNION is invalid SQL,
+        // so mirror it explicitly with families.wife_id.
+        $wifeSide = $this->hasManyThrough(Person::class, Family::class, 'wife_id', 'child_in_family_id')
+            ->getQuery()
+            ->select(['people.*', 'families.wife_id as laravel_through_key']);
+
+        return $this->hasManyThrough(Person::class, Family::class, 'husband_id', 'child_in_family_id')
+            ->union($wifeSide);
     }
 
     public function fullname(): string

--- a/tests/Unit/Models/PersonFamilyGraphTest.php
+++ b/tests/Unit/Models/PersonFamilyGraphTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Family;
+use App\Models\Person;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The family graph is GEDCOM-shaped: parents/father/mother/children all walk
+ * through the family row, and Family deliberately unsets the vendor's public
+ * $husband/$wife/$id so __get resolves the App\Models\Person overrides instead.
+ * That machinery had no direct assertions — only that eager-loading didn't
+ * throw. These pin the actual linkage and are revert-sensitive: drop the
+ * unset() in Family::__construct or the husband()/wife() overrides and they
+ * fail.
+ */
+class PersonFamilyGraphTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_traversal_links_child_to_parents_and_back(): void
+    {
+        $husband = Person::factory()->create();
+        $wife = Person::factory()->create();
+        $family = Family::factory()->create([
+            'husband_id' => $husband->id,
+            'wife_id' => $wife->id,
+        ]);
+        $child = Person::factory()->create(['child_in_family_id' => $family->id]);
+
+        // Re-fetch so nothing rides on relations hydrated at create time.
+        $child = Person::findOrFail($child->id);
+
+        // Upward: child → family → parent.
+        $this->assertInstanceOf(Person::class, $child->father());
+        $this->assertTrue($child->father()->is($husband), 'father() did not resolve the husband');
+        $this->assertInstanceOf(Person::class, $child->mother());
+        $this->assertTrue($child->mother()->is($wife), 'mother() did not resolve the wife');
+
+        $parentIds = $child->parents()->pluck('id');
+        $this->assertCount(2, $parentIds);
+        $this->assertTrue($parentIds->contains($husband->id));
+        $this->assertTrue($parentIds->contains($wife->id));
+
+        // Downward: parent → children (hasManyThrough union, both sides).
+        $this->assertTrue(
+            Person::findOrFail($husband->id)->children()->get()->pluck('id')->contains($child->id),
+            'husband->children() did not include the child'
+        );
+        $this->assertTrue(
+            Person::findOrFail($wife->id)->children()->get()->pluck('id')->contains($child->id),
+            'wife->children() did not include the child'
+        );
+
+        // The dynamic-property form is what the reports/charts use (e.g. HenryReport,
+        // DeVilliersReport, descendant charts) — it must resolve the same rows.
+        $this->assertTrue(
+            Person::findOrFail($husband->id)->children->pluck('id')->contains($child->id),
+            '$person->children property did not include the child'
+        );
+    }
+
+    public function test_family_husband_and_wife_resolve_to_app_person(): void
+    {
+        $husband = Person::factory()->create();
+        $wife = Person::factory()->create();
+        $family = Family::factory()->create([
+            'husband_id' => $husband->id,
+            'wife_id' => $wife->id,
+        ]);
+
+        $family = Family::findOrFail($family->id);
+
+        // Magic-property access only works because __construct unset the vendor's
+        // shadowing public $husband/$wife; the overrides bind them to App\Models\Person.
+        $this->assertInstanceOf(Person::class, $family->husband);
+        $this->assertTrue($family->husband->is($husband));
+        $this->assertInstanceOf(Person::class, $family->wife);
+        $this->assertTrue($family->wife->is($wife));
+    }
+}


### PR DESCRIPTION
## What

`Person::children()` has been throwing on every call. Found while adding the traversal test the family graph never had.

## The bug

`children()` unions two `hasManyThrough` legs (husband-side + wife-side). `HasManyThrough::get()` auto-appends `laravel_through_key` (`people.*, families.husband_id`) to the **outer** leg only — the inner union subquery keeps a different column set, so the query is invalid SQL:

```
SQLSTATE[HY000]: General error: 1 SELECTs to the left and right of UNION
do not have the same number of result columns
```

This is standard SQL — **MySQL/MariaDB rejects it too**, not just the SQLite test DB.

### Why it went unnoticed
No test ever resolved the relation (the coverage gap this PR also closes). But there are live callers that read `$person->children`:
- `app/Livewire/HenryReport.php`
- `app/Livewire/DeVilliersReport.php`
- the descendant chart components

Each would fatal the moment that path runs.

## The fix

Mirror the outer leg's auto-added columns on the inner subquery (`people.*` + `families.wife_id as laravel_through_key`) so both sides of the UNION have the same column count. The per-person constraints (`husband_id`/`wife_id = id`) were already correct — only the projection was mismatched.

## Test

`tests/Unit/Models/PersonFamilyGraphTest.php` covers the whole GEDCOM-shaped walk that had **zero** direct assertions (CLAUDE.md's "don't clean it up" area):
- `father()` / `mother()` / `parents()`
- `children()` — both `->get()` and the `$person->children` property form, exercising both union legs
- `Family`'s vendor-shadowed `husband` / `wife` magic properties

Revert-sensitive to the `children()` fix, the `Family::__construct` `unset()`, and the `husband()`/`wife()` overrides.

Gates green: PHPStan 0, Pint, full suite 783 passed.