### PR TITLE
Apply the unavailable contract to record-matching providers (ticket 07)

### DIFF
--- a/app/Jobs/RunRecordMatchingJob.php
+++ b/app/Jobs/RunRecordMatchingJob.php
@@ -10,6 +10,7 @@ use App\Services\RecordMatcher\Providers\ExampleProvider;
 use App\Services\RecordMatcher\Providers\FamilySearchProvider;
 use App\Services\RecordMatcher\Providers\MyHeritageProvider;
 use App\Services\RecordMatcher\RecordMatcherService;
+use App\Support\Unavailable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -70,6 +71,17 @@ class RunRecordMatchingJob implements ShouldQueue
             foreach ($providers as $provider) {
                 try {
                     $candidates = $provider->search($person);
+
+                    if ($candidates instanceof Unavailable) {
+                        Log::warning('Record matching provider unavailable; skipped', [
+                            'provider' => class_basename($provider),
+                            'person_id' => $person->id,
+                            'reason' => $candidates->reason,
+                        ]);
+
+                        continue;
+                    }
+
                     $scored = $matcher->scoreCandidates($person, $candidates);
 
                     foreach ($scored as $entry) {

--- a/app/Services/RecordMatcher/Providers/AncestryProvider.php
+++ b/app/Services/RecordMatcher/Providers/AncestryProvider.php
@@ -3,6 +3,7 @@
 namespace App\Services\RecordMatcher\Providers;
 
 use App\Models\Person;
+use App\Support\Unavailable;
 use Exception;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -36,7 +37,7 @@ class AncestryProvider implements ExternalRecordProviderInterface
      *
      * @param  Person|int  $localPerson
      */
-    public function search($localPerson): array
+    public function search($localPerson): array|Unavailable
     {
         $person = is_int($localPerson) ? Person::find($localPerson) : $localPerson;
 
@@ -44,16 +45,21 @@ class AncestryProvider implements ExternalRecordProviderInterface
             return [];
         }
 
-        // If API key is not configured, return empty results
         if ($this->apiKey === '' || $this->apiKey === '0') {
             Log::warning('Ancestry API key not configured');
 
-            return [];
+            return new Unavailable('Ancestry is not configured.');
         }
 
         try {
             $searchParams = $this->buildSearchParams($person);
             $response = $this->performSearch($searchParams);
+
+            if (! is_array($response)) {
+                Log::error('Ancestry returned an unreadable response', ['person_id' => $person->id]);
+
+                return new Unavailable('Ancestry returned an unreadable response.');
+            }
 
             return $this->parseResponse($response);
         } catch (Exception $e) {
@@ -62,7 +68,7 @@ class AncestryProvider implements ExternalRecordProviderInterface
                 'error' => $e->getMessage(),
             ]);
 
-            return [];
+            return new Unavailable('Ancestry request failed: '.$e->getMessage());
         }
     }
 
@@ -114,7 +120,7 @@ class AncestryProvider implements ExternalRecordProviderInterface
     /**
      * Perform the actual API search.
      */
-    protected function performSearch(array $searchParams): array
+    protected function performSearch(array $searchParams): mixed
     {
         $response = Http::timeout($this->timeout)
             ->withHeaders([
@@ -127,7 +133,9 @@ class AncestryProvider implements ExternalRecordProviderInterface
             throw new Exception('Ancestry API request failed: '.$response->status());
         }
 
-        return $response->json() ?? [];
+        // Return the decoded body as-is (null/scalar for an unreadable response);
+        // the caller distinguishes that from a valid empty result.
+        return $response->json();
     }
 
     /**

--- a/app/Services/RecordMatcher/Providers/ExternalRecordProviderInterface.php
+++ b/app/Services/RecordMatcher/Providers/ExternalRecordProviderInterface.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace App\Services\RecordMatcher\Providers;
 
 use App\Models\Person;
+use App\Support\Unavailable;
 
 interface ExternalRecordProviderInterface
 {
     /**
      * Search external records for a given local person.
      *
-     * Return an iterable/array of associative arrays representing candidate records,
-     * each containing at least a provider-specific id and fields used for scoring.
+     * Returns an array of candidate records (each an associative array with at
+     * least a provider id and the fields used for scoring), OR an Unavailable
+     * when the provider could not search — so "we could not look" is never
+     * mistaken for "we looked and found nothing". An empty array means the
+     * search ran and matched nothing.
      *
      * Example candidate:
      * [
@@ -26,5 +30,5 @@ interface ExternalRecordProviderInterface
      *
      * @param  Person|int  $localPerson
      */
-    public function search($localPerson): array;
+    public function search($localPerson): array|Unavailable;
 }

--- a/app/Services/RecordMatcher/Providers/FamilySearchProvider.php
+++ b/app/Services/RecordMatcher/Providers/FamilySearchProvider.php
@@ -3,6 +3,7 @@
 namespace App\Services\RecordMatcher\Providers;
 
 use App\Models\Person;
+use App\Support\Unavailable;
 use Exception;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -36,7 +37,7 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
      *
      * @param  Person|int  $localPerson
      */
-    public function search($localPerson): array
+    public function search($localPerson): array|Unavailable
     {
         $person = is_int($localPerson) ? Person::find($localPerson) : $localPerson;
 
@@ -44,16 +45,21 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
             return [];
         }
 
-        // If API key is not configured, return empty results
         if ($this->apiKey === '' || $this->apiKey === '0') {
             Log::warning('FamilySearch API key not configured');
 
-            return [];
+            return new Unavailable('FamilySearch is not configured.');
         }
 
         try {
             $searchParams = $this->buildSearchParams($person);
             $response = $this->performSearch($searchParams);
+
+            if (! is_array($response)) {
+                Log::error('FamilySearch returned an unreadable response', ['person_id' => $person->id]);
+
+                return new Unavailable('FamilySearch returned an unreadable response.');
+            }
 
             return $this->parseResponse($response);
         } catch (Exception $e) {
@@ -62,7 +68,7 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
                 'error' => $e->getMessage(),
             ]);
 
-            return [];
+            return new Unavailable('FamilySearch request failed: '.$e->getMessage());
         }
     }
 
@@ -115,7 +121,7 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
     /**
      * Perform the actual API search.
      */
-    protected function performSearch(array $searchParams): array
+    protected function performSearch(array $searchParams): mixed
     {
         $response = Http::timeout($this->timeout)
             ->withHeaders([
@@ -128,7 +134,7 @@ class FamilySearchProvider implements ExternalRecordProviderInterface
             throw new Exception('FamilySearch API request failed: '.$response->status());
         }
 
-        return $response->json() ?? [];
+        return $response->json();
     }
 
     /**

--- a/app/Services/RecordMatcher/Providers/MyHeritageProvider.php
+++ b/app/Services/RecordMatcher/Providers/MyHeritageProvider.php
@@ -3,6 +3,7 @@
 namespace App\Services\RecordMatcher\Providers;
 
 use App\Models\Person;
+use App\Support\Unavailable;
 use Exception;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -36,7 +37,7 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
      *
      * @param  Person|int  $localPerson
      */
-    public function search($localPerson): array
+    public function search($localPerson): array|Unavailable
     {
         $person = is_int($localPerson) ? Person::find($localPerson) : $localPerson;
 
@@ -44,16 +45,21 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
             return [];
         }
 
-        // If API key is not configured, return empty results
         if ($this->apiKey === '' || $this->apiKey === '0') {
             Log::warning('MyHeritage API key not configured');
 
-            return [];
+            return new Unavailable('MyHeritage is not configured.');
         }
 
         try {
             $searchParams = $this->buildSearchParams($person);
             $response = $this->performSearch($searchParams);
+
+            if (! is_array($response)) {
+                Log::error('MyHeritage returned an unreadable response', ['person_id' => $person->id]);
+
+                return new Unavailable('MyHeritage returned an unreadable response.');
+            }
 
             return $this->parseResponse($response);
         } catch (Exception $e) {
@@ -62,7 +68,7 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
                 'error' => $e->getMessage(),
             ]);
 
-            return [];
+            return new Unavailable('MyHeritage request failed: '.$e->getMessage());
         }
     }
 
@@ -115,7 +121,7 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
     /**
      * Perform the actual API search.
      */
-    protected function performSearch(array $searchParams): array
+    protected function performSearch(array $searchParams): mixed
     {
         $response = Http::timeout($this->timeout)
             ->withHeaders([
@@ -128,7 +134,7 @@ class MyHeritageProvider implements ExternalRecordProviderInterface
             throw new Exception('MyHeritage API request failed: '.$response->status());
         }
 
-        return $response->json() ?? [];
+        return $response->json();
     }
 
     /**

--- a/app/Services/SmartMatchingService.php
+++ b/app/Services/SmartMatchingService.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Services\RecordMatcher\Providers\AncestryProvider;
 use App\Services\RecordMatcher\Providers\FamilySearchProvider;
 use App\Services\RecordMatcher\Providers\MyHeritageProvider;
+use App\Support\Unavailable;
 use DateTime;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
@@ -142,6 +143,15 @@ class SmartMatchingService
         foreach ($this->providers as $providerName => $provider) {
             try {
                 $candidates = $provider->search($person);
+
+                if ($candidates instanceof Unavailable) {
+                    Log::warning("Provider unavailable: {$providerName}", [
+                        'person_id' => $person->id,
+                        'reason' => $candidates->reason,
+                    ]);
+
+                    continue;
+                }
 
                 foreach ($candidates as $candidate) {
                     $confidence = $this->calculateMatchConfidence($person, $candidate);

--- a/tests/Unit/Services/RecordMatcher/Providers/AncestryProviderTest.php
+++ b/tests/Unit/Services/RecordMatcher/Providers/AncestryProviderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Services\RecordMatcher\Providers;
 
 use App\Models\Person;
 use App\Services\RecordMatcher\Providers\AncestryProvider;
+use App\Support\Unavailable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
@@ -37,16 +38,16 @@ class AncestryProviderTest extends TestCase
         $this->assertEquals('Ancestry', $this->provider->getName());
     }
 
-    public function test_search_returns_empty_array_when_not_configured(): void
+    public function test_search_reports_unavailable_when_not_configured(): void
     {
         Config::set('services.ancestry.api_key', '');
         $provider = new AncestryProvider;
 
         $person = Person::factory()->create();
-        $results = $provider->search($person);
+        $result = $provider->search($person);
 
-        $this->assertIsArray($results);
-        $this->assertEmpty($results);
+        $this->assertInstanceOf(Unavailable::class, $result);
+        $this->assertStringContainsString('not configured', $result->reason);
     }
 
     public function test_search_parses_response_with_records_key(): void

--- a/tests/Unit/Services/RecordMatcher/Providers/FamilySearchProviderTest.php
+++ b/tests/Unit/Services/RecordMatcher/Providers/FamilySearchProviderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Services\RecordMatcher\Providers;
 
 use App\Models\Person;
 use App\Services\RecordMatcher\Providers\FamilySearchProvider;
+use App\Support\Unavailable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
@@ -37,16 +38,16 @@ class FamilySearchProviderTest extends TestCase
         $this->assertEquals('FamilySearch', $this->provider->getName());
     }
 
-    public function test_search_returns_empty_array_when_not_configured(): void
+    public function test_search_reports_unavailable_when_not_configured(): void
     {
         Config::set('services.familysearch.api_key', '');
         $provider = new FamilySearchProvider;
 
         $person = Person::factory()->create();
-        $results = $provider->search($person);
+        $result = $provider->search($person);
 
-        $this->assertIsArray($results);
-        $this->assertEmpty($results);
+        $this->assertInstanceOf(Unavailable::class, $result);
+        $this->assertStringContainsString('not configured', $result->reason);
     }
 
     public function test_search_parses_gedcomx_format_correctly(): void

--- a/tests/Unit/Services/RecordMatcher/Providers/MyHeritageProviderTest.php
+++ b/tests/Unit/Services/RecordMatcher/Providers/MyHeritageProviderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Services\RecordMatcher\Providers;
 
 use App\Models\Person;
 use App\Services\RecordMatcher\Providers\MyHeritageProvider;
+use App\Support\Unavailable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
@@ -46,7 +47,7 @@ class MyHeritageProviderTest extends TestCase
         $this->assertEquals('MyHeritage', $this->provider->getName());
     }
 
-    public function test_search_returns_empty_array_when_api_key_not_configured(): void
+    public function test_search_reports_unavailable_when_api_key_not_configured(): void
     {
         Config::set('services.myheritage.api_key', '');
         $provider = new MyHeritageProvider;
@@ -56,10 +57,10 @@ class MyHeritageProviderTest extends TestCase
             'last_name' => 'Doe',
         ]);
 
-        $results = $provider->search($person);
+        $result = $provider->search($person);
 
-        $this->assertIsArray($results);
-        $this->assertEmpty($results);
+        $this->assertInstanceOf(Unavailable::class, $result);
+        $this->assertStringContainsString('not configured', $result->reason);
     }
 
     public function test_search_returns_empty_array_for_invalid_person(): void
@@ -142,7 +143,7 @@ class MyHeritageProviderTest extends TestCase
         $this->assertEquals('M', $results[0]['gender']);
     }
 
-    public function test_search_handles_api_errors(): void
+    public function test_search_reports_unavailable_on_a_failed_request(): void
     {
         Http::fake([
             'api.myheritage.test/*' => Http::response([], 500),
@@ -153,10 +154,10 @@ class MyHeritageProviderTest extends TestCase
             'last_name' => 'Doe',
         ]);
 
-        $results = $this->provider->search($person);
+        $result = $this->provider->search($person);
 
-        $this->assertIsArray($results);
-        $this->assertEmpty($results);
+        $this->assertInstanceOf(Unavailable::class, $result);
+        $this->assertStringContainsString('request failed', $result->reason);
     }
 
     public function test_search_accepts_person_model(): void

--- a/tests/Unit/Services/RecordMatcher/RecordMatcherServiceTest.php
+++ b/tests/Unit/Services/RecordMatcher/RecordMatcherServiceTest.php
@@ -10,6 +10,8 @@ use App\Models\AISuggestedMatch;
 use App\Models\Person;
 use App\Services\RecordMatcher\RecordMatcherService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
@@ -64,6 +66,27 @@ class RecordMatcherServiceTest extends TestCase
             ->withArgs(fn (string $message, array $context = []): bool => $message === 'Record matching job completed'
                 && ($context['persons_processed'] ?? 0) === 1)
             ->once();
+    }
+
+    public function test_the_job_skips_a_provider_that_reports_unavailable(): void
+    {
+        // A configured provider whose request fails returns Unavailable, not an
+        // array. The job must recognise that and log the reason, rather than feed
+        // it to the scorer (which would TypeError and read as a generic failure).
+        Config::set('services.ancestry.api_key', 'configured');
+        Config::set('services.myheritage.api_key', '');
+        Config::set('services.familysearch.api_key', '');
+        Http::fake(['*' => Http::response([], 500)]);
+        Person::factory()->create(['surn' => 'Lovelace']);
+        Log::spy();
+
+        (new RunRecordMatchingJob)->handle(new RecordMatcherService);
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn (string $message, array $context = []): bool => $message === 'Record matching provider unavailable; skipped'
+                && str_contains((string) ($context['reason'] ?? ''), 'request failed'))
+            ->atLeast()->once();
+        $this->assertDatabaseCount('ai_suggested_matches', 0);
     }
 
     public function test_learn_from_feedback_does_not_crash_on_the_parents_factor(): void


### PR DESCRIPTION
Ticket 07 of the *no-fabricated-data* feature.

## Problem
The record-matching providers signalled *"did not / could not search"* with an empty array — indistinguishable from *"searched, found nothing"*. For a genealogy product those are completely different claims about a person's family.

## Change
`ExternalRecordProviderInterface::search` now returns `array|Unavailable`. Each provider (Ancestry, MyHeritage, FamilySearch) returns `Unavailable` with a reason that distinguishes the three failure modes the ticket names:
- **absent credentials** → `"<name> is not configured."`
- **failed request** → `"<name> request failed: …"`
- **rejected / unreadable 2xx response** → `"<name> returned an unreadable response."` (`performSearch` now returns the decoded body as-is; `search` checks `is_array` before parsing).

A valid empty result stays `[]` — the search ran and matched nothing.

Both dispatch sites (`RunRecordMatchingJob`, `SmartMatchingService`) branch on `instanceof Unavailable` **before** scoring — otherwise an `Unavailable` reaches `scoreCandidates(array)` and TypeErrors, swallowed as a generic failure — and log the reason so an administrator can see why a provider declined. Confidence scoring, free-text date handling and the GEDCOM-column fixes are untouched.

**Interface note:** there is no live "search now" UI (`AIRecordMatchResource` reads persisted suggestion rows), so the *not-configured vs found-nothing* distinction surfaces through the typed contract and the logged reason rather than a Filament notification. When a live-search trigger is added, it renders `->reason` the same way `PhotosRelationManager` does for facial recognition.

## Tests
- Provider tests assert the typed result + reason on the not-configured and request-failure paths (flipped from `assertEmpty`).
- A job test pins that an unavailable provider is skipped with its reason logged, persisting nothing (revert-sensitive to the guard).

## Gates
- `php artisan test` — **833 passed, 12 skipped, 0 failures**.
- Pint clean; PHPStan clean (union return type + `instanceof` narrowing; no baseline change).
- Correctness review (verified no unguarded `search()` caller, JSON-decode edge cases, covariance) — no issues.