### PR TITLE
fix(matching): stop learnFromFeedback crashing on the parents factor

### DIFF
--- a/app/Services/RecordMatcher/RecordMatcherService.php
+++ b/app/Services/RecordMatcher/RecordMatcherService.php
@@ -188,7 +188,14 @@ class RecordMatcherService
         $fields = array_keys($this->weights);
         foreach ($fields as $field) {
             $sim = 0.0;
-            if (in_array($field, ['first_name', 'last_name', 'birth_place', 'parents'])) {
+            if ($field === 'parents') {
+                // Mirror scoreSingle: the parents factor is a surname proxy.
+                // (There is no `parents` column — Person::parents() is a
+                // Collection, so reading it as an attribute would throw.)
+                if (! empty($candidate['last_name']) && ! empty($local->surn)) {
+                    $sim = $this->stringSimilarity(strtolower((string) $local->surn), strtolower((string) $candidate['last_name']));
+                }
+            } elseif (in_array($field, ['first_name', 'last_name', 'birth_place'])) {
                 $column = self::PERSON_COLUMNS[$field] ?? $field;
                 $lv = strtolower((string) ($local->{$column} ?? ''));
                 $cv = strtolower((string) ($candidate[$field] ?? ''));

--- a/tests/Unit/Services/RecordMatcher/RecordMatcherServiceTest.php
+++ b/tests/Unit/Services/RecordMatcher/RecordMatcherServiceTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Services\RecordMatcher;
 
 use App\Jobs\RunRecordMatchingJob;
+use App\Models\AIMatchModel;
+use App\Models\AISuggestedMatch;
 use App\Models\Person;
 use App\Services\RecordMatcher\RecordMatcherService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -62,5 +64,29 @@ class RecordMatcherServiceTest extends TestCase
             ->withArgs(fn (string $message, array $context = []): bool => $message === 'Record matching job completed'
                 && ($context['persons_processed'] ?? 0) === 1)
             ->once();
+    }
+
+    public function test_learn_from_feedback_does_not_crash_on_the_parents_factor(): void
+    {
+        $person = Person::factory()->create(['surn' => 'Lovelace']);
+
+        $match = AISuggestedMatch::create([
+            'local_person_id' => $person->id,
+            'provider' => 'Example',
+            'external_record_id' => 'ext-1',
+            'candidate_data' => ['id' => 'ext-1', 'first_name' => 'Ada', 'last_name' => 'Lovelace'],
+            'confidence' => 0.9,
+            'status' => 'pending',
+        ]);
+
+        $before = AIMatchModel::count();
+
+        // The 'parents' weight key read $local->parents, but Person::parents()
+        // returns a Collection, not a relation, so Eloquent threw a
+        // LogicException — the whole feedback loop crashed before persisting.
+        (new RecordMatcherService)->learnFromFeedback($match, 'confirm');
+
+        // Completing the loop persists exactly one new weight snapshot.
+        $this->assertSame($before + 1, AIMatchModel::count());
     }
 }


### PR DESCRIPTION
## Problem
`RecordMatcherService::learnFromFeedback()` loops over every weight key and, for the `parents` key, read `$local->parents`. But `Person::parents()` returns a **Collection** (a computed union of the `child_in_family` husband/wife), not a relationship — so Eloquent threw:

```
LogicException: App\Models\Person::parents must return a relationship instance.
```

The whole `learnFromFeedback` call crashed before it could persist a weight snapshot. The method has **no callers yet** (the feedback UI isn't wired), so it's a latent landmine — confirming/rejecting a suggested match would have thrown.

## Fix
Special-case the `parents` factor to **mirror `scoreSingle`** — a surname proxy (local `surn` vs candidate `last_name`) — instead of reading a non-existent `parents` attribute. The other factors (`first_name`/`last_name`/`birth_place` via `PERSON_COLUMNS`, `birth_year`) are unchanged.

## Test
`RecordMatcherServiceTest::test_learn_from_feedback_does_not_crash_on_the_parents_factor` — drives `learnFromFeedback` through the `parents` factor and asserts it persists one new weight snapshot. Throws `LogicException` pre-fix.

## Verification
- New test throws pre-fix, passes after.
- Full suite: 799 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.