### PR TITLE
fix(fan-chart): root the chart at the selected person

### DIFF
--- a/app/Livewire/FanChartComponent.php
+++ b/app/Livewire/FanChartComponent.php
@@ -11,7 +11,46 @@ use Livewire\Component;
 
 class FanChartComponent extends Component
 {
-    public $people;
+    /** @var array<string, mixed> */
+    public array $tree = [];
+
+    public function mount(?Person $person = null): void
+    {
+        $this->tree = $this->buildTree($person);
+    }
+
+    /**
+     * Build the ancestor hierarchy the D3 fan chart expects: the selected person
+     * as the root node, with children[] = father then mother, recursively. (In
+     * an ancestor fan, d3's "children" are the parents.)
+     *
+     * @return array<string, mixed>
+     */
+    private function buildTree(?Person $person, int $generations = 4): array
+    {
+        if (! $person) {
+            return [];
+        }
+
+        $node = [
+            'id' => $person->id,
+            'name' => $person->fullname(),
+            'birth_year' => $person->birth_year,
+            'death_year' => $person->death_year,
+            'sex' => $person->sex,
+            'children' => [],
+        ];
+
+        if ($generations > 0) {
+            foreach ([$person->father(), $person->mother()] as $parent) {
+                if ($parent) {
+                    $node['children'][] = $this->buildTree($parent, $generations - 1);
+                }
+            }
+        }
+
+        return $node;
+    }
 
     public function getColumnSpan(): int|string|array
     {
@@ -25,8 +64,6 @@ class FanChartComponent extends Component
 
     public function render(): Factory|View
     {
-        $this->people = Person::all();
-
-        return view('livewire.fan-chart-component', ['people' => $this->people]);
+        return view('livewire.fan-chart-component', ['tree' => $this->tree]);
     }
 }

--- a/resources/views/livewire/fan-chart-component.blade.php
+++ b/resources/views/livewire/fan-chart-component.blade.php
@@ -8,11 +8,13 @@
         <script src="{{ asset('js/fan-chart.js') }}"></script>
         <script>
             document.addEventListener('DOMContentLoaded', function () {
-                const people = @json($people);
-                if (people && people.length > 0) {
-                    initializeFanChart(people);
+                // Single ancestor tree rooted at the selected person (d3.hierarchy
+                // expects one rooted node, not a flat list).
+                const tree = @json($tree);
+                if (tree && tree.id) {
+                    initializeFanChart(tree);
                 } else {
-                    console.warn('No data available to render the fan chart.');
+                    console.warn('No person selected to render the fan chart.');
                 }
             });
         </script>

--- a/tests/Feature/Livewire/FanChartComponentTest.php
+++ b/tests/Feature/Livewire/FanChartComponentTest.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Feature\Livewire;
 
 use App\Livewire\FanChartComponent;
+use App\Models\Family;
 use App\Models\Person;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
@@ -12,20 +15,37 @@ class FanChartComponentTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_component_can_be_rendered(): void
+    public function test_component_can_be_rendered_without_a_person(): void
     {
-        Person::factory()->count(3)->create();
-
         Livewire::test(FanChartComponent::class)
-            ->assertStatus(200);
+            ->assertStatus(200)
+            ->assertSet('tree', []);
     }
 
-    public function test_component_loads_all_people(): void
+    /**
+     * The page passes the selected person (?person_id) into
+     * <livewire:fan-chart-component :person="$person" />, but the component had
+     * no person property and rendered Person::all() — so it ignored the
+     * selection and always drew the same thing. It now roots an ancestor tree at
+     * the selected person.
+     */
+    public function test_it_roots_the_chart_at_the_selected_person_with_ancestors(): void
     {
-        $people = Person::factory()->count(5)->create();
+        $father = Person::factory()->create(['givn' => 'Grandpa', 'surn' => 'Root']);
+        $mother = Person::factory()->create(['givn' => 'Grandma', 'surn' => 'Root']);
+        $family = Family::factory()->create(['husband_id' => $father->id, 'wife_id' => $mother->id]);
+        $root = Person::factory()->create(['givn' => 'Child', 'surn' => 'Root', 'child_in_family_id' => $family->id]);
 
-        $component = Livewire::test(FanChartComponent::class);
+        // A second, unrelated person that must NOT become the root.
+        Person::factory()->create(['givn' => 'Stranger', 'surn' => 'Other']);
 
-        $this->assertCount(5, Person::all());
+        $tree = Livewire::test(FanChartComponent::class, ['person' => $root])->get('tree');
+
+        $this->assertSame($root->id, $tree['id']);
+        $this->assertSame('Child Root', $tree['name']);
+
+        $ancestorIds = array_column($tree['children'], 'id');
+        $this->assertContains($father->id, $ancestorIds);
+        $this->assertContains($mother->id, $ancestorIds);
     }
 }


### PR DESCRIPTION
## Problem
The `/fan-chart` page resolves `?person_id` and passes the Person into:
```blade
<livewire:fan-chart-component :person="$person" />
```
But `FanChartComponent` had **no `person` property**, and its `render()` did `Person::all()` — so the selection was silently dropped and it handed a **flat list of everyone** to the D3 fan chart. The chart (`initializeFanChart` → `d3.hierarchy(data)`) expects a **single rooted node** with a `children` array. Result: the same broken/arbitrary render regardless of who was selected.

## Fix
- Accept the person via `mount(?Person $person)`.
- Build an **ancestor hierarchy rooted at the selected person** — `children[]` = father then mother, recursively (in an ancestor fan, d3's "children" are the parents), with the exact fields the JS reads (`id`, `name`, `birth_year`, `death_year`, `sex`).
- Feed that single tree to the chart; the blade guards on `tree.id` and the no-selection path renders cleanly (`tree = []`).

Fixed depth of 4 generations; null-guarded so childless roots and missing parents are fine.

## Test
`FanChartComponentTest` — asserts the tree is rooted at the selected person and includes both parents (an unrelated person must not become the root). Replaces the old vacuous `loads all people` test (which only asserted `Person::all()` and never touched the component). Both new assertions fail pre-fix.

## Verification
- Tests fail pre-fix, pass after; the controller test stays green.
- Full suite: 806 passed, 12 skipped. PHPStan level 4: 0 errors. Pint: clean.