### PR TITLE
Introduce the typed unavailable result, piloted on facial recognition (ticket 06)

### DIFF
--- a/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
@@ -97,6 +97,12 @@ class PhotosRelationManager extends AppRelationManager
                                 ->body("Found {$result['faces_detected']} face(s)")
                                 ->success()
                                 ->send();
+                        } else {
+                            Notification::make()
+                                ->title('Analysis failed')
+                                ->body($result['error'] ?? 'Unknown error')
+                                ->danger()
+                                ->send();
                         }
                     }),
             ])

--- a/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
+++ b/app/Filament/App/Resources/PersonResource/RelationManagers/PhotosRelationManager.php
@@ -5,6 +5,7 @@ namespace App\Filament\App\Resources\PersonResource\RelationManagers;
 use App\Filament\App\Resources\AppRelationManager;
 use App\Models\PersonPhoto;
 use App\Services\FacialRecognitionService;
+use App\Support\Unavailable;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
@@ -84,7 +85,13 @@ class PhotosRelationManager extends AppRelationManager
                         $facialRecognitionService = app(FacialRecognitionService::class);
                         $result = $facialRecognitionService->analyzePhoto($record);
 
-                        if ($result['success']) {
+                        if ($result instanceof Unavailable) {
+                            Notification::make()
+                                ->title('Facial recognition unavailable')
+                                ->body($result->reason)
+                                ->warning()
+                                ->send();
+                        } elseif ($result['success']) {
                             Notification::make()
                                 ->title('Photo analyzed')
                                 ->body("Found {$result['faces_detected']} face(s)")
@@ -111,7 +118,13 @@ class PhotosRelationManager extends AppRelationManager
                         $facialRecognitionService = app(FacialRecognitionService::class);
                         $result = $facialRecognitionService->analyzePhoto($record);
 
-                        if ($result['success']) {
+                        if ($result instanceof Unavailable) {
+                            Notification::make()
+                                ->title('Facial recognition unavailable')
+                                ->body($result->reason)
+                                ->warning()
+                                ->send();
+                        } elseif ($result['success']) {
                             Notification::make()
                                 ->title('Photo analyzed')
                                 ->body("Found {$result['faces_detected']} face(s)")

--- a/app/Services/FacialRecognitionService.php
+++ b/app/Services/FacialRecognitionService.php
@@ -7,6 +7,7 @@ use App\Models\PersonPhoto;
 use App\Models\PhotoTag;
 use App\Services\FacialRecognition\FacialRecognitionProviderInterface;
 use App\Services\FacialRecognition\Providers\MockProvider;
+use App\Support\Unavailable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -53,19 +54,16 @@ class FacialRecognitionService
     /**
      * Analyze a photo and create tags for detected faces
      *
-     * @return array Results of the analysis
+     * @return array|Unavailable Analysis results, or Unavailable when no provider is configured
      */
-    public function analyzePhoto(PersonPhoto $photo): array
+    public function analyzePhoto(PersonPhoto $photo): array|Unavailable
     {
         if (! $this->isAvailable()) {
             Log::warning('No facial recognition provider configured; photo not analysed', [
                 'photo_id' => $photo->id,
             ]);
 
-            return [
-                'success' => false,
-                'error' => 'Facial recognition is not configured.',
-            ];
+            return new Unavailable('Facial recognition is not configured.');
         }
 
         try {

--- a/app/Support/Unavailable.php
+++ b/app/Support/Unavailable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * The typed result meaning "a provider-backed feature could not run", carrying a
+ * human-readable reason the presentation layer renders to the user.
+ *
+ * It is a distinct type — not a null, false, or empty array — so "we could not
+ * look" is never mistaken for "we looked and found nothing". Callers branch on
+ * `instanceof Unavailable` and show the reason ("not configured") rather than an
+ * empty result.
+ */
+final class Unavailable
+{
+    public function __construct(public readonly string $reason) {}
+}

--- a/tests/Feature/Services/FacialRecognitionGateTest.php
+++ b/tests/Feature/Services/FacialRecognitionGateTest.php
@@ -9,6 +9,7 @@ use App\Models\PersonPhoto;
 use App\Models\PhotoTag;
 use App\Models\User;
 use App\Services\FacialRecognitionService;
+use App\Support\Unavailable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -57,8 +58,8 @@ class FacialRecognitionGateTest extends TestCase
 
         $result = (new FacialRecognitionService)->analyzePhoto($photo);
 
-        $this->assertFalse($result['success']);
-        $this->assertSame('Facial recognition is not configured.', $result['error']);
+        $this->assertInstanceOf(Unavailable::class, $result);
+        $this->assertStringContainsString('not configured', $result->reason);
         $this->assertDatabaseCount('photo_tags', 0);
     }
 


### PR DESCRIPTION
Ticket 06 of the *no-fabricated-data* feature — the expand phase of the honest-degradation contract.

## Problem
`FacialRecognitionService::analyzePhoto` signalled an unconfigured provider with an `['success' => false, 'error' => …]` array — a shape a caller cannot distinguish *by type* from a real failure. Worse, the create action ignored the non-success case entirely, so an unconfigured install showed the user **nothing**.

## Change
`App\Support\Unavailable` is a typed result carrying a human-readable `reason`. It is a distinct type — not a null, false, or empty array — so *"we could not look"* is never mistaken for *"we looked and found nothing"*.

- `analyzePhoto` returns `array|Unavailable`; the no-provider path returns `Unavailable('Facial recognition is not configured.')`.
- Both `PersonResource` photo actions branch on `instanceof Unavailable` and render `->reason` (a warning), so an unconfigured feature reads as unconfigured. The create hook also gained the missing error-array branch (a pre-existing silent-failure gap, flagged in review).
- `FacialRecognitionGateTest` now asserts the **typed result and its reason**, and that **no tags were persisted** — observable behaviour, not which internals ran.

Piloted here because facial recognition already has the availability check the pattern generalises (`isAvailable`, config default `'none'`, unknown name → no provider). **Tickets 07/08** migrate the remaining provider-backed services (record matching, conferencing, handwriting) onto this type.

**Scope note:** `createFaceEncoding`'s no-provider path keeps its honest `null` — it is internal and its return is ignored by both callers, so no interface consumes a reason there.

## Gates
- `php artisan test` — **832 passed, 12 skipped, 0 failures**.
- Pint clean; PHPStan clean (union return type narrows correctly in the callers; no baseline change).
- Correctness review (caught the create-hook silent failure) + over-engineering review.