### PR TITLE
fix(media): backfill gid/group/type on media_objects_file

### DIFF
--- a/database/migrations/2026_07_20_100000_add_gid_group_type_to_media_objects_file_table.php
+++ b/database/migrations/2026_07_20_100000_add_gid_group_type_to_media_objects_file_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * media_objects_file's create migration only added id/form/medi/timestamps, but
+ * the vendor MediaObjeectFile declares gid/group/type fillable and
+ * MediaObject::files() filters on gid + group. Backfill the missing columns so
+ * the relation (and the "Select GEDCOM Media" action) stops fatalling.
+ * Types mirror media_objects (gid = integer, group = string).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('media_objects_file', function (Blueprint $table): void {
+            if (! Schema::hasColumn('media_objects_file', 'gid')) {
+                $table->integer('gid')->nullable();
+            }
+            if (! Schema::hasColumn('media_objects_file', 'group')) {
+                $table->string('group')->nullable();
+            }
+            if (! Schema::hasColumn('media_objects_file', 'type')) {
+                $table->string('type')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('media_objects_file', function (Blueprint $table): void {
+            $table->dropColumn(['gid', 'group', 'type']);
+        });
+    }
+};

--- a/tests/Feature/Models/MediaObjectFilesTest.php
+++ b/tests/Feature/Models/MediaObjectFilesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\MediaObject;
+use App\Models\MediaObjeectFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * media_objects_file was created with only id/form/medi/timestamps, but
+ * MediaObject::files() filters on `gid` + `group` (the GEDCOM gid/group
+ * pseudo-key the vendor model declares fillable). So the relation — used by
+ * the "Select GEDCOM Media" action on Edit Person — fatalled with
+ * "no such column: gid". Guards that the relation resolves and matches on
+ * gid + group='obje'.
+ */
+class MediaObjectFilesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_files_relation_returns_matching_gedcom_files(): void
+    {
+        $media = MediaObject::factory()->create();
+
+        $match = MediaObjeectFile::create([
+            'gid' => $media->id,
+            'group' => 'obje',
+            'form' => 'jpeg',
+            'medi' => 'photo',
+        ]);
+
+        // Non-matching group must be excluded by the relation's ->where('group', 'obje').
+        MediaObjeectFile::create([
+            'gid' => $media->id,
+            'group' => 'note',
+            'form' => 'txt',
+            'medi' => 'other',
+        ]);
+
+        $files = MediaObject::with('files')->find($media->id)->files;
+
+        $this->assertCount(1, $files);
+        $this->assertTrue($files->first()->is($match));
+    }
+}


### PR DESCRIPTION
## Problem
`MediaObject::files()` filters on `gid` + `group` (the GEDCOM gid/group pseudo-key the vendor `MediaObjeectFile` declares fillable), but that table's create migration only added `id/form/medi/timestamps`. So the relation fatalled with `SQLSTATE[HY000]: table media_objects_file has no column named gid`.

The relation is exercised by the **"Select GEDCOM Media"** header action on **Edit Person** (`EditPerson.php`), which eager-loads `files` and reads `$media->files->first()?->medi` — so the action could **never** succeed. The vendor `MediaObjectFileFactory` also sets `group/gid/type`, so its insert path was broken identically.

## Fix
Additive `add_*_to_*` migration (guarded with `Schema::hasColumn`) adding the three missing columns — `gid` (integer), `group` (string), `type` (string) — matching `media_objects` column types and the vendor model's `$fillable`. The relation and its callers were already correct; only the schema was out of sync, so no PHP changes were needed.

## Test
`tests/Feature/Models/MediaObjectFilesTest.php` — creates a `MediaObject`, inserts a matching (`group='obje'`) and a non-matching file row, and asserts the eager-loaded `files` relation returns exactly the matching one. Revert-sensitive: dropping the migration reproduces the `no column named gid` fatal.

## Verification
- New test fails (QueryException: no column named gid) before the migration, passes after.
- Full suite: 788 passed, 12 skipped.
- PHPStan level 4: 0 errors. Pint: clean.