### PR TITLE
fix(filament): drop phantom columns from FamilyEventResource

### DIFF
--- a/app/Filament/App/Resources/FamilyEventResource.php
+++ b/app/Filament/App/Resources/FamilyEventResource.php
@@ -73,25 +73,6 @@ class FamilyEventResource extends AppResource
                     ->numeric(),
                 TextInput::make('day')
                     ->numeric(),
-                TextInput::make('type')
-                    ->maxLength(255),
-                TextInput::make('plac')
-                    ->maxLength(255),
-                TextInput::make('addr_id')
-                    ->numeric(),
-                TextInput::make('phon')
-                    ->maxLength(255),
-                Textarea::make('caus')
-                    ->maxLength(65535)
-                    ->columnSpanFull(),
-                TextInput::make('age')
-                    ->maxLength(255),
-                TextInput::make('agnc')
-                    ->maxLength(255),
-                TextInput::make('husb')
-                    ->numeric(),
-                TextInput::make('wife')
-                    ->numeric(),
             ]);
     }
 
@@ -129,25 +110,6 @@ class FamilyEventResource extends AppResource
                     ->numeric()
                     ->sortable(),
                 TextColumn::make('day')
-                    ->numeric()
-                    ->sortable(),
-                TextColumn::make('type')
-                    ->searchable(),
-                TextColumn::make('plac')
-                    ->searchable(),
-                TextColumn::make('addr_id')
-                    ->numeric()
-                    ->sortable(),
-                TextColumn::make('phon')
-                    ->searchable(),
-                TextColumn::make('age')
-                    ->searchable(),
-                TextColumn::make('agnc')
-                    ->searchable(),
-                TextColumn::make('husb')
-                    ->numeric()
-                    ->sortable(),
-                TextColumn::make('wife')
                     ->numeric()
                     ->sortable(),
             ])

--- a/tests/Feature/Filament/FamilyEventResourceTest.php
+++ b/tests/Feature/Filament/FamilyEventResourceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\FamilyEventResource\Pages\CreateFamilyEvent;
+use App\Models\Family;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * FamilyEventResource still referenced columns that no migration creates
+ * (type/plac/phon/caus/age/agnc/husb/wife/addr_id). They are in the vendor
+ * model's fillable, so the form wrote them on save — "table family_events has
+ * no column named type". Guards that a create round-trips through the real
+ * columns only. (year/month/day ARE real — added by a later migration — so
+ * they stay; only the never-created columns were removed.)
+ */
+class FamilyEventResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actAsTeamMember(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    public function test_a_family_event_can_be_created(): void
+    {
+        $this->actAsTeamMember();
+        $family = Family::factory()->create();
+
+        Livewire::test(CreateFamilyEvent::class)
+            ->fillForm([
+                'family_id' => $family->id,
+                'date' => '1900',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('family_events', [
+            'family_id' => $family->id,
+            'date' => '1900',
+        ]);
+    }
+}


### PR DESCRIPTION
## The bug

`FamilyEventResource`'s form and table referenced **nine columns that no migration creates** — `type, plac, phon, caus, age, agnc, husb, wife, addr_id` (commented out in `create_family_events_table`, but still in the vendor model's `$fillable`). So:

- **Every Create/Edit save fatalled**: `SQLSTATE[42S22] table family_events has no column named type` (the form wrote them).
- Table marked them `searchable()`/`sortable()`, so list search/sort built SQL on missing columns.

## The fix

Remove those nine from the form and table.

**Kept `year`/`month`/`day`** — a two-axis code review caught that these are *real* columns (added later by `2026_06_01_002108_add_date_columns_to_family_events_table.php`); an earlier draft wrongly removed them. Final diff removes only the genuinely-phantom nine.

## Test

`FamilyEventResourceTest::test_a_family_event_can_be_created` — creates a `FamilyEvent` through the Filament page with a real `Family` and asserts the row round-trips. Revert-sensitive: re-adding any phantom form input makes the save fatal again.

## Known follow-ups (pre-existing, not touched here)
- The vendor `FamilyEvent::$fillable` still lists the phantom keys, so a **mass-assign / GEDCOM-import path** passing them could hit the same `42S22`. This resource-scoped fix doesn't address that root fault line.
- `converted_date` isn't in `$fillable`, so its (retained) form input is silently dropped on save. Pre-existing, non-fatal.

Gates green: PHPStan 0, Pint, full suite 787.