### PR TITLE
fix(models): override Family::children() to use App\Models\Person

### DIFF
--- a/app/Models/Family.php
+++ b/app/Models/Family.php
@@ -89,6 +89,20 @@ class Family extends \FamilyTree365\LaravelGedcom\Models\Family
         return $this->hasOne(Person::class, 'id', 'wife_id');
     }
 
+    /**
+     * Override the vendor's children relationship to use App\Models\Person.
+     *
+     * The vendor Family::children() points at the vendor Person, which extends
+     * plain Model — no SoftDeletes, no BelongsToTenant. So a family's children
+     * included soft-deleted people and ignored the tenant scope. App\Models\Person
+     * carries both, mirroring the husband()/wife()/events() overrides above.
+     */
+    #[\Override]
+    public function children(): HasMany
+    {
+        return $this->hasMany(Person::class, 'child_in_family_id');
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id', 'id');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1327,12 +1327,6 @@ parameters:
 			path: app/Modules/Family/Services/FamilyService.php
 
 		-
-			message: '#^Relation ''children'' is not found in App\\Models\\Family model\.$#'
-			identifier: larastan.relationExistence
-			count: 2
-			path: app/Modules/Family/Services/FamilyService.php
-
-		-
 			message: '#^Instantiated class App\\Modules\\Import\\Services\\ExportService not found\.$#'
 			identifier: class.notFound
 			count: 1

--- a/tests/Unit/Models/PersonFamilyGraphTest.php
+++ b/tests/Unit/Models/PersonFamilyGraphTest.php
@@ -82,4 +82,26 @@ class PersonFamilyGraphTest extends TestCase
         $this->assertInstanceOf(Person::class, $family->wife);
         $this->assertTrue($family->wife->is($wife));
     }
+
+    public function test_family_children_use_app_person_and_exclude_soft_deleted(): void
+    {
+        $family = Family::factory()->create();
+        $child = Person::factory()->create(['child_in_family_id' => $family->id]);
+        $ghost = Person::factory()->create(['child_in_family_id' => $family->id]);
+
+        $family = Family::findOrFail($family->id);
+
+        // The override binds children to App\Models\Person (SoftDeletes + tenant
+        // scope); the vendor relation points at its own scopeless Person.
+        $this->assertInstanceOf(Person::class, $family->children->first());
+        $this->assertTrue($family->children->pluck('id')->contains($child->id));
+
+        // A soft-deleted child must drop out — proves the App model's SoftDeletes
+        // scope is in play (the vendor Person has none, so it would still appear).
+        $ghost->delete();
+        $this->assertFalse(
+            $family->fresh()->children->pluck('id')->contains($ghost->id),
+            'A soft-deleted person is still returned as a family child'
+        );
+    }
 }


### PR DESCRIPTION
## The bug

`App\Models\Family` overrides `husband()`, `wife()`, and `events()` to point at the App models — but **not `children()`**. So it inherits the vendor `Family::children()` = `hasMany(FamilyTree365\LaravelGedcom\Models\Person, 'child_in_family_id')`.

The vendor `Person` extends plain `Model` — **no `SoftDeletes`, no `BelongsToTenant`**. `App\Models\Person` has both. Result: a family's `children` included **soft-deleted people** and **ignored the tenant scope**.

Live on:
- `GET /api/families/{family}/children` (`FamilyController::children`)
- `GET /api/families/{family}` (`FamilyController::show` eager-loads `'children'`)

Found by an adversarial relation sweep and independently corroborated by a second scout. Sibling of the `Person::children()` UNION fix (#1573).

## The fix

One-line override mirroring `husband()`/`wife()`/`events()`:

```php
#[\Override]
public function children(): HasMany
{
    return $this->hasMany(Person::class, 'child_in_family_id');
}
```

## Test

`PersonFamilyGraphTest::test_family_children_use_app_person_and_exclude_soft_deleted` — asserts children resolve to `App\Models\Person` and a soft-deleted child drops out. Revert-sensitive: fails without the override (vendor Person has no SoftDeletes).

Also removes the now-resolved `Family::children` baseline entry in `FamilyService` — the ratchet **shrinks**.

Gates green: PHPStan 0, Pint, full suite 784.