### PR TITLE
fix(dna): guard missing kits in triangulation result storage

### DIFF
--- a/app/Services/DnaTriangulationService.php
+++ b/app/Services/DnaTriangulationService.php
@@ -303,7 +303,26 @@ class DnaTriangulationService
             $baseKitId = $results['base_kit']['id'];
             $baseKit = Dna::find($baseKitId);
 
+            if (! $baseKit) {
+                Log::warning('Triangulation base kit not found; skipping result storage', [
+                    'base_kit_id' => $baseKitId,
+                ]);
+
+                return;
+            }
+
             foreach ($results['matches'] as $match) {
+                // file1/file2 are NOT NULL, so a match whose kit row is gone can't
+                // be stored — skip it rather than dereferencing a null Dna::find.
+                $matchKit = Dna::find($match['kit_id']);
+                if (! $matchKit) {
+                    Log::warning('Triangulation match kit not found; skipping match', [
+                        'kit_id' => $match['kit_id'] ?? null,
+                    ]);
+
+                    continue;
+                }
+
                 // Check if match already exists
                 $existing = DnaMatching::where('user_id', $baseKit->user_id)
                     ->where('match_id', $match['user_id'])
@@ -331,7 +350,7 @@ class DnaTriangulationService
                         'match_id' => $match['user_id'],
                         'match_name' => $match['kit_name'],
                         'file1' => $baseKit->file_name,
-                        'file2' => Dna::find($match['kit_id'])->file_name,
+                        'file2' => $matchKit->file_name,
                         'total_shared_cm' => $match['total_cms'],
                         'largest_cm_segment' => $match['largest_cm'],
                         'confidence_level' => $match['confidence_level'],

--- a/tests/Unit/Services/DnaTriangulationServiceTest.php
+++ b/tests/Unit/Services/DnaTriangulationServiceTest.php
@@ -219,4 +219,53 @@ class DnaTriangulationServiceTest extends TestCase
             'predicted_relationship' => 'Second Cousin',
         ]);
     }
+
+    public function test_store_skips_a_match_whose_kit_is_missing_instead_of_crashing(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $kit1 = Dna::factory()->create(['user_id' => $user1->id]);
+        $kit2 = Dna::factory()->create(['user_id' => $user2->id]);
+
+        $results = [
+            'base_kit' => ['id' => $kit1->id],
+            'matches' => [
+                $this->matchPayload(['kit_id' => $kit2->id, 'user_id' => $user2->id]),
+                // kit_id points at a kit that does not exist: Dna::find returns
+                // null, and reading ->file_name on it used to fatal the whole run.
+                $this->matchPayload(['kit_id' => 999999, 'user_id' => 424242]),
+            ],
+        ];
+
+        $this->service->storeTriangulationResults($results, 'one_to_many');
+
+        $this->assertDatabaseHas('dna_matchings', [
+            'user_id' => $user1->id,
+            'match_id' => $user2->id,
+            'file2' => $kit2->file_name,
+        ]);
+        $this->assertDatabaseMissing('dna_matchings', ['match_id' => 424242]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function matchPayload(array $overrides): array
+    {
+        return array_merge([
+            'kit_id' => 0,
+            'kit_name' => 'Test Kit',
+            'user_id' => 0,
+            'comparison_performed' => true,
+            'total_cms' => 150.0,
+            'largest_cm' => 45.0,
+            'confidence_level' => 70,
+            'predicted_relationship' => 'Second Cousin',
+            'shared_segments_count' => 12,
+            'match_quality_score' => 75.0,
+            'chromosome_breakdown' => [],
+        ], $overrides);
+    }
 }


### PR DESCRIPTION
## Problem
`DnaTriangulationService::storeTriangulationResults()` built each `DnaMatching` row with:
```php
'file2' => Dna::find($match['kit_id'])->file_name,
```
When a match's kit row was absent, `Dna::find` returned `null` and reading `->file_name` on it threw `Attempt to read property "file_name" on null` — aborting result storage for the **entire** triangulation batch. The base kit was also dereferenced unchecked (`$baseKit->user_id`, `->file_name`), so a missing base kit crashed the same way.

## Fix
- Return early (with a warning) if the base kit is missing — every row depends on it.
- Skip (with a warning) any match whose kit can't be found. `file1`/`file2` are NOT NULL, so a row without the kit's `file_name` can't be built anyway; valid matches in the same batch still store.

## Test
`DnaTriangulationServiceTest::test_store_skips_a_match_whose_kit_is_missing_instead_of_crashing` — a batch with one real and one missing-kit match stores the real one and skips the other. Throws (null-deref) pre-fix.

## Verification
- New test throws pre-fix, passes after; existing happy-path test still green.
- Full suite: 804 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.