### PR TITLE
fix(query): group two orWhereHas so OR can't escape its scope

### DIFF
--- a/app/Livewire/VirtualEventRsvp.php
+++ b/app/Livewire/VirtualEventRsvp.php
@@ -306,11 +306,15 @@ class VirtualEventRsvp extends Component
                 continue;
             }
 
-            // Check if email is already invited
+            // Check if email is already invited. Group the OR so it stays within
+            // this event's attendees — an unwrapped orWhereHas would match users
+            // attending other events under the same email.
             $existingAttendee = $this->event->attendees()
-                ->where('guest_email', $email)
-                ->orWhereHas('user', function ($query) use ($email): void {
-                    $query->where('email', $email);
+                ->where(function ($q) use ($email): void {
+                    $q->where('guest_email', $email)
+                        ->orWhereHas('user', function ($query) use ($email): void {
+                            $query->where('email', $email);
+                        });
                 })
                 ->first();
 

--- a/app/Services/SmartMatchingService.php
+++ b/app/Services/SmartMatchingService.php
@@ -50,17 +50,32 @@ class SmartMatchingService
     }
 
     /**
+     * People in the user's current team who are missing at least one parent —
+     * no child_in_family link at all, or a family with a missing husband/wife.
+     *
+     * @return Collection<int, Person>
+     */
+    public function findPeopleWithMissingParents(User $user): Collection
+    {
+        return Person::where('team_id', $user->current_team_id)
+            // Group the OR so it can't break out of the team_id filter and pull
+            // in other teams' people.
+            ->where(function ($query): void {
+                $query->whereNull('child_in_family_id')
+                    ->orWhereHas('childInFamily', function ($q): void {
+                        $q->whereNull('husband_id')->orWhereNull('wife_id');
+                    });
+            })
+            ->get();
+    }
+
+    /**
      * Find smart matches for user's unknown ancestors
      */
     public function findSmartMatches(User $user): Collection
     {
         // Get people with missing parent information
-        $peopleWithMissingParents = Person::where('team_id', $user->current_team_id)
-            ->whereNull('child_in_family_id')
-            ->orWhereHas('childInFamily', function ($query): void {
-                $query->whereNull('husband_id')->orWhereNull('wife_id');
-            })
-            ->get();
+        $peopleWithMissingParents = $this->findPeopleWithMissingParents($user);
 
         $matches = collect();
 

--- a/tests/Feature/Livewire/VirtualEventRsvpInviteTest.php
+++ b/tests/Feature/Livewire/VirtualEventRsvpInviteTest.php
@@ -125,6 +125,44 @@ class VirtualEventRsvpInviteTest extends TestCase
         );
     }
 
+    /**
+     * The duplicate-invite check scoped attendees with
+     * ->where('guest_email', $email)->orWhereHas('user', ...). The unwrapped OR
+     * broke out of the event's attendees() constraint, so a user attending a
+     * DIFFERENT event under that email was treated as already invited here.
+     */
+    public function test_send_invitations_ignores_an_attendee_of_another_event(): void
+    {
+        $creator = $this->event->creator;
+
+        // A user attends a *different* event under the email we're inviting here.
+        $this->actingAs($creator);
+        $otherEvent = VirtualEvent::create([
+            'title' => 'Other Event',
+            'status' => 'published',
+            'start_time' => now()->addWeek(),
+            'end_time' => now()->addWeek()->addHours(2),
+            'created_by' => $creator->id,
+        ]);
+        $otherUser = User::factory()->create(['email' => 'invitee@example.com']);
+        VirtualEventAttendee::create([
+            'virtual_event_id' => $otherEvent->id,
+            'user_id' => $otherUser->id,
+            'rsvp_status' => 'accepted',
+        ]);
+
+        Livewire::actingAs($creator)
+            ->test(VirtualEventRsvp::class, ['event' => $this->event])
+            ->set('invite_emails', ['invitee@example.com'])
+            ->call('sendInvitations')
+            ->assertOk();
+
+        $this->assertDatabaseHas('virtual_event_attendees', [
+            'virtual_event_id' => $this->event->id,
+            'guest_email' => 'invitee@example.com',
+        ]);
+    }
+
     private function member(): User
     {
         $user = User::factory()->create(['current_team_id' => $this->team->id]);

--- a/tests/Unit/Services/SmartMatchingServiceTest.php
+++ b/tests/Unit/Services/SmartMatchingServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services;
 
+use App\Models\Family;
 use App\Models\Person;
 use App\Models\Team;
 use App\Models\User;
@@ -90,6 +91,29 @@ class SmartMatchingServiceTest extends TestCase
         $matches = $service->findSmartMatches($user);
 
         $this->assertInstanceOf(Collection::class, $matches);
+    }
+
+    public function test_missing_parent_candidates_stay_within_the_users_team(): void
+    {
+        $team = Team::factory()->create();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+
+        // In-team candidate: no parent family at all — should be selected.
+        $ours = Person::factory()->create(['team_id' => $team->id, 'child_in_family_id' => null]);
+
+        // Another team's person whose family is missing a parent. The
+        // unparenthesised orWhereHas used to pull this across the team boundary.
+        $otherTeam = Team::factory()->create();
+        $family = Family::factory()->create(['husband_id' => null]);
+        $theirs = Person::factory()->create([
+            'team_id' => $otherTeam->id,
+            'child_in_family_id' => $family->id,
+        ]);
+
+        $found = $this->service->findPeopleWithMissingParents($user)->pluck('id');
+
+        $this->assertContains($ours->id, $found);
+        $this->assertNotContains($theirs->id, $found, 'A person from another team leaked into the candidates.');
     }
 
     public function test_service_creates_smart_match_records_for_found_matches(): void


### PR DESCRIPTION
## Problem
Two Eloquent queries applied a scoping filter and then an **unparenthesised** `orWhereHas`, so the `OR` bound at the statement's top level and escaped the scope:

**1. SmartMatchingService (tenant leak)**
```php
Person::where('team_id', X)->whereNull('child_in_family_id')->orWhereHas('childInFamily', ...)
// => WHERE (team_id = X AND child_in_family_id IS NULL) OR EXISTS(...)
```
The `OR` broke out of the `team_id` filter, leaking **other teams' people** into a user's smart-match candidates.

**2. VirtualEventRsvp::sendInvitations (cross-event leak)**
```php
$this->event->attendees()->where('guest_email', X)->orWhereHas('user', fn => email = X)
// => WHERE (virtual_event_id = X AND guest_email = X) OR EXISTS(user email = X)
```
The `OR` escaped the event's `attendees()` constraint, so a user attending a **different** event under that email was treated as already invited here — blocking a legitimate invite.

## Fix
Wrap each OR in a `->where(closure)` so the scoping stays an `AND` over the whole OR: `scope AND (a OR b)`. The SmartMatching query is extracted to `findPeopleWithMissingParents()` so the tenant-scoping is a testable unit.

## Tests
- `SmartMatchingServiceTest` — missing-parent candidates stay within the user's team (an other-team person with a parent-less family leaks in pre-fix).
- `VirtualEventRsvpInviteTest` — an invite is created even when that email attends another event (blocked pre-fix).

## Verification
- Both tests fail on the pre-fix queries, pass after.
- Full suite: 800 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.