### PR TITLE
fix(matching): read the GEDCOM name columns the import populates

### DIFF
--- a/app/Jobs/RunRecordMatchingJob.php
+++ b/app/Jobs/RunRecordMatchingJob.php
@@ -57,8 +57,10 @@ class RunRecordMatchingJob implements ShouldQueue
             'providers' => array_map(fn ($p): string => new ReflectionClass($p)->getShortName(), $providers),
         ]);
 
-        // Fetch a sample of persons to run against (could be queued per-person)
-        $persons = Person::whereNotNull('last_name')->limit(200)->get();
+        // Fetch a sample of persons to run against (could be queued per-person).
+        // Filter on surn — the GEDCOM surname column import populates; last_name
+        // is never written, so filtering on it selected nobody.
+        $persons = Person::whereNotNull('surn')->limit(200)->get();
 
         $totalMatches = 0;
         $newByTeam = [];

--- a/app/Services/RecordMatcher/Providers/AncestryProvider.php
+++ b/app/Services/RecordMatcher/Providers/AncestryProvider.php
@@ -74,11 +74,11 @@ class AncestryProvider implements ExternalRecordProviderInterface
         $params = [];
 
         // Name parameters
-        if ($person->first_name) {
-            $params['givenName'] = $person->first_name;
+        if ($person->givn) {
+            $params['givenName'] = $person->givn;
         }
-        if ($person->last_name) {
-            $params['surname'] = $person->last_name;
+        if ($person->surn) {
+            $params['surname'] = $person->surn;
         }
 
         // Birth information

--- a/app/Services/RecordMatcher/Providers/FamilySearchProvider.php
+++ b/app/Services/RecordMatcher/Providers/FamilySearchProvider.php
@@ -74,11 +74,11 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
         $params = [];
 
         // Name parameters
-        if ($person->first_name) {
-            $params['givenName'] = $person->first_name;
+        if ($person->givn) {
+            $params['givenName'] = $person->givn;
         }
-        if ($person->last_name) {
-            $params['surname'] = $person->last_name;
+        if ($person->surn) {
+            $params['surname'] = $person->surn;
         }
 
         // Birth information

--- a/app/Services/RecordMatcher/Providers/MyHeritageProvider.php
+++ b/app/Services/RecordMatcher/Providers/MyHeritageProvider.php
@@ -74,11 +74,11 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
         $params = [];
 
         // Name parameters
-        if ($person->first_name) {
-            $params['first_name'] = $person->first_name;
+        if ($person->givn) {
+            $params['first_name'] = $person->givn;
         }
-        if ($person->last_name) {
-            $params['last_name'] = $person->last_name;
+        if ($person->surn) {
+            $params['last_name'] = $person->surn;
         }
 
         // Birth information

--- a/app/Services/RecordMatcher/RecordMatcherService.php
+++ b/app/Services/RecordMatcher/RecordMatcherService.php
@@ -9,6 +9,17 @@ use Illuminate\Support\Str;
 
 class RecordMatcherService
 {
+    /**
+     * Weight/candidate factor key => the Person column that actually holds it.
+     * GEDCOM import writes givn/surn/birthday_plac; the like-named columns
+     * (first_name/last_name/birth_place) are never populated.
+     */
+    private const PERSON_COLUMNS = [
+        'first_name' => 'givn',
+        'last_name' => 'surn',
+        'birth_place' => 'birthday_plac',
+    ];
+
     protected array $weights;
 
     public function __construct()
@@ -58,17 +69,18 @@ class RecordMatcherService
         $totalWeight = array_sum(array_values($this->weights));
         $score = 0.0;
 
-        // first name similarity
+        // first name similarity. The weight/candidate key is first_name, but the
+        // local person stores the given name under the GEDCOM column givn.
         if (! empty($this->weights['first_name'])) {
-            $firstPerson = Str::lower($person->first_name ?? '');
+            $firstPerson = Str::lower($person->givn ?? '');
             $firstCand = Str::lower($cand['first_name'] ?? '');
             $sim = $this->stringSimilarity($firstPerson, $firstCand);
             $score += $this->weights['first_name'] * $sim;
         }
 
-        // last name
+        // last name (GEDCOM column: surn)
         if (! empty($this->weights['last_name'])) {
-            $lastPerson = Str::lower($person->last_name ?? '');
+            $lastPerson = Str::lower($person->surn ?? '');
             $lastCand = Str::lower($cand['last_name'] ?? '');
             $sim = $this->stringSimilarity($lastPerson, $lastCand);
             $score += $this->weights['last_name'] * $sim;
@@ -92,9 +104,9 @@ class RecordMatcherService
             $score += $this->weights['birth_year'] * $sim;
         }
 
-        // birth place fuzzy match
+        // birth place fuzzy match (GEDCOM column: birthday_plac)
         if (! empty($this->weights['birth_place'])) {
-            $pp = Str::lower($person->birth_place ?? '');
+            $pp = Str::lower($person->birthday_plac ?? '');
             $cp = Str::lower($cand['birth_place'] ?? '');
             $sim = $this->stringSimilarity($pp, $cp);
             $score += $this->weights['birth_place'] * $sim;
@@ -103,9 +115,9 @@ class RecordMatcherService
         // parents - simplistic check if last names or parent names match
         if (! empty($this->weights['parents'])) {
             $sim = 0.0;
-            // example: check if candidate last name equals person last_name or matches parent last_name fields
-            if (! empty($cand['last_name']) && ! empty($person->last_name)) {
-                $sim = $this->stringSimilarity(Str::lower($person->last_name), Str::lower($cand['last_name']));
+            // example: check if candidate last name equals person surname or matches parent last_name fields
+            if (! empty($cand['last_name']) && ! empty($person->surn)) {
+                $sim = $this->stringSimilarity(Str::lower($person->surn), Str::lower($cand['last_name']));
             }
             $score += $this->weights['parents'] * $sim;
         }
@@ -177,7 +189,8 @@ class RecordMatcherService
         foreach ($fields as $field) {
             $sim = 0.0;
             if (in_array($field, ['first_name', 'last_name', 'birth_place', 'parents'])) {
-                $lv = strtolower((string) ($local->{$field} ?? ''));
+                $column = self::PERSON_COLUMNS[$field] ?? $field;
+                $lv = strtolower((string) ($local->{$column} ?? ''));
                 $cv = strtolower((string) ($candidate[$field] ?? ''));
                 $sim = $this->stringSimilarity($lv, $cv);
             } elseif ($field === 'birth_year') {

--- a/tests/Feature/Services/RecordMatcherPlaceParamsTest.php
+++ b/tests/Feature/Services/RecordMatcherPlaceParamsTest.php
@@ -64,6 +64,45 @@ class RecordMatcherPlaceParamsTest extends TestCase
         $this->assertSame('Leeds, England', $params[$deathKey] ?? null);
     }
 
+    /**
+     * @return array<string, array{0: class-string, 1: string, 2: string}>
+     */
+    public static function nameCases(): array
+    {
+        return [
+            'ancestry' => [AncestryProvider::class, 'givenName', 'surname'],
+            'familysearch' => [FamilySearchProvider::class, 'givenName', 'surname'],
+            'myheritage' => [MyHeritageProvider::class, 'first_name', 'last_name'],
+        ];
+    }
+
+    /**
+     * The name guards read $person->first_name/last_name, which GEDCOM import
+     * never populates (the columns are givn/surn), so no provider ever sent a
+     * name to search — the same silent-null failure as the place params above.
+     */
+    #[DataProvider('nameCases')]
+    public function test_provider_sends_the_persons_given_and_surname(
+        string $providerClass,
+        string $givenKey,
+        string $surnameKey
+    ): void {
+        $this->actingAs(User::factory()->withPersonalTeam()->create());
+
+        $person = Person::factory()->create([
+            'givn' => 'Ada',
+            'surn' => 'Lovelace',
+        ]);
+
+        $method = new ReflectionMethod($providerClass, 'buildSearchParams');
+        $method->setAccessible(true);
+
+        $params = $method->invoke(new $providerClass, $person);
+
+        $this->assertSame('Ada', $params[$givenKey] ?? null);
+        $this->assertSame('Lovelace', $params[$surnameKey] ?? null);
+    }
+
     #[DataProvider('providerCases')]
     public function test_provider_omits_place_when_the_person_has_none(
         string $providerClass,

--- a/tests/Unit/Services/RecordMatcher/RecordMatcherServiceTest.php
+++ b/tests/Unit/Services/RecordMatcher/RecordMatcherServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\RecordMatcher;
+
+use App\Jobs\RunRecordMatchingJob;
+use App\Models\Person;
+use App\Services\RecordMatcher\RecordMatcherService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+/**
+ * The matcher scored the local person on $person->first_name/last_name/birth_place,
+ * but GEDCOM import writes givn/surn/birthday_plac — the first_name/last_name
+ * columns are never populated (and aren't fillable). So every name/place factor
+ * scored zero on real data, and the job's candidate query
+ * (whereNotNull('last_name')) selected nobody at all. These pin both to the
+ * columns the data actually uses.
+ */
+class RecordMatcherServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_scores_a_matching_candidate_using_gedcom_columns(): void
+    {
+        $person = Person::factory()->create([
+            'givn' => 'Ada',
+            'surn' => 'Lovelace',
+            'birth_year' => 1815,
+            'birthday_plac' => 'London, England',
+        ]);
+
+        // Candidate uses the providers' normalised keys (first_name/last_name/...).
+        $candidate = [
+            'id' => 'x1',
+            'first_name' => 'Ada',
+            'last_name' => 'Lovelace',
+            'birth_year' => 1815,
+            'birth_place' => 'London, England',
+        ];
+
+        $scored = (new RecordMatcherService)->scoreCandidates($person, [$candidate]);
+
+        // Pre-fix only birth_year scores (names/place null on the person) → ~0.19,
+        // below the job's 0.45 threshold. Post-fix every factor hits → ~1.0.
+        $this->assertGreaterThanOrEqual(0.45, $scored[0]['score']);
+    }
+
+    public function test_job_selects_people_by_the_populated_name_column(): void
+    {
+        // Factory persons mirror imported data: surn set, last_name null.
+        Person::factory()->create();
+        Log::spy();
+
+        (new RunRecordMatchingJob)->handle(new RecordMatcherService);
+
+        // Pre-fix the job filtered on last_name (always null) and processed 0
+        // people; it must select on surn.
+        Log::shouldHaveReceived('info')
+            ->withArgs(fn (string $message, array $context = []): bool => $message === 'Record matching job completed'
+                && ($context['persons_processed'] ?? 0) === 1)
+            ->once();
+    }
+}


### PR DESCRIPTION
## Problem
The record-matching subsystem read the local person's name/place via `$person->first_name` / `->last_name` / `->birth_place`. But GEDCOM import (and `PersonFactory`) populate **`givn` / `surn` / `birthday_plac`** — the `first_name`/`last_name` columns are never written (nor fillable) and `birth_place` isn't a column at all. On real imported data:

- Every name/place scoring factor in `RecordMatcherService` contributed **zero** (null reads).
- `RunRecordMatchingJob` fetched candidates with `Person::whereNotNull('last_name')` → **zero people** → the whole job was a silent no-op regardless of scoring.

(The birth-place *provider* params were already fixed to `birthday_plac`; the name params and the scorer/job were still on the wrong columns.)

## Fix
Swap the **local-person** reads to `givn`/`surn`/`birthday_plac`:
- `RecordMatcherService::scoreSingle()` — first/last name + birth place + the parents factor.
- `RecordMatcherService::learnFromFeedback()` — via a shared `PERSON_COLUMNS` factor→column map (the loop reads `$local->{field}`).
- `MyHeritageProvider`/`AncestryProvider`/`FamilySearchProvider` — name params.
- `RunRecordMatchingJob` — candidate query `whereNotNull('surn')`.

The weight keys and the **candidate-array** keys (`first_name`/`last_name`/`birth_place`) stay unchanged — those are the providers' normalised output format, already correct. No `first_name` accessor on Person (dead real columns of that name exist; an accessor would shadow them and still wouldn't fix the job's SQL).

## Tests
- `RecordMatcherServiceTest` — scorer scores a matching candidate **≥ 0.45** (job threshold); pre-fix ~0.19. And the job's completion log reports `persons_processed = 1` on imported-shape data (0 pre-fix).
- `RecordMatcherPlaceParamsTest` — extended with name-param cases: each provider sends the person's given/surname. Pre-fix these are null.

## Verification
- All 5 new assertions fail on pre-fix code, pass after.
- Full suite: 798 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.