### PR TITLE
Add the fabrication gate; stop inventing face-match confidence

### DIFF
--- a/app/Services/FacialRecognitionService.php
+++ b/app/Services/FacialRecognitionService.php
@@ -166,7 +166,10 @@ class FacialRecognitionService
         foreach ($detectedFaces as $index => $face) {
             // Find if this face matches a known person
             $matchedPerson = null;
-            $confidence = $face['confidence'] ?? 0;
+            // A provider that reports no confidence has not measured one. Storing 0 would
+            // read as "certainly not this person" — a claim the provider never made. The
+            // column is nullable so absence can be recorded as absence.
+            $confidence = $face['confidence'] ?? null;
 
             foreach ($matches as $match) {
                 if (($match['face_index'] ?? null) === $index) {

--- a/app/Services/FamilyMatchingService.php
+++ b/app/Services/FamilyMatchingService.php
@@ -157,7 +157,10 @@ class FamilyMatchingService
             'matched_name' => $matchData['name'] ?? null,
             'matched_email' => $matchData['email'] ?? null,
             'relationship_type' => 'potential_relative',
-            'confidence_score' => $matchData['confidence_score'] ?? 0,
+            // findPotentialConnections always computes this from the shared surnames, so the
+            // key is present. The old `?? 0` was dead defensiveness that, if ever reached,
+            // would fabricate a certainty; without it an absent key fails loudly instead.
+            'confidence_score' => $matchData['confidence_score'],
             'matching_criteria' => [
                 'common_surnames' => $matchData['common_surnames'] ?? [],
             ],

--- a/resources/views/livewire/facial-recognition-review.blade.php
+++ b/resources/views/livewire/facial-recognition-review.blade.php
@@ -46,7 +46,11 @@
                         {{ $currentTag['person_name'] }}
                     </p>
                     <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                        Confidence: {{ number_format($currentTag['confidence'], 1) }}%
+                        @if($currentTag['confidence'] === null)
+                            Confidence: <span title="The provider reported no confidence for this match">not reported</span>
+                        @else
+                            Confidence: {{ number_format($currentTag['confidence'], 1) }}%
+                        @endif
                     </p>
                 @else
                     <p class="text-sm text-gray-600 dark:text-gray-400">

--- a/tests/Feature/Livewire/FacialRecognitionReviewConfidenceTest.php
+++ b/tests/Feature/Livewire/FacialRecognitionReviewConfidenceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\FacialRecognitionReview;
+use App\Models\Person;
+use App\Models\PersonPhoto;
+use App\Models\PhotoTag;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * The review interface must distinguish a match whose confidence the provider
+ * did not report (stored null) from one it reported as zero. number_format(null)
+ * would print "0.0%" — reprinting the very fabrication the storage fix removed —
+ * so the null case renders "not reported" instead.
+ */
+final class FacialRecognitionReviewConfidenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function pendingTagWithConfidence(mixed $confidence): void
+    {
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $user->id]);
+        $user->current_team_id = $team->id;
+        $user->save();
+        $this->actingAs($user);
+
+        $person = Person::factory()->create(['team_id' => $team->id, 'givn' => 'Ada', 'surn' => 'Lovelace']);
+        $photo = PersonPhoto::factory()->create(['team_id' => $team->id]);
+
+        PhotoTag::factory()->pending()->create([
+            'photo_id' => $photo->id,
+            'person_id' => $person->id,
+            'team_id' => $team->id,
+            'confidence' => $confidence,
+        ]);
+    }
+
+    public function test_an_unreported_confidence_reads_as_not_reported(): void
+    {
+        $this->pendingTagWithConfidence(null);
+
+        Livewire::test(FacialRecognitionReview::class)
+            ->assertSee('not reported')
+            ->assertDontSee('0.0%');
+    }
+
+    public function test_a_reported_confidence_reads_as_a_percentage(): void
+    {
+        $this->pendingTagWithConfidence(0.9);
+
+        Livewire::test(FacialRecognitionReview::class)
+            ->assertDontSee('not reported');
+    }
+}

--- a/tests/Feature/Services/FaceMatchConfidenceTest.php
+++ b/tests/Feature/Services/FaceMatchConfidenceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\PersonPhoto;
+use App\Models\PhotoTag;
+use App\Services\FacialRecognitionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * A provider that returns a face without a confidence figure has not measured
+ * one. The service must store that absence as null, not substitute 0 — a stored
+ * 0 reads in the review interface as "certainly not this person", a claim the
+ * provider never made. Guards the fix at FacialRecognitionService::createPhotoTags.
+ */
+final class FaceMatchConfidenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @param  list<array<string, mixed>>  $detectedFaces
+     * @param  list<array<string, mixed>>  $matches
+     */
+    private function createTags(PersonPhoto $photo, array $detectedFaces, array $matches): void
+    {
+        $method = new ReflectionMethod(FacialRecognitionService::class, 'createPhotoTags');
+        $method->invoke(new FacialRecognitionService, $photo, $detectedFaces, $matches);
+    }
+
+    public function test_a_face_without_a_reported_confidence_stores_no_confidence(): void
+    {
+        $photo = PersonPhoto::factory()->create();
+
+        $this->createTags($photo, [['bounding_box' => ['x' => 1, 'y' => 2, 'w' => 3, 'h' => 4]]], []);
+
+        $this->assertDatabaseHas('photo_tags', ['photo_id' => $photo->id, 'confidence' => null]);
+        $this->assertDatabaseMissing('photo_tags', ['photo_id' => $photo->id, 'confidence' => 0]);
+    }
+
+    public function test_a_reported_confidence_is_stored_unchanged(): void
+    {
+        $photo = PersonPhoto::factory()->create();
+
+        $this->createTags($photo, [['confidence' => 0.42, 'bounding_box' => ['x' => 1]]], []);
+
+        $tag = PhotoTag::where('photo_id', $photo->id)->firstOrFail();
+        $this->assertSame('0.42', (string) $tag->confidence);
+    }
+
+    public function test_a_matched_face_stores_the_match_confidence(): void
+    {
+        $photo = PersonPhoto::factory()->create();
+
+        $this->createTags(
+            $photo,
+            [['bounding_box' => ['x' => 1]]],
+            [['face_index' => 0, 'person_id' => null, 'confidence' => 0.87]],
+        );
+
+        $tag = PhotoTag::where('photo_id', $photo->id)->firstOrFail();
+        $this->assertSame('0.87', (string) $tag->confidence);
+    }
+}

--- a/tests/Support/Fabrication/AllowlistEntry.php
+++ b/tests/Support/Fabrication/AllowlistEntry.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Fabrication;
+
+/**
+ * One deliberately-excused use of randomness in the application source.
+ *
+ * Every entry names the exact site and the exact mechanism, and carries a
+ * written reason a reviewer can evaluate — an entry without one is rejected,
+ * so adding to the allowlist is a conscious act rather than a way to silence
+ * the gate. The category separates ordinary identifier/token generation from
+ * security-bearing randomness, so the two concerns are never conflated.
+ */
+final class AllowlistEntry
+{
+    public const CATEGORIES = ['identifier', 'token', 'api-request-id', 'mock', 'security'];
+
+    /**
+     * @param  string  $path  path relative to app/ (or the label passed to scanSource)
+     * @param  string  $mechanism  the exact mechanism excused, or '*' for every mechanism in the file
+     * @param  string  $category  one of self::CATEGORIES
+     */
+    public function __construct(
+        public readonly string $path,
+        public readonly string $mechanism,
+        public readonly string $category,
+        public readonly string $reason,
+    ) {}
+
+    public function excuses(Violation $violation): bool
+    {
+        return $this->path === $violation->file
+            && ($this->mechanism === '*' || $this->mechanism === $violation->mechanism);
+    }
+}

--- a/tests/Support/Fabrication/FabricationScanner.php
+++ b/tests/Support/Fabrication/FabricationScanner.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Fabrication;
+
+/**
+ * The executable definition of "this application does not invent data".
+ *
+ * It tokenises the application source and reports every generation of
+ * randomness (and, later, every hardcoded stand-in for a measured value)
+ * that no allowlist entry excuses. Tokenising rather than pattern-matching is
+ * deliberate: the grep-based sweep this replaces used word boundaries and so
+ * could not see `random_int` embedded in a larger identifier, and it matched
+ * the same call names inside comments. token_get_all resolves each call to its
+ * exact name and drops comments, closing both gaps.
+ */
+final class FabricationScanner
+{
+    /** Global functions whose only purpose is to produce randomness. */
+    private const RANDOM_FUNCTIONS = [
+        'rand', 'mt_rand', 'random_int', 'random_bytes', 'uniqid',
+        'shuffle', 'str_shuffle', 'array_rand', 'srand', 'mt_srand',
+        'openssl_random_pseudo_bytes', 'lcg_value', 'fake',
+    ];
+
+    /** Static methods (on the short class name) that produce a random value. */
+    private const STATIC_RANDOM = [
+        'Str' => ['random', 'password', 'uuid', 'orderedUuid'],
+        'Arr' => ['random'],
+    ];
+
+    /**
+     * Identifier fragments that name a measurement of certainty or match
+     * quality. A value you did not measure has no such figure — substituting a
+     * literal for it invents one, unlike a count, where an absent count of zero
+     * is a true statement.
+     */
+    private const CERTAINTY_VOCAB = [
+        'confidence', 'match_quality', 'quality_score', 'probability',
+        'similarity_score', 'certainty',
+    ];
+
+    /**
+     * @param  list<AllowlistEntry>  $allowlist
+     */
+    public function __construct(private readonly array $allowlist = [])
+    {
+        foreach ($allowlist as $entry) {
+            if (trim($entry->reason) === '') {
+                throw new \InvalidArgumentException(
+                    "Allowlist entry for {$entry->path} ({$entry->mechanism}) has no justification. "
+                    .'Every allowlist entry must carry a reason a reviewer can evaluate.'
+                );
+            }
+
+            if (! in_array($entry->category, AllowlistEntry::CATEGORIES, true)) {
+                throw new \InvalidArgumentException(
+                    "Allowlist entry for {$entry->path} has unknown category '{$entry->category}'."
+                );
+            }
+        }
+    }
+
+    /**
+     * Scan every .php file under $dir, reporting paths relative to it.
+     *
+     * @return list<Violation>
+     */
+    public function scanDirectory(string $dir): array
+    {
+        $dir = rtrim($dir, '/');
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $violations = [];
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = substr($file->getPathname(), strlen($dir) + 1);
+            $source = file_get_contents($file->getPathname());
+
+            foreach ($this->scanSource($source, $relative) as $violation) {
+                $violations[] = $violation;
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param  list<Violation>  $violations
+     */
+    public static function explain(array $violations): string
+    {
+        if ($violations === []) {
+            return '';
+        }
+
+        $lines = ['The application source invents data at:'];
+
+        foreach ($violations as $violation) {
+            $lines[] = $violation->describe();
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /** @return list<Violation> */
+    public function scanSource(string $source, string $relativePath): array
+    {
+        $tokens = token_get_all($source);
+        $significant = $this->significantTokens($tokens);
+
+        $violations = [];
+
+        foreach ($significant as $i => $token) {
+            $violation = $this->randomnessViolation($significant, $i, $relativePath)
+                ?? $this->certaintyStandInViolation($significant, $i, $relativePath);
+
+            if ($violation !== null && ! $this->isAllowed($violation)) {
+                $violations[] = $violation;
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param  list<array{0:int,1:string,2:int}>  $tokens
+     */
+    private function randomnessViolation(array $tokens, int $i, string $file): ?Violation
+    {
+        $mechanism = $this->randomnessAt($tokens, $i);
+
+        if ($mechanism === null) {
+            return null;
+        }
+
+        return new Violation(
+            file: $file,
+            line: $tokens[$i][2],
+            mechanism: $mechanism,
+            reason: "Generates randomness ({$mechanism}). Application source must not invent "
+                .'data. Either remove the randomness, or add an allowlist entry with a written '
+                .'justification a reviewer can evaluate.',
+        );
+    }
+
+    /**
+     * A certainty measurement coalesced (?? / ?:) to a hardcoded literal: an
+     * invented figure where none was measured.
+     *
+     * @param  list<array{0:int,1:string,2:int}>  $tokens
+     */
+    private function certaintyStandInViolation(array $tokens, int $i, string $file): ?Violation
+    {
+        if ($tokens[$i][0] !== T_COALESCE) {
+            return null;
+        }
+
+        if (! $this->rightOperandIsNumericLiteral($tokens, $i)) {
+            return null;
+        }
+
+        $word = $this->certaintyWordInLeftOperand($tokens, $i);
+
+        if ($word === null) {
+            return null;
+        }
+
+        return new Violation(
+            file: $file,
+            line: $tokens[$i][2],
+            mechanism: "certainty '{$word}' defaulted to a literal",
+            reason: "Substitutes a hardcoded value for an absent '{$word}' measurement. A "
+                ."certainty you did not measure is not 0 — that reads as 'certainly wrong', a "
+                .'different claim. Coalesce to null so absence is representable, or remove the '
+                .'fallback so it fails loudly.',
+        );
+    }
+
+    /**
+     * @param  list<array{0:int,1:string,2:int}>  $tokens
+     */
+    private function rightOperandIsNumericLiteral(array $tokens, int $coalesce): bool
+    {
+        $next = $tokens[$coalesce + 1] ?? null;
+
+        if ($next !== null && ($next[1] === '-' || $next[1] === '+')) {
+            $next = $tokens[$coalesce + 2] ?? null;
+        }
+
+        return $next !== null && ($next[0] === T_LNUMBER || $next[0] === T_DNUMBER);
+    }
+
+    /**
+     * Walk back over the left operand (to the nearest statement/argument
+     * boundary) looking for a certainty-vocabulary identifier, array key, or
+     * variable name.
+     *
+     * @param  list<array{0:int,1:string,2:int}>  $tokens
+     */
+    private function certaintyWordInLeftOperand(array $tokens, int $coalesce): ?string
+    {
+        $boundaries = [';', '(', ',', '{', '}'];
+
+        for ($j = $coalesce - 1; $j >= 0; $j--) {
+            [$id, $text] = $tokens[$j];
+
+            if ($id === T_DOUBLE_ARROW || in_array($text, $boundaries, true)) {
+                break;
+            }
+
+            $name = match ($id) {
+                T_VARIABLE => strtolower(ltrim($text, '$')),
+                T_STRING => strtolower($text),
+                T_CONSTANT_ENCAPSED_STRING => strtolower(trim($text, "'\"")),
+                default => null,
+            };
+
+            if ($name === null) {
+                continue;
+            }
+
+            foreach (self::CERTAINTY_VOCAB as $vocab) {
+                if (str_contains($name, $vocab)) {
+                    return $vocab;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function isAllowed(Violation $violation): bool
+    {
+        foreach ($this->allowlist as $entry) {
+            if ($entry->excuses($violation)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Reduce the token stream to the array-form tokens that carry meaning,
+     * dropping whitespace and comments but keeping single-character tokens
+     * (like "(" or "::") re-encoded as [id, text, line] so lookahead is uniform.
+     *
+     * @param  array<int, array{0:int,1:string,2:int}|string>  $tokens
+     * @return list<array{0:int,1:string,2:int}>
+     */
+    private function significantTokens(array $tokens): array
+    {
+        $out = [];
+        $line = 1;
+
+        foreach ($tokens as $token) {
+            if (is_array($token)) {
+                $line = $token[2];
+
+                if ($token[0] === T_WHITESPACE || $token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT) {
+                    continue;
+                }
+
+                $out[] = [$token[0], $token[1], $token[2]];
+
+                continue;
+            }
+
+            // Single-character token ("(", ")", "::" is T_DOUBLE_COLON so is array).
+            $out[] = [-1, $token, $line];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  list<array{0:int,1:string,2:int}>  $tokens
+     */
+    private function randomnessAt(array $tokens, int $i): ?string
+    {
+        [$id, $text] = $tokens[$i];
+
+        if ($id !== T_STRING) {
+            return null;
+        }
+
+        $name = strtolower($text);
+        $next = $tokens[$i + 1][1] ?? null;
+        $prev = $tokens[$i - 1][1] ?? null;
+
+        if (in_array($name, self::RANDOM_FUNCTIONS, true) && $next === '(' && $prev !== '->' && $prev !== '::') {
+            return $text;
+        }
+
+        // Static call: <Class>::<method>(  — the class token sits two before the
+        // method regardless of any namespace prefix, since it is the token that
+        // immediately precedes "::".
+        if ($next === '(' && $prev === '::') {
+            $class = $tokens[$i - 2][1] ?? '';
+
+            foreach (self::STATIC_RANDOM as $shortClass => $methods) {
+                if ($class === $shortClass && in_array($text, $methods, true)) {
+                    return "{$shortClass}::{$text}";
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Support/Fabrication/Violation.php
+++ b/tests/Support/Fabrication/Violation.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Fabrication;
+
+/**
+ * One place in the application source where the fabrication gate found either
+ * the generation of randomness or a hardcoded stand-in for a measured value,
+ * and no allowlist entry excused it.
+ */
+final class Violation
+{
+    public function __construct(
+        public readonly string $file,
+        public readonly int $line,
+        public readonly string $mechanism,
+        public readonly string $reason,
+    ) {}
+
+    public function describe(): string
+    {
+        return "{$this->file}:{$this->line} — {$this->mechanism}\n    {$this->reason}";
+    }
+}

--- a/tests/Unit/FabricationGateTest.php
+++ b/tests/Unit/FabricationGateTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\Fabrication\AllowlistEntry;
+use Tests\Support\Fabrication\FabricationScanner;
+
+final class FabricationGateTest extends TestCase
+{
+    /**
+     * The gate. Every generation of randomness in the application source must
+     * be excused by an allowlist entry that says why it is not fabrication.
+     * The allowlist lives here as data, one justified entry per site.
+     *
+     * @return list<AllowlistEntry>
+     */
+    private function allowlist(): array
+    {
+        return [
+            new AllowlistEntry(
+                'Services/FacialRecognition/Providers/MockProvider.php', '*', 'mock',
+                'Demonstration provider. It fabricates faces and encodings by design, but is '
+                .'only instantiated when FACIAL_RECOGNITION_PROVIDER=mock; the config default is '
+                ."'none' and an unknown provider name yields no provider, so it is unreachable "
+                .'unless deliberately opted in.',
+            ),
+            new AllowlistEntry(
+                'Actions/Jetstream/InviteTeamMember.php', 'Str::random', 'token',
+                'Team-member invitation token — a random identifier mailed to the invitee, not a value read as a finding.',
+            ),
+            new AllowlistEntry(
+                'Models/VirtualEventAttendee.php', 'Str::random', 'token',
+                'Attendee invitation token — a random identifier, not a domain value.',
+            ),
+            new AllowlistEntry(
+                'Services/DnaImportService.php', 'Str::random', 'identifier',
+                'Kit variable_name identifier, generated inside a collision-retry loop that re-rolls until unique.',
+            ),
+            new AllowlistEntry(
+                'Services/VideoConferencing/GoogleMeetService.php', 'uniqid', 'api-request-id',
+                'requestId for the Google Meet createRequest call — an external API request identifier.',
+            ),
+            new AllowlistEntry(
+                'Services/VideoConferencing/ZoomService.php', 'Str::random', 'security',
+                'Meeting password. Security-bearing randomness, not fabrication: it was deliberately '
+                .'moved off str_shuffle to Str::random (CSPRNG-backed) for entropy. Classified as '
+                .'security so it is never conflated with an invented domain value.',
+            ),
+            new AllowlistEntry(
+                'Filament/App/Resources/GedcomResource/Pages/CreateGedcom.php', 'Str::uuid', 'identifier',
+                'GEDCOM import slug — a unique identifier for the import, not a domain value.',
+            ),
+            new AllowlistEntry(
+                'Jobs/ImportGedcom.php', 'Str::uuid', 'identifier',
+                'GEDCOM import slug identifier.',
+            ),
+            new AllowlistEntry(
+                'Jobs/ImportGrampsXml.php', 'Str::uuid', 'identifier',
+                'GRAMPS import slug identifier.',
+            ),
+            new AllowlistEntry(
+                'Services/GedcomService.php', 'Str::uuid', 'identifier',
+                'GEDCOM import slug identifier.',
+            ),
+        ];
+    }
+
+    public function test_the_application_source_generates_no_unexcused_randomness(): void
+    {
+        $scanner = new FabricationScanner($this->allowlist());
+
+        $violations = $scanner->scanDirectory(dirname(__DIR__, 2).'/app');
+
+        $this->assertSame([], $violations, "\n".FabricationScanner::explain($violations));
+    }
+
+    public function test_it_flags_a_randomness_call_in_source(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $violations = $scanner->scanSource("<?php\n\$x = random_int(1, 3);\n", 'Bad.php');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame(2, $violations[0]->line);
+        $this->assertStringContainsString('random_int', $violations[0]->mechanism);
+    }
+
+    public function test_it_flags_a_static_randomness_call(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $violations = $scanner->scanSource("<?php\n\$t = Str::random(32);\n", 'Bad.php');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('Str::random', $violations[0]->mechanism);
+    }
+
+    public function test_it_ignores_randomness_names_that_only_appear_in_comments(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $source = "<?php\n// this used to call random_int(1, 3) to invent faces\n\$x = 1;\n";
+
+        $this->assertSame([], $scanner->scanSource($source, 'Documented.php'));
+    }
+
+    public function test_an_allowlisted_site_is_excused(): void
+    {
+        $scanner = new FabricationScanner([
+            new AllowlistEntry('Bad.php', 'random_int', 'identifier', 'kit identifier with collision retry'),
+        ]);
+
+        $this->assertSame([], $scanner->scanSource("<?php\n\$x = random_int(1, 3);\n", 'Bad.php'));
+    }
+
+    public function test_a_different_mechanism_in_an_allowlisted_file_is_still_flagged(): void
+    {
+        $scanner = new FabricationScanner([
+            new AllowlistEntry('Bad.php', 'Str::random', 'token', 'attendee token'),
+        ]);
+
+        $violations = $scanner->scanSource("<?php\n\$x = random_int(1, 3);\n", 'Bad.php');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('random_int', $violations[0]->mechanism);
+    }
+
+    public function test_it_flags_a_certainty_coalesced_to_a_literal(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $violations = $scanner->scanSource("<?php\n\$c = \$face['confidence'] ?? 0;\n", 'Bad.php');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame(2, $violations[0]->line);
+        $this->assertStringContainsString('confidence', $violations[0]->mechanism);
+    }
+
+    public function test_a_certainty_coalesced_to_null_is_honest(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $this->assertSame([], $scanner->scanSource("<?php\n\$c = \$face['confidence'] ?? null;\n", 'Ok.php'));
+    }
+
+    public function test_a_count_coalesced_to_a_literal_is_not_a_certainty(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $this->assertSame([], $scanner->scanSource("<?php\n\$n = \$stats['people_count'] ?? 0;\n", 'Ok.php'));
+    }
+
+    public function test_an_allowlist_entry_without_a_justification_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new FabricationScanner([
+            new AllowlistEntry('Bad.php', 'random_int', 'identifier', '   '),
+        ]);
+    }
+}


### PR DESCRIPTION
## What

Ticket 05 of the *no-fabricated-data* feature — an executable definition of "this application does not invent data", running as part of the normal test suite (`Tests\Unit\FabricationGateTest`, no DB/Laravel boot). Closes ticket 17 as well, because the gate caught it.

## The gate

`tests/Support/Fabrication/FabricationScanner.php` tokenises the application source (`token_get_all`) rather than pattern-matching. That closes the two gaps that let the prior grep-based sweep fail: it matches **exact call names** (so `random_int` is not missed by a `\brand\b` boundary) and **ignores comments** (so docblocks describing removed fabrication don't false-positive). It reports:

- **Randomness** generated outside a small allowlist. The allowlist lives in the test **as data, one written justification per site**; an entry with no reason is rejected by the scanner constructor. **Security-bearing** randomness (the Zoom meeting password) is categorised distinctly so it is never conflated with a fabricated domain value.
- **Certainty stand-ins**: a certainty/quality measurement (`confidence`, `match_quality`, …) coalesced to a **non-null literal** — a made-up figure where none was measured. A *count* or position defaulted to `0` is a true statement and passes; a certainty you did not measure is not `0` (that reads as "certainly wrong").

The scanner is verified against known-bad fixtures, so a change that accidentally neuters it is caught.

## Two fabrications the gate caught (fixed, not allowlisted)

The certainty arm flagged two live cases the manual sweep had missed. The gate lands green by **fixing** them:

- **`FacialRecognitionService::createPhotoTags`** stored `$face['confidence'] ?? 0` — a face the provider returned *without* a confidence got `0`, which reads in the review UI as "certainly not this person". Now stores `null` (column is nullable), and the review blade renders **"not reported"** for null instead of `number_format(null)` → `"0.0%"`. **This is ticket 17.**
- **`FamilyMatchingService::createConnection`** had a dead `?? 0` on `confidence_score` that would fabricate a certainty if ever reached. `findPotentialConnections` always sets the key, so it is dropped — an absent key now fails loudly instead.

## Tests

All behavioural and revert-sensitive:
- `FabricationGateTest` — the gate + scanner unit behaviour + the real-tree assertion.
- `FaceMatchConfidenceTest` — null-not-zero storage, reported value preserved, matched-face confidence.
- `FacialRecognitionReviewConfidenceTest` — the review interface distinguishes "not reported" from a reported figure.

## Gates

- `php artisan test` — **813 passed, 12 skipped, 0 failures**.
- Pint `--test` clean; PHPStan clean (gate lives in `tests/`, outside `paths: app` — no baseline change).