### PR TITLE
fix(social): tag matches with account_id so family connections get created

### DIFF
--- a/app/Services/FamilyMatchingService.php
+++ b/app/Services/FamilyMatchingService.php
@@ -32,10 +32,11 @@ class FamilyMatchingService
 
         foreach ($connectedAccounts as $account) {
             $accountMatches = $this->findMatchesForAccount($user, $account);
-            // Add account_id to each match for later processing
-            $accountMatches->each(function (array $match) use ($account): void {
-                $match['account_id'] = $account->id;
-            });
+            // Tag each match with its account for processMatches(). map(), not each():
+            // $match is a by-value array, so mutating it inside each() is discarded.
+            $accountMatches = $accountMatches->map(
+                fn (array $match): array => [...$match, 'account_id' => $account->id]
+            );
             $matches = $matches->merge($accountMatches);
         }
 

--- a/tests/Unit/Services/FamilyMatchingServiceTest.php
+++ b/tests/Unit/Services/FamilyMatchingServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services;
 
 use App\Models\ConnectedAccount;
+use App\Models\Person;
 use App\Models\SocialConnectionPrivacy;
 use App\Models\SocialFamilyConnection;
 use App\Models\User;
@@ -101,5 +102,53 @@ class FamilyMatchingServiceTest extends TestCase
         $count = $this->service->processMatches($user);
 
         $this->assertEquals(0, $count);
+    }
+
+    /**
+     * The happy path: when a real cross-account surname match exists,
+     * processMatches must actually create the connection. Guards the
+     * account_id tagging in findPotentialConnections — a by-value each()
+     * silently dropped it, so this always returned 0.
+     */
+    public function test_process_matches_creates_a_connection_for_a_real_match(): void
+    {
+        $searcher = User::factory()->withPersonalTeam()->create();
+        SocialConnectionPrivacy::factory()->create([
+            'user_id' => $searcher->id,
+            'allow_family_discovery' => true,
+        ]);
+        Person::factory()->create(['team_id' => $searcher->current_team_id, 'surn' => 'Shakespeare']);
+        ConnectedAccount::factory()->create([
+            'user_id' => $searcher->id,
+            'provider' => 'facebook',
+            'provider_id' => 'searcher-111',
+            'enable_family_matching' => true,
+            'cached_profile_data' => ['synced' => true],
+        ]);
+
+        // A different user on the same provider sharing a surname, discoverable.
+        $relative = User::factory()->withPersonalTeam()->create();
+        SocialConnectionPrivacy::factory()->create([
+            'user_id' => $relative->id,
+            'allow_family_discovery' => true,
+        ]);
+        Person::factory()->create(['team_id' => $relative->current_team_id, 'surn' => 'Shakespeare']);
+        ConnectedAccount::factory()->create([
+            'user_id' => $relative->id,
+            'provider' => 'facebook',
+            'provider_id' => 'relative-999',
+            'enable_family_matching' => true,
+            'cached_profile_data' => ['synced' => true],
+        ]);
+
+        $count = $this->service->processMatches($searcher);
+
+        $this->assertGreaterThan(0, $count, 'processMatches created no connection for a real match');
+        $this->assertTrue(
+            SocialFamilyConnection::where('user_id', $searcher->id)
+                ->where('matched_social_id', 'relative-999')
+                ->exists(),
+            'No SocialFamilyConnection was created for the matching relative'
+        );
     }
 }


### PR DESCRIPTION
## The bug

`FamilyMatchingService::findPotentialConnections()` tags each match with its owning account:

```php
$accountMatches->each(function (array $match) use ($account): void {
    $match['account_id'] = $account->id;   // by-value array → write discarded
});
```

`$match` is a by-value `array`, and `Collection::each` ignores the closure's return, so `account_id` is never written. `processMatches()` then gates connection creation on `isset($match['account_id'])` — **always false** — so it creates nothing and returns `0` for every user, even when real surname matches exist. `SocialConnections` (Livewire) flashes "Found 0 potential family connection(s)!" regardless. The whole social family-matching feature is dead.

Found by an adversarial bug sweep; `account_id` is set nowhere else (the persisted `createConnection` uses a different key, `connected_account_id`).

## The fix

`map()` instead of `each()` — return the tagged array:

```php
$accountMatches = $accountMatches->map(
    fn (array $match): array => [...$match, 'account_id' => $account->id]
);
```

## Test

Added `test_process_matches_creates_a_connection_for_a_real_match` — sets up two users on the same provider sharing a surname and asserts a `SocialFamilyConnection` is created. It fails with the old `each()`, passes with `map()`. The existing "returns zero when no matches" test passed **vacuously** (it asserted 0 when there genuinely were none).

Gates green: PHPStan 0, Pint, full suite 784 passed.