### PR TITLE
fix(report): read GEDCOM place columns in the Ahnentafel report

### DIFF
--- a/app/Livewire/AhnentafelReport.php
+++ b/app/Livewire/AhnentafelReport.php
@@ -45,8 +45,9 @@ class AhnentafelReport extends Component
             'sex' => $person->sex,
             'birth_date' => $person->birthday?->format('d M Y'),
             'death_date' => $person->deathday?->format('d M Y'),
-            'birth_place' => $person->birth_place ?? '',
-            'death_place' => $person->death_place ?? '',
+            // GEDCOM columns; birth_place/death_place are not columns and read null.
+            'birth_place' => $person->birthday_plac ?? '',
+            'death_place' => $person->deathday_plac ?? '',
         ];
 
         // Build ancestors using Ahnentafel numbering system

--- a/tests/Feature/Livewire/AhnentafelReportTest.php
+++ b/tests/Feature/Livewire/AhnentafelReportTest.php
@@ -55,4 +55,22 @@ class AhnentafelReportTest extends TestCase
             ->call('generateReport', 99999)
             ->assertSet('reportData', []);
     }
+
+    public function test_report_carries_the_gedcom_birth_and_death_place(): void
+    {
+        // The report read $person->birth_place / ->death_place, which are not
+        // columns (GEDCOM import writes birthday_plac / deathday_plac), so the
+        // place always came back empty.
+        $person = Person::factory()->create([
+            'birthday_plac' => 'Manchester, England',
+            'deathday_plac' => 'Leeds, England',
+        ]);
+
+        $data = Livewire::test(AhnentafelReport::class)
+            ->call('generateReport', $person->id)
+            ->get('reportData');
+
+        $this->assertSame('Manchester, England', $data[1]['birth_place']);
+        $this->assertSame('Leeds, England', $data[1]['death_place']);
+    }
 }


### PR DESCRIPTION
## Problem
`AhnentafelReport` built each ancestor row from `$person->birth_place` / `$person->death_place`. Those are **not columns** — GEDCOM import writes `birthday_plac` / `deathday_plac` — so Eloquent returned null and every ancestor's place came back empty in `reportData`.

Same wrong-column bug class as #1581 (the record matcher). A grep of `app/` confirms this was the **last** local-person straggler reading `->birth_place`/`->death_place`/`->first_name`/`->last_name`.

## Fix
Read `birthday_plac` / `deathday_plac`. The `reportData` keys `birth_place`/`death_place` stay — they're the component's output contract (consistent with how it also collects `givn`/`surn` under their own keys).

## Test
`AhnentafelReportTest::test_report_carries_the_gedcom_birth_and_death_place` — asserts `reportData` carries the person's birth/death place. Empty (fails) pre-fix.

## Verification
- New assertion fails pre-fix, passes after.
- Full suite: 799 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.