### PR TITLE
fix(filament): repair three removed-API fatals on live screens

### DIFF
--- a/app/Filament/App/Resources/ChecklistTemplateResource.php
+++ b/app/Filament/App/Resources/ChecklistTemplateResource.php
@@ -37,6 +37,7 @@ use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Str;
 
 class ChecklistTemplateResource extends AppResource
 {
@@ -205,7 +206,7 @@ class ChecklistTemplateResource extends AppResource
                         'dna' => 'purple',
                         default => 'gray',
                     })
-                    ->formatStateUsing(fn (string $state): string => str_replace('_', ' ', title_case($state))),
+                    ->formatStateUsing(fn (string $state): string => Str::title(str_replace('_', ' ', $state))),
                 TextColumn::make('difficulty_level')
                     ->badge()
                     ->color(fn (string $state): string => match ($state) {

--- a/app/Filament/App/Resources/ChecklistTemplateResource/Pages/ViewChecklistTemplate.php
+++ b/app/Filament/App/Resources/ChecklistTemplateResource/Pages/ViewChecklistTemplate.php
@@ -12,6 +12,7 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
 
 class ViewChecklistTemplate extends ViewRecord
 {
@@ -54,7 +55,7 @@ class ViewChecklistTemplate extends ViewRecord
                                         'dna' => 'purple',
                                         default => 'gray',
                                     })
-                                    ->formatStateUsing(fn (string $state): string => str_replace('_', ' ', title_case($state))),
+                                    ->formatStateUsing(fn (string $state): string => Str::title(str_replace('_', ' ', $state))),
                                 TextEntry::make('difficulty_level')
                                     ->badge()
                                     ->color(fn (string $state): string => match ($state) {

--- a/app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
+++ b/app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
@@ -7,6 +7,7 @@ use App\Models\MediaObject;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Storage;
 
@@ -37,14 +38,14 @@ class EditPerson extends EditRecord
                 ->action(function (array $data): void {
                     $mediaId = $data['media_id'] ?? null;
                     if (! $mediaId) {
-                        $this->notify('danger', 'No media selected.');
+                        Notification::make()->title('No media selected.')->danger()->send();
 
                         return;
                     }
 
                     $media = MediaObject::with('files')->find($mediaId);
                     if (! $media) {
-                        $this->notify('danger', 'Selected media not found.');
+                        Notification::make()->title('Selected media not found.')->danger()->send();
 
                         return;
                     }
@@ -54,7 +55,7 @@ class EditPerson extends EditRecord
                     $filePath = $file?->medi ?? null;
 
                     if (! $filePath) {
-                        $this->notify('danger', 'Selected media has no associated file path.');
+                        Notification::make()->title('Selected media has no associated file path.')->danger()->send();
 
                         return;
                     }
@@ -85,7 +86,7 @@ class EditPerson extends EditRecord
                     $record->photo_url = $url;
                     $record->save();
 
-                    $this->notify('success', 'Person photo updated from GEDCOM media.');
+                    Notification::make()->title('Person photo updated from GEDCOM media.')->success()->send();
                     // Refresh the page to show updated image in the form/table.
                     $this->redirect($this->getResource()::getUrl('edit', ['record' => $record]));
                 }),

--- a/app/Filament/App/Resources/VirtualEventResource/Pages/ViewVirtualEvent.php
+++ b/app/Filament/App/Resources/VirtualEventResource/Pages/ViewVirtualEvent.php
@@ -34,8 +34,8 @@ class ViewVirtualEvent extends ViewRecord
     #[\Override]
     public function infolist(Schema $schema): Schema
     {
-        return $infolist
-            ->schema([
+        return $schema
+            ->components([
                 Section::make('Event Details')
                     ->schema([
                         Grid::make(2)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -109,12 +109,6 @@ parameters:
 			path: app/Filament/App/Resources/ChecklistTemplateResource.php
 
 		-
-			message: '#^Function title_case not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource.php
-
-		-
 			message: '#^Method App\\Filament\\App\\Resources\\ChecklistTemplateResource\:\:getNavigationBadge\(\) should return string\|null but returns int\<0, max\>\.$#'
 			identifier: return.type
 			count: 1
@@ -123,12 +117,6 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 1
-			path: app/Filament/App/Resources/ChecklistTemplateResource/Pages/ViewChecklistTemplate.php
-
-		-
-			message: '#^Function title_case not found\.$#'
-			identifier: function.notFound
 			count: 1
 			path: app/Filament/App/Resources/ChecklistTemplateResource/Pages/ViewChecklistTemplate.php
 
@@ -160,12 +148,6 @@ parameters:
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$photo_url\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
-
-		-
-			message: '#^Call to an undefined method App\\Filament\\App\\Resources\\PersonResource\\Pages\\EditPerson\:\:notify\(\)\.$#'
-			identifier: method.notFound
-			count: 4
 			path: app/Filament/App/Resources/PersonResource/Pages/EditPerson.php
 
 		-
@@ -286,12 +268,6 @@ parameters:
 			message: '#^Match expression does not handle remaining value\: string$#'
 			identifier: match.unhandled
 			count: 2
-			path: app/Filament/App/Resources/VirtualEventResource/Pages/ViewVirtualEvent.php
-
-		-
-			message: '#^Undefined variable\: \$infolist$#'
-			identifier: variable.undefined
-			count: 1
 			path: app/Filament/App/Resources/VirtualEventResource/Pages/ViewVirtualEvent.php
 
 		-

--- a/tests/Feature/Filament/ChecklistTemplateListRenderTest.php
+++ b/tests/Feature/Filament/ChecklistTemplateListRenderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\ChecklistTemplateResource\Pages\ListChecklistTemplates;
+use App\Models\ChecklistTemplate;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * The category column formats state through a helper. It used title_case(),
+ * removed from Laravel in v6, so listing templates fatalled as soon as a row
+ * rendered. Rendering the table with a real row exercises that formatter.
+ */
+class ChecklistTemplateListRenderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_renders_the_category_column(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        $template = ChecklistTemplate::create([
+            'name' => 'Vital Records',
+            'created_by' => $user->id,
+            'category' => 'vital_records',
+        ]);
+
+        Livewire::test(ListChecklistTemplates::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$template]);
+    }
+}


### PR DESCRIPTION
Three user-reachable Filament fatals, each **baselined instead of fixed** — so the crashes shipped hidden behind `phpstan-baseline.neon`. Found by an adversarial Filament sweep.

## Fatals

1. **`title_case()` removed in Laravel 6** (app is on 13) — `ChecklistTemplateResource.php:208` + `ViewChecklistTemplate.php:57`. Listing or viewing a checklist template fatalled on the `category` column (`Call to undefined function title_case()`). → `Str::title(str_replace('_', ' ', $state))` (underscores replaced first so multi-word statuses title-case).
2. **Undefined `$infolist`** — `ViewVirtualEvent.php:37` returned `$infolist->schema([...])`; `$infolist` doesn't exist, so opening any Virtual Event's View page fatalled. → `$schema->components([...])`, the v4 top-level Schema API used everywhere else in the codebase (verified: 4 uses, `->schema()` never at top level).
3. **`$this->notify()` removed in Filament v3** — `EditPerson.php` (4 branches of the "Select GEDCOM Media" action) → `Notification::make()->title(...)->danger()/success()->send()`.

## Guardrails
- Removed the **four** now-resolved `phpstan-baseline` entries — the ratchet shrinks, and phpstan now **fails CI if any of these bugs is reintroduced** (they're no longer ignorable).
- Added `ChecklistTemplateListRenderTest` — renders the list table with a real row, exercising the `title_case` formatter; revert-sensitive (fails if `title_case()` returns). The `$infolist`/`notify` fixes are symbol-existence corrections guarded by phpstan.

Gates green: PHPStan 0, Pint, full suite 785.