### PR TITLE
Apply the unavailable contract to video conferencing (ticket 08a)

### DIFF
--- a/app/Filament/App/Resources/VirtualEventResource.php
+++ b/app/Filament/App/Resources/VirtualEventResource.php
@@ -9,6 +9,7 @@ use App\Filament\App\Resources\VirtualEventResource\Pages\ViewVirtualEvent;
 use App\Filament\App\Resources\VirtualEventResource\RelationManagers\AttendeesRelationManager;
 use App\Models\VirtualEvent;
 use App\Services\VideoConferencingService;
+use App\Support\Unavailable;
 use Carbon\Carbon;
 use Exception;
 use Filament\Actions\Action;
@@ -309,7 +310,17 @@ class VirtualEventResource extends AppResource
         abort_unless(static::collaborationTierPermits('update'), 403);
 
         try {
-            app(VideoConferencingService::class)->createMeeting($record);
+            $result = app(VideoConferencingService::class)->createMeeting($record);
+
+            if ($result instanceof Unavailable) {
+                Notification::make()
+                    ->title('Meeting Not Created')
+                    ->body($result->reason)
+                    ->warning()
+                    ->send();
+
+                return;
+            }
 
             Notification::make()
                 ->title('Meeting Created')

--- a/app/Filament/App/Resources/VirtualEventResource/Pages/EditVirtualEvent.php
+++ b/app/Filament/App/Resources/VirtualEventResource/Pages/EditVirtualEvent.php
@@ -4,6 +4,7 @@ namespace App\Filament\App\Resources\VirtualEventResource\Pages;
 
 use App\Filament\App\Resources\VirtualEventResource;
 use App\Services\VideoConferencingService;
+use App\Support\Unavailable;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
@@ -26,7 +27,17 @@ class EditVirtualEvent extends EditRecord
                 ->action(function (): void {
                     try {
                         $service = app(VideoConferencingService::class);
-                        $service->createMeeting($this->getRecord());
+                        $result = $service->createMeeting($this->getRecord());
+
+                        if ($result instanceof Unavailable) {
+                            Notification::make()
+                                ->title('Meeting Not Created')
+                                ->body($result->reason)
+                                ->warning()
+                                ->send();
+
+                            return;
+                        }
 
                         Notification::make()
                             ->title('Meeting Created')
@@ -50,7 +61,17 @@ class EditVirtualEvent extends EditRecord
                 ->action(function (): void {
                     try {
                         $service = app(VideoConferencingService::class);
-                        $service->updateMeeting($this->getRecord());
+                        $result = $service->updateMeeting($this->getRecord());
+
+                        if ($result instanceof Unavailable) {
+                            Notification::make()
+                                ->title('Meeting Not Updated')
+                                ->body($result->reason)
+                                ->warning()
+                                ->send();
+
+                            return;
+                        }
 
                         Notification::make()
                             ->title('Meeting Updated')
@@ -87,7 +108,15 @@ class EditVirtualEvent extends EditRecord
         if (! empty($record->meeting_id) && $record->platform !== 'custom') {
             try {
                 $service = app(VideoConferencingService::class);
-                $service->updateMeeting($record);
+                $result = $service->updateMeeting($record);
+
+                if ($result instanceof Unavailable) {
+                    Notification::make()
+                        ->title('Meeting Not Updated')
+                        ->body('Event saved, but the meeting was not updated: '.$result->reason)
+                        ->warning()
+                        ->send();
+                }
             } catch (Exception $e) {
                 Notification::make()
                     ->title('Meeting Update Failed')

--- a/app/Services/VideoConferencingService.php
+++ b/app/Services/VideoConferencingService.php
@@ -7,6 +7,7 @@ use App\Services\VideoConferencing\GoogleMeetService;
 use App\Services\VideoConferencing\TeamsService;
 use App\Services\VideoConferencing\VideoConferencingInterface;
 use App\Services\VideoConferencing\ZoomService;
+use App\Support\Unavailable;
 use Exception;
 use Illuminate\Support\Facades\Log;
 
@@ -26,8 +27,17 @@ class VideoConferencingService
     /**
      * Create a meeting for the given virtual event
      */
-    public function createMeeting(VirtualEvent $event): array
+    public function createMeeting(VirtualEvent $event): array|Unavailable
     {
+        if (! $this->isPlatformConfigured($event->platform)) {
+            Log::warning('Video conferencing platform not configured; meeting not created', [
+                'event_id' => $event->id,
+                'platform' => $event->platform,
+            ]);
+
+            return new Unavailable($this->platformLabel($event->platform).' is not configured.');
+        }
+
         try {
             $service = $this->getService($event->platform);
 
@@ -75,8 +85,17 @@ class VideoConferencingService
     /**
      * Update an existing meeting
      */
-    public function updateMeeting(VirtualEvent $event): array
+    public function updateMeeting(VirtualEvent $event): array|Unavailable
     {
+        if (! $this->isPlatformConfigured($event->platform)) {
+            Log::warning('Video conferencing platform not configured; meeting not updated', [
+                'event_id' => $event->id,
+                'platform' => $event->platform,
+            ]);
+
+            return new Unavailable($this->platformLabel($event->platform).' is not configured.');
+        }
+
         try {
             $service = $this->getService($event->platform);
 
@@ -302,5 +321,13 @@ class VideoConferencingService
         } catch (Exception) {
             return false;
         }
+    }
+
+    /**
+     * Human-readable name for a platform key, for a user-facing reason.
+     */
+    protected function platformLabel(string $platform): string
+    {
+        return $this->getAvailablePlatforms()[$platform]['name'] ?? ucfirst($platform);
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -62,6 +62,10 @@ return [
         'client_id' => env('GOOGLE_CLIENT_ID'),
         'client_secret' => env('GOOGLE_CLIENT_SECRET'),
         'redirect' => env('GOOGLE_REDIRECT_URI', env('APP_URL').'/oauth/google/callback'),
+        // Google Meet conferencing (GoogleMeetService) — without these the
+        // platform stays disabled rather than unreachable.
+        'refresh_token' => env('GOOGLE_REFRESH_TOKEN'),
+        'enabled' => env('GOOGLE_MEET_ENABLED', false),
     ],
 
     'twitter' => [
@@ -72,6 +76,38 @@ return [
 
     'google_vision' => [
         'api_key' => env('GOOGLE_VISION_API_KEY'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Video Conferencing
+    |--------------------------------------------------------------------------
+    |
+    | ZoomService and TeamsService read these keys; they existed nowhere in the
+    | config, so those platforms could not be enabled at all without editing
+    | source. Declared here so an administrator can configure them via env. An
+    | unset key leaves the platform not-configured (it degrades to Unavailable),
+    | not unreachable.
+    |
+    */
+
+    // Credential keys default to '' (not null): ZoomService/TeamsService assign
+    // them to typed string properties via config(key, ''), whose default only
+    // fires when the key is ABSENT — now that the key is present, an unset env
+    // must resolve to '' rather than null or construction TypeErrors.
+    'zoom' => [
+        'enabled' => env('ZOOM_ENABLED', false),
+        'base_url' => env('ZOOM_BASE_URL', 'https://api.zoom.us/v2'),
+        'key' => env('ZOOM_KEY', ''),
+        'secret' => env('ZOOM_SECRET', ''),
+        'account_id' => env('ZOOM_ACCOUNT_ID', ''),
+    ],
+
+    'teams' => [
+        'enabled' => env('TEAMS_ENABLED', false),
+        'client_id' => env('TEAMS_CLIENT_ID', ''),
+        'client_secret' => env('TEAMS_CLIENT_SECRET', ''),
+        'tenant_id' => env('TEAMS_TENANT_ID', ''),
     ],
 
     /*

--- a/tests/Feature/Services/VideoConferencingUnavailableTest.php
+++ b/tests/Feature/Services/VideoConferencingUnavailableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\User;
+use App\Models\VirtualEvent;
+use App\Services\VideoConferencingService;
+use App\Support\Unavailable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A conferencing platform that is not configured must report Unavailable with a
+ * reason, not throw a generic exception — so a caller can distinguish "not
+ * configured" (a warning the admin can act on) from "configured but failing" (a
+ * runtime error), and never records a meeting that was not created.
+ */
+final class VideoConferencingUnavailableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function event(string $platform): VirtualEvent
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        return VirtualEvent::create([
+            'title' => 'Reunion',
+            'status' => 'published',
+            'start_time' => now()->addWeek(),
+            'end_time' => now()->addWeek()->addHours(2),
+            'created_by' => $user->id,
+            'platform' => $platform,
+        ]);
+    }
+
+    public function test_creating_a_meeting_on_an_unconfigured_platform_reports_unavailable(): void
+    {
+        config(['services.zoom.key' => '', 'services.zoom.secret' => '', 'services.zoom.account_id' => '']);
+
+        $event = $this->event('zoom');
+
+        $result = app(VideoConferencingService::class)->createMeeting($event);
+
+        $this->assertInstanceOf(Unavailable::class, $result);
+        $this->assertStringContainsString('not configured', $result->reason);
+        $this->assertNull($event->fresh()->meeting_id);
+    }
+
+    public function test_updating_a_meeting_on_an_unconfigured_platform_reports_unavailable(): void
+    {
+        config(['services.teams.client_id' => '', 'services.teams.client_secret' => '', 'services.teams.tenant_id' => '']);
+
+        $event = $this->event('teams');
+
+        $result = app(VideoConferencingService::class)->updateMeeting($event);
+
+        $this->assertInstanceOf(Unavailable::class, $result);
+        $this->assertStringContainsString('not configured', $result->reason);
+    }
+}


### PR DESCRIPTION
First half of ticket 08 of the *no-fabricated-data* feature (handwriting follows in 08b).

## Problem
`VideoConferencingService::createMeeting`/`updateMeeting` threw a generic exception when a platform was not configured — a caller couldn't distinguish *"not configured"* from *"configured but failing"*. And the Filament consumers **ignored the return value**, catching only exceptions — so a not-configured platform could still flash a green "Meeting Created" toast.

## Change
- Both manager methods gate on `isPlatformConfigured` and return `Unavailable("<Platform> is not configured.")` for the not-configured case. A configured-but-failing call still throws — so the two remain **distinct** (warning vs error), which is an acceptance criterion.
- Every consumer — the resource's `create` table action and the edit page's `create`/`update` actions and `afterSave` — branches on `instanceof Unavailable` and renders `->reason` as a **warning** instead of a false success.
- Declares config the providers read but that existed **nowhere**: `services.zoom` and `services.teams` blocks, and `services.google.refresh_token`/`enabled`. So those platforms are configurable via env rather than unreachable.

**Trap avoided:** the credential keys default to `''`, not `null`. `ZoomService`/`TeamsService` assign them to typed `string` properties via `config(key, '')`, whose default only fires when the key is *absent* — now that the key is present, an unset env must resolve to `''` or construction TypeErrors (the same present-but-null trap the record-matcher providers document).

## Tests
`VideoConferencingUnavailableTest` — creating/updating a meeting on an unconfigured platform returns `Unavailable` with a reason and records no meeting (revert-sensitive: the code previously threw).

## Gates
- `php artisan test` — **835 passed, 12 skipped, 0 failures**.
- Pint clean; PHPStan clean (union return type + `instanceof` narrowing; no baseline change).
- Reviewed for over-engineering (ponytail-review): lean.