### PR TITLE
fix(api): validate the columns DnaController::store actually inserts

### DIFF
--- a/app/Http/Controllers/Api/DnaController.php
+++ b/app/Http/Controllers/Api/DnaController.php
@@ -24,9 +24,12 @@ class DnaController extends Controller
     public function store(Request $request): JsonResponse
     {
         $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'file_name' => ['required', 'string', 'max:255'],
             'variable_name' => ['required', 'string', 'max:20', 'unique:dnas,variable_name'],
-            'gedcom_id' => ['nullable', 'exists:gedcoms,id'],
         ]);
+
+        $data['user_id'] = $request->user()->id;
 
         return response()->json(Dna::create($data), 201);
     }

--- a/tests/Feature/Api/DnaApiTest.php
+++ b/tests/Feature/Api/DnaApiTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Dna;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * DnaController::store() only validated variable_name, but the dnas table
+ * requires name, file_name and user_id (all NOT NULL). A well-formed request
+ * therefore 500'd on the INSERT. It also validated a gedcom_id that no column
+ * or fillable accepts. Guards the store path against the real schema.
+ */
+class DnaApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->withPersonalTeam()->create();
+        $team = $this->user->ownedTeams()->first();
+        if ($team) {
+            $this->user->forceFill(['current_team_id' => $team->id])->save();
+            $this->user->setRelation('currentTeam', $team);
+        }
+        Sanctum::actingAs($this->user);
+    }
+
+    public function test_store_creates_dna_for_authenticated_user(): void
+    {
+        $response = $this->postJson('/api/dna', [
+            'name' => 'Kit A',
+            'file_name' => 'kit-a.txt',
+            'variable_name' => 'var_abc',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonFragment(['variable_name' => 'var_abc']);
+
+        $this->assertDatabaseHas('dnas', [
+            'variable_name' => 'var_abc',
+            'name' => 'Kit A',
+            'file_name' => 'kit-a.txt',
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    public function test_store_requires_the_columns_the_table_needs(): void
+    {
+        $this->postJson('/api/dna', ['variable_name' => 'var_xyz'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['name', 'file_name']);
+    }
+
+    public function test_store_rejects_duplicate_variable_name(): void
+    {
+        Dna::factory()->create(['variable_name' => 'var_dup']);
+
+        $this->postJson('/api/dna', [
+            'name' => 'Kit B',
+            'file_name' => 'kit-b.txt',
+            'variable_name' => 'var_dup',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['variable_name']);
+    }
+}


### PR DESCRIPTION
## Problem
`POST /api/dna` (`DnaController::store`, `auth:sanctum`) returned **HTTP 500** on a well-formed request. It validated only `variable_name` (plus a bogus `gedcom_id` rule), but the `dnas` table requires `name`, `file_name` and `user_id` — all NOT NULL with no default. So a valid request passed validation and then threw a `QueryException` on INSERT:

```
SQLSTATE[23000]: NOT NULL constraint failed: dnas.name
```

The `gedcom_id` rule mapped to no `dnas` column and isn't in `Dna::$fillable`, so it was silently dropped even when sent.

## Fix
Validate `name`/`file_name`/`variable_name` and stamp `user_id` from the Sanctum-authenticated user; drop the dead `gedcom_id` rule. `team_id` is auto-stamped by `BelongsToTenant` and `consent_given` defaults false, so no other columns are needed. Matches the idiom in sibling API controllers (`TreeController`, `TeamController` use the same `$request->user()->id` ownership stamp; none use FormRequests).

Because `validate()` returns only validated keys, a client-supplied `user_id` is stripped before the server sets it — no mass-assignment leak.

## Test
`tests/Feature/Api/DnaApiTest.php` — create happy path (201 + DB row incl `user_id`), required-column validation (422 on `name`+`file_name`), and duplicate `variable_name` (422).

## Verification
- New create test fails with `NOT NULL constraint failed: dnas.name` before the fix, passes after.
- Full suite: 790 passed, 12 skipped.
- PHPStan level 4: 0 errors. Pint: clean.
- Two-axis code review (standards + spec): no blocking findings.