### PR TITLE
fix(gedcom): isolate Source records in GEDCOM export across teams

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\Family;
 use App\Models\Person;
+use App\Models\Source;
 use App\Modules\ModuleManager;
 use App\Modules\ModuleServiceProvider;
 use Exception;
@@ -26,6 +27,7 @@ class AppServiceProvider extends ServiceProvider
         // tables.
         $this->app->bind(\FamilyTree365\LaravelGedcom\Models\Person::class, Person::class);
         $this->app->bind(\FamilyTree365\LaravelGedcom\Models\Family::class, Family::class);
+        $this->app->bind(\FamilyTree365\LaravelGedcom\Models\Source::class, Source::class);
 
         // Register the module manager as a singleton
         $this->app->singleton(ModuleManager::class, fn ($app) => new ModuleManager);

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
         "liberu-genealogy/laravel-dna": "^2.0",
-        "liberu-genealogy/laravel-gedcom": "^8.5",
+        "liberu-genealogy/laravel-gedcom": "^8.6",
         "liberu/laravel-gramps-xml": "dev-main",
         "livewire/livewire": "^4.0",
         "spatie/laravel-menu": "^4.0",
@@ -47,11 +47,11 @@
             "type": "package",
             "package": {
                 "name": "liberu-genealogy/laravel-gedcom",
-                "version": "v8.5.0",
+                "version": "v8.6.0",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/liberu-genealogy/laravel-gedcom.git",
-                    "reference": "v8.5.0"
+                    "reference": "v8.6.0"
                 },
                 "require": {
                     "php": ">=8.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c6b1311d2d7bdf72e058af627e390d9",
+    "content-hash": "ddc1b03e06db04fbcb27bb0f765df519",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -4979,11 +4979,11 @@
         },
         {
             "name": "liberu-genealogy/laravel-gedcom",
-            "version": "v8.5.0",
+            "version": "v8.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberu-genealogy/laravel-gedcom.git",
-                "reference": "v8.5.0"
+                "reference": "v8.6.0"
             },
             "require": {
                 "illuminate/database": "^11.0||^12.0||^13.0",

--- a/tests/Feature/Tenancy/GedcomExportSourceIsolationTest.php
+++ b/tests/Feature/Tenancy/GedcomExportSourceIsolationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Jobs\ExportGedCom;
+use App\Models\Family;
+use App\Models\Person;
+use App\Models\Source;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * The GEDCOM generator resolves Source through the container, so a
+ * tenant-scoped Source binding keeps one team's export from embedding another
+ * team's source records. Guards the container binding + the upstream generator
+ * fix together; revert-sensitive to removing the Source bind in AppServiceProvider.
+ */
+class GedcomExportSourceIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_export_excludes_another_teams_sources(): void
+    {
+        Storage::fake('private');
+
+        // Victim team owns a source with a distinctive marker.
+        $victim = User::factory()->withPersonalTeam()->create();
+        Source::factory()->create([
+            'team_id' => $victim->current_team_id,
+            'sour' => 'VICTIM-SECRET-SOURCE',
+            'titl' => 'Victim private citation',
+        ]);
+
+        // Exporting team has its own tree (a family, so a FAM record is emitted)
+        // and its own source.
+        $exporter = User::factory()->withPersonalTeam()->create();
+        $teamId = $exporter->current_team_id;
+        $husband = Person::factory()->create(['team_id' => $teamId]);
+        $wife = Person::factory()->create(['team_id' => $teamId]);
+        Family::factory()->create(['team_id' => $teamId, 'husband_id' => $husband->id, 'wife_id' => $wife->id]);
+        Source::factory()->create(['team_id' => $teamId, 'sour' => 'EXPORTER-OWN-SOURCE']);
+
+        (new ExportGedCom('tree.ged', $exporter, $teamId))->handle();
+
+        $content = (string) Storage::disk('private')->get(ExportGedCom::directoryFor($teamId).'/tree.ged');
+
+        // Positive assertion first: the exporter's own source must be present, so
+        // the absence check below can't pass vacuously on an over-filtered/empty file.
+        $this->assertStringContainsString('EXPORTER-OWN-SOURCE', $content);
+        $this->assertStringNotContainsString('VICTIM-SECRET-SOURCE', $content);
+    }
+}


### PR DESCRIPTION
## Problem
The GEDCOM generator instantiated the vendor `Source` model directly, reading the **unscoped** `sources` table. So one team's export embedded **every** team's source records — a cross-tenant privacy leak ("Leak #2").

## Fix (two load-bearing halves)
1. **Upstream** — bump `liberu-genealogy/laravel-gedcom` to **v8.6.0** ([PR #94](https://github.com/liberu-genealogy/laravel-gedcom/pull/94), "Resolve Source through the container in GedcomGenerator"). The generator now resolves `Source` via the container instead of `new Source`.
2. **App-side** — bind the vendor `\FamilyTree365\LaravelGedcom\Models\Source` to `App\Models\Source` (which uses `BelongsToTenant`) in `AppServiceProvider::register()`, alongside the existing Person/Family binds. The export now resolves the tenant-scoped model and sees only the acting team's sources.

Both are required: with either the vendor bump **or** the bind missing, the export still leaks the other team's source (verified locally by removing the bind → test fails).

## Test
`tests/Feature/Tenancy/GedcomExportSourceIsolationTest.php` — a victim team owns a source with a distinctive marker; a second team exports its own tree; asserts the marker never appears in the exported file. Revert-sensitive to the Source bind.

## Verification
- Test passes with both halves; fails if the bind is removed.
- Full suite (with v8.6.0): 806 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.
- composer.lock change is scoped to laravel-gedcom v8.5.0 → v8.6.0 only.