### PR TITLE
fix(realtime): broadcast ResearchSpace updates on a private channel

### DIFF
--- a/app/Events/ResearchSpaceUpdated.php
+++ b/app/Events/ResearchSpaceUpdated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -25,8 +26,14 @@ class ResearchSpaceUpdated implements ShouldBroadcastNow
         return $this->payload;
     }
 
-    public function broadcastOn()
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
     {
-        return ['research-space.'.$this->researchSpaceId];
+        // Private channel so routes/channels.php authorises subscribers to the
+        // space's owner/collaborators. A raw string is a public channel — no
+        // auth — which would expose one space's collaboration to any listener.
+        return [new PrivateChannel('research-space.'.$this->researchSpaceId)];
     }
 }

--- a/app/Livewire/ResearchSpace/CollaboratorBoard.php
+++ b/app/Livewire/ResearchSpace/CollaboratorBoard.php
@@ -47,7 +47,7 @@ class CollaboratorBoard extends Component
         event(new ResearchSpaceUpdated($this->space->id, ['content' => $this->content, 'user_id' => auth()->id()]));
     }
 
-    #[On('echo:research-space.{spaceId},ResearchSpaceUpdated')]
+    #[On('echo-private:research-space.{spaceId},ResearchSpaceUpdated')]
     public function onExternalUpdate($payload): void
     {
         // When we get an external broadcast, update local content

--- a/resources/views/livewire/research-space/collaborator-board.blade.php
+++ b/resources/views/livewire/research-space/collaborator-board.blade.php
@@ -17,7 +17,7 @@
         // Example of initiating Echo presence/listening from the front-end if Echo is set up.
         // window.Echo.private(`research-space.{{ $space->id }}`)
         //     .listen('ResearchSpaceUpdated', (e) => {
-        //         Livewire.dispatch(`echo:research-space.{{ $space->id }},ResearchSpaceUpdated`, e);
+        //         Livewire.dispatch(`echo-private:research-space.{{ $space->id }},ResearchSpaceUpdated`, e);
         //     });
     </script>
 </div>

--- a/tests/Unit/Events/ResearchSpaceUpdatedTest.php
+++ b/tests/Unit/Events/ResearchSpaceUpdatedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Events;
+
+use App\Events\ResearchSpaceUpdated;
+use Illuminate\Broadcasting\PrivateChannel;
+use Tests\TestCase;
+
+/**
+ * The event broadcast on a raw string channel ('research-space.{id}'), which
+ * Laravel treats as a PUBLIC channel — no authorization, so any client could
+ * subscribe and read another space's collaboration. routes/channels.php already
+ * restricts this channel to the owner/collaborators; broadcasting on a private
+ * channel is what makes that authorization apply.
+ */
+class ResearchSpaceUpdatedTest extends TestCase
+{
+    public function test_it_broadcasts_on_a_private_channel(): void
+    {
+        $channels = (new ResearchSpaceUpdated(42, ['content' => 'x']))->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertSame('private-research-space.42', $channels[0]->name);
+    }
+}


### PR DESCRIPTION
## Problem
`ResearchSpaceUpdated::broadcastOn()` returned a **raw string** channel:
```php
return ['research-space.'.$this->researchSpaceId];
```
Laravel treats a string as a **public** channel — **no authorization runs**. `routes/channels.php` already restricts `research-space.{id}` to the space's **owner or a collaborator**, but that callback only applies to private/presence channels. So any client that can reach the broadcaster could subscribe to `research-space.{id}` and receive another space's collaboration payloads — a cross-tenant privacy leak.

## Fix
- Broadcast on a **`PrivateChannel`** so the existing owner/collaborator authorization in `channels.php` is enforced.
- Switch the Livewire listener from `#[On('echo:research-space...')]` (public) to `#[On('echo-private:research-space...')]` so it subscribes to the private channel. `new PrivateChannel('research-space.{id}')` has wire name `private-research-space.{id}`, which Laravel matches against the `research-space.{id}` callback.
- Updated the commented Echo example in the blade to dispatch to the private listener.

**Caveat (out of scope):** broadcasting is currently `null` and `channels.php` isn't loaded (no `BroadcastServiceProvider` / `withBroadcasting()`), so the feature is latent. This fix ensures that **when** broadcasting is enabled, the channel is authorized rather than wide open. Wiring up the broadcaster/Echo is a separate enablement task.

## Test
`ResearchSpaceUpdatedTest` — asserts the event broadcasts on a private `research-space.{id}` channel (wire name `private-research-space.42`). Fails pre-fix (raw string).

## Verification
- New test fails pre-fix, passes after.
- Full suite: 805 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.