### PR TITLE
fix(models): Citation belongs to one Source, not belongsToMany

### DIFF
--- a/app/Models/Citation.php
+++ b/app/Models/Citation.php
@@ -18,9 +18,14 @@ class Citation extends Model
     #[\Override]
     protected $attributes = ['is_active' => false];
 
-    public function sources()
+    /**
+     * The source this citation references. citations.source_id is a single FK
+     * (Source hasMany Citation), so this is a belongsTo — not the belongsToMany
+     * it used to be, which queried a citation_source pivot no migration creates.
+     */
+    public function source(): BelongsTo
     {
-        return $this->belongsToMany(Source::class);
+        return $this->belongsTo(Source::class);
     }
 
     public function user(): BelongsTo

--- a/tests/Unit/Models/CitationTest.php
+++ b/tests/Unit/Models/CitationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Citation;
+use App\Models\Source;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * citations.source_id is a single FK into sources (Source hasMany Citation), but
+ * Citation::sources() was declared belongsToMany, which queries a citation_source
+ * pivot that no migration creates — reading it fataled with "no such table". The
+ * relation is a belongsTo.
+ */
+class CitationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_citation_belongs_to_its_source(): void
+    {
+        $source = Source::factory()->create();
+        $citation = Citation::factory()->create(['source_id' => $source->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $citation->source());
+        $this->assertTrue($citation->source->is($source));
+    }
+}


### PR DESCRIPTION
## Problem
`citations.source_id` is a single nullable FK into `sources`, and `Source::citations()` is a `hasMany` — so a Citation belongs to **one** Source. But `Citation::sources()` was declared `belongsToMany(Source::class)`, which queries a `citation_source` pivot table that **no migration creates**. Reading the relation fataled:

```
SQLSTATE[HY000]: no such table: citation_source
```

## Fix
Replace it with a `belongsTo` named `source()` (singular — it resolves one Source via `source_id`, matching Laravel's belongsTo convention and `Source hasMany Citation`).

The old `sources()` had **no callers** — `CitationResource` edits `source_id` as a plain field, and a grep found no static or dynamic (`with`/`load`/`relationship('sources')`) references — so the rename breaks nothing.

## Test
`tests/Unit/Models/CitationTest.php` — asserts the relation is a `BelongsTo` and resolves the citation's source. Pre-fix `$citation->source()` is an undefined method.

## Verification
- New test errors pre-fix (undefined method / broken pivot), passes after.
- Full suite: 799 passed, 12 skipped. PHPStan level 4: 0 errors (no stale baseline entry). Pint: clean.