### PR TITLE
fix(admin): repair the Modules list page (500 on every load)

### DIFF
--- a/app/Filament/Admin/Resources/ModuleResource.php
+++ b/app/Filament/Admin/Resources/ModuleResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\ModuleResource\Pages\ListModules;
+use App\Models\Module;
 use App\Modules\ModuleManager;
 use Exception;
 use Filament\Actions\Action;
@@ -18,13 +19,16 @@ use Filament\Tables\Columns\TagsColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Str;
 
 class ModuleResource extends Resource
 {
+    // A placeholder model (no `modules` table) that is never queried — rows come
+    // from ModuleManager via ->records(). It exists only so Filament's table
+    // plumbing has a model to reference for labels, keys and authorization.
     #[\Override]
-    protected static ?string $model = null; // We don't use a traditional model
+    protected static ?string $model = Module::class;
 
     #[\Override]
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-puzzle-piece';
@@ -61,7 +65,9 @@ class ModuleResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-            ->query(static::getEloquentQuery())
+            // Rows come from ModuleManager as arrays via the native records()
+            // data source; the placeholder model is never queried for them.
+            ->records(static::getModuleRecords(...))
             ->columns([
                 TextColumn::make('name')
                     ->label('Module Name')
@@ -141,6 +147,52 @@ class ModuleResource extends Resource
             ]);
     }
 
+    /**
+     * Build the table's array records from ModuleManager, applying the table's
+     * current filter/search/sort, and return a paginator (so Filament reads the
+     * count from total() rather than building an Eloquent query it has no model
+     * for). Keyed by module name so row actions resolve the right module.
+     *
+     * @param  array<string, array{value: mixed}>|null  $filters
+     * @return LengthAwarePaginator<int, array<string, mixed>>
+     */
+    public static function getModuleRecords(
+        ?string $sortColumn,
+        ?string $sortDirection,
+        ?array $filters,
+        ?string $search,
+        int $page,
+        int|string $recordsPerPage,
+    ): LengthAwarePaginator {
+        $modules = collect(app(ModuleManager::class)->getAllModulesInfo());
+
+        $enabled = $filters['enabled']['value'] ?? null;
+        if ($enabled !== null && $enabled !== '') {
+            $modules = $modules->where('enabled', filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+        }
+
+        if (filled($search)) {
+            $needle = Str::lower($search);
+            $modules = $modules->filter(
+                fn (array $module): bool => str_contains(Str::lower((string) $module['name']), $needle)
+            );
+        }
+
+        if (filled($sortColumn)) {
+            $modules = $modules->sortBy($sortColumn, SORT_REGULAR, $sortDirection === 'desc');
+        }
+
+        $perPage = is_numeric($recordsPerPage) ? (int) $recordsPerPage : max($modules->count(), 1);
+
+        return new LengthAwarePaginator(
+            $modules->forPage($page, $perPage),
+            $modules->count(),
+            $perPage,
+            $page,
+            ['path' => LengthAwarePaginator::resolveCurrentPath()],
+        );
+    }
+
     #[\Override]
     public static function getRelations(): array
     {
@@ -155,67 +207,6 @@ class ModuleResource extends Resource
         return [
             'index' => ListModules::route('/'),
         ];
-    }
-
-    /**
-     * Get the Eloquent query for modules.
-     */
-    #[\Override]
-    public static function getEloquentQuery(): Builder
-    {
-        // Create a fake query builder that returns module data
-        $moduleManager = app(ModuleManager::class);
-        $modules = $moduleManager->getAllModulesInfo();
-
-        // Convert to a collection and create a fake query
-        $collection = collect($modules)->map(fn ($module) => (object) $module);
-
-        // Return a custom query builder
-        return new class($collection) extends Builder
-        {
-            public function __construct(protected $modules) {}
-
-            public function get($columns = ['*'])
-            {
-                return $this->modules;
-            }
-
-            public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $total = null)
-            {
-                return new LengthAwarePaginator(
-                    $this->modules->forPage($page ?? 1, $perPage),
-                    $this->modules->count(),
-                    $perPage,
-                    $page ?? 1,
-                    [
-                        'path' => request()->url(),
-                        'pageName' => $pageName,
-                    ]
-                );
-            }
-
-            public function where($column, $operator = null, $value = null, $boolean = 'and')
-            {
-                if ($column === 'enabled' && $value !== null) {
-                    $this->modules = $this->modules->filter(fn ($module) => $module->enabled === (bool) $value);
-                }
-
-                return $this;
-            }
-
-            public function orderBy($column, $direction = 'asc'): self
-            {
-                $this->modules = $this->modules->sortBy($column, SORT_REGULAR, $direction === 'desc');
-
-                return $this;
-            }
-
-            // Add other necessary methods as needed
-            public function __call($method, $parameters)
-            {
-                return $this;
-            }
-        };
     }
 
     #[\Override]

--- a/app/Filament/Admin/Resources/ModuleResource/Pages/ListModules.php
+++ b/app/Filament/Admin/Resources/ModuleResource/Pages/ListModules.php
@@ -11,12 +11,26 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
-use Illuminate\Database\Eloquent\Builder;
+use Filament\Tables\Table;
 
 class ListModules extends ListRecords
 {
     #[\Override]
     protected static string $resource = ModuleResource::class;
+
+    /**
+     * Module rows are arrays (from ->records()), not Eloquent Models, so disable
+     * the framework's default row-click record action/URL — both are
+     * type-hinted Model and would fatal on an array record. The toggle/info row
+     * actions still work.
+     */
+    #[\Override]
+    protected function makeTable(): Table
+    {
+        return parent::makeTable()
+            ->recordAction(null)
+            ->recordUrl(null);
+    }
 
     #[\Override]
     protected function getHeaderActions(): array
@@ -68,14 +82,5 @@ class ListModules extends ListRecords
                     }
                 }),
         ];
-    }
-
-    /**
-     * Override to use custom data source.
-     */
-    #[\Override]
-    protected function getTableQuery(): Builder
-    {
-        return ModuleResource::getEloquentQuery();
     }
 }

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Modules\ModuleManager;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Placeholder model for the admin ModuleResource.
+ *
+ * Modules live on disk and are managed by {@see ModuleManager} —
+ * there is no `modules` table and this model is never queried. It exists only so
+ * Filament's resource/table plumbing has a model to reference for labels, keys
+ * and authorization; the actual rows are supplied by the table's ->records()
+ * data source (see ModuleResource::getModuleRecords()).
+ */
+class Module extends Model
+{
+    protected $table = 'modules';
+}

--- a/tests/Filament/Admin/ModuleResourceListRenderTest.php
+++ b/tests/Filament/Admin/ModuleResourceListRenderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Admin;
+
+use App\Filament\Admin\Resources\ModuleResource\Pages\ListModules;
+use App\Models\User;
+use App\Modules\ModuleManager;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * ModuleResource's fake query builder cast each module to (object), but every
+ * column/action closure, the `array $record` type-hint, and the info-modal
+ * blade access records as arrays. So rendering a non-empty module list threw
+ * "Cannot use object of type stdClass as array" on the toggle action's ->label
+ * closure — a hard 500 on the admin Modules page. This mounts the list page
+ * with real modules present so a regression back to object access fails loudly.
+ */
+class ModuleResourceListRenderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAdmin(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $role = Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+        app(PermissionRegistrar::class)->setPermissionsTeamId($user->current_team_id);
+        $user->assignRole($role);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        Gate::before(fn () => true);
+        Filament::setCurrentPanel('admin');
+
+        return $user;
+    }
+
+    public function test_modules_list_page_renders_rows(): void
+    {
+        $this->actingAdmin();
+
+        // Guard: the fatal only surfaces when the table has rows, so assert the
+        // data source actually discovered modules before trusting assertOk().
+        $modules = app(ModuleManager::class)->getAllModulesInfo();
+        $this->assertNotEmpty($modules, 'No modules discovered — the render path would be untested.');
+
+        Livewire::test(ListModules::class)
+            ->assertOk()
+            ->assertSee((string) $modules[array_key_first($modules)]['name']);
+    }
+
+    public function test_modules_list_page_survives_the_enabled_filter(): void
+    {
+        $this->actingAdmin();
+
+        // The enabled filter routes through getModuleRecords()'s array filtering,
+        // the other place the old object-vs-array mismatch fataled.
+        Livewire::test(ListModules::class)
+            ->filterTable('enabled', true)
+            ->assertOk()
+            ->filterTable('enabled', false)
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
## Problem
The admin panel's **Modules** page (`/admin` → System → Modules) returned a hard **500 on every load**. `ModuleResource` fed the table a hand-rolled anonymous `Eloquent\Builder` subclass wrapping module info from `ModuleManager`:

1. It never called `parent::__construct`, so its underlying query was null. Filament clones the table query on every render → `clone(): Argument #1 ($object) must be of type object, null given` in `Builder::__clone` — fatal before a single row rendered.
2. Behind that lurked a second fatal: it cast each module to `(object)`, but every column/action closure, the `array $record` action type-hint, and the info-modal blade read records as **arrays** (`Cannot use object of type stdClass as array`).

Filament v5's table internals in the query path require Eloquent **Models**, so a fake-builder-of-arrays can't work — it hits `Column::hasRelationship(Model $record)` and the `Model`-typed row-click closures.

## Fix
Use Filament v5.6.6's **native `Table::records()`** array data source instead of a fake query builder:
- `getModuleRecords()` returns a `LengthAwarePaginator` of module **arrays**, applying the current enabled-filter, search (name) and sort. Returning a paginator means Filament reads the count from `total()` and never builds an Eloquent count query.
- A tiny placeholder **`App\Models\Module`** (no `modules` table, never queried) gives the resource a `$model` so Filament resolves labels/keys/query. Rows come from `records()`.
- `ListModules::makeTable()` nulls the framework's default **Model-typed** row-click `recordAction`/`recordUrl` (ListRecords sets them unconditionally after `table()`, so this is the required seam).

Records stay keyed by module **name** through filter/sort/pagination, so `__key` = name and the toggle/info row actions resolve the correct module.

## Tests
`tests/Filament/Admin/ModuleResourceListRenderTest.php` — mounts the list page under the admin panel with real modules present (asserts discovery is non-empty first, so the render path is actually exercised), and drives the enabled filter. Both fatal on the pre-fix code (clone error).

## Verification
- Both tests fail (clone fatal) before the fix, pass after.
- Full suite: 789 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.
- Two-axis code review (standards + spec): no blocking findings; record-key/action resolution verified through Filament internals.