### PR TITLE
Ban domain-value construction in error handling; complete the fabrication gate (ticket 09)

### DIFF
--- a/docs/no-fabricated-data.md
+++ b/docs/no-fabricated-data.md
@@ -1,0 +1,50 @@
+# The application must never present invented data as fact
+
+This is a hard rule, not a matter of taste. For a genealogy product it is the
+most severe failure mode available: a user cannot tell an invented
+great-grandmother — complete with a plausible source link — from a real
+archival hit, and may record the invention as family history that outlives the
+software.
+
+## The rule
+
+Where the platform cannot compute something, it says so plainly and says why.
+Every figure on screen is either derived from the user's data or absent.
+
+Concretely:
+
+1. **Application source does not generate randomness** outside a small,
+   justified allowlist (identifier and token generation). A random value is not
+   a measurement.
+2. **A certainty is never a hardcoded stand-in.** An unmeasured confidence,
+   match quality or similarity is not `0` — that reads as "certainly wrong", a
+   different claim. Coalesce to `null` so absence is representable, or let the
+   failure propagate.
+3. **An error-handling branch may not construct a domain value.** A `catch`
+   block may log, translate the exception, or rethrow. It may not produce a
+   centimorgan count, a confidence score, a detected face, a matched record, or
+   a relationship estimate. An error is visible and recoverable; an invented
+   finding is not.
+
+## Why a fallback that invents a plausible value is worse than an error
+
+It is the path of least resistance when a dependency is unavailable: it keeps
+the demonstration working, keeps the tests green, and produces output that looks
+like success. That is exactly why it is dangerous — it fails silently, in a way
+review and CI both demonstrably missed across four services here. An error
+surfaces and can be fixed; an invented ancestor gets recorded as fact.
+
+When a provider-backed feature cannot run, return the typed
+`App\Support\Unavailable` result carrying a human-readable reason, and render
+that reason to the user ("not configured") rather than an empty or invented
+result.
+
+## The gate
+
+`Tests\Unit\FabricationGateTest` enforces all three rules mechanically against
+`app/` on every test run. If your change trips it, you have two routes forward:
+
+- **Remove the randomness / literal / construction** — usually the right fix.
+- **Add an allowlist entry** (randomness only) in the test, with a written
+  justification a reviewer can evaluate. An entry without a reason fails. The
+  allowlist is meant to be small and to shrink over time.

--- a/tests/Support/Fabrication/FabricationScanner.php
+++ b/tests/Support/Fabrication/FabricationScanner.php
@@ -209,7 +209,14 @@ final class FabricationScanner
             return null;
         }
 
+        // The key is the token before the operator — but for a bracketed field
+        // assignment ($result['confidence'] = 0.85) that token is ']', so step
+        // back over it to the key inside the brackets.
         $prev = $tokens[$i - 1] ?? null;
+        if (($prev[1] ?? null) === ']') {
+            $prev = $tokens[$i - 2] ?? null;
+        }
+
         $name = match ($prev[0] ?? null) {
             T_VARIABLE => strtolower(ltrim($prev[1], '$')),
             T_STRING => strtolower($prev[1]),

--- a/tests/Support/Fabrication/FabricationScanner.php
+++ b/tests/Support/Fabrication/FabricationScanner.php
@@ -115,12 +115,14 @@ final class FabricationScanner
     {
         $tokens = token_get_all($source);
         $significant = $this->significantTokens($tokens);
+        $catchRanges = $this->catchBlockRanges($significant);
 
         $violations = [];
 
         foreach ($significant as $i => $token) {
             $violation = $this->randomnessViolation($significant, $i, $relativePath)
-                ?? $this->certaintyStandInViolation($significant, $i, $relativePath);
+                ?? $this->certaintyStandInViolation($significant, $i, $relativePath)
+                ?? $this->domainValueInCatchViolation($significant, $i, $relativePath, $catchRanges);
 
             if ($violation !== null && ! $this->isAllowed($violation)) {
                 $violations[] = $violation;
@@ -128,6 +130,127 @@ final class FabricationScanner
         }
 
         return $violations;
+    }
+
+    /**
+     * Index ranges (into the significant-token list) that lie inside a catch
+     * block body, so error-handling branches can be checked for the
+     * construction of a domain value.
+     *
+     * @param  list<array{0:int,1:string,2:int}>  $tokens
+     * @return list<array{0:int,1:int}>
+     */
+    private function catchBlockRanges(array $tokens): array
+    {
+        $ranges = [];
+        $n = count($tokens);
+
+        for ($i = 0; $i < $n; $i++) {
+            if ($tokens[$i][0] !== T_CATCH) {
+                continue;
+            }
+
+            $open = $i + 1;
+            while ($open < $n && $tokens[$open][1] !== '{') {
+                $open++;
+            }
+
+            if ($open >= $n) {
+                continue;
+            }
+
+            $depth = 0;
+            $close = $open;
+            for (; $close < $n; $close++) {
+                if ($tokens[$close][1] === '{') {
+                    $depth++;
+                } elseif ($tokens[$close][1] === '}') {
+                    $depth--;
+                    if ($depth === 0) {
+                        break;
+                    }
+                }
+            }
+
+            $ranges[] = [$open + 1, $close - 1];
+            $i = $close;
+        }
+
+        return $ranges;
+    }
+
+    /**
+     * A catch block may log, translate the exception, or rethrow. It may not
+     * assign a certainty/finding vocabulary key or variable to a hardcoded
+     * literal — that constructs a value the user reads as a finding, on the very
+     * path where nothing was measured.
+     *
+     * @param  list<array{0:int,1:string,2:int}>  $tokens
+     * @param  list<array{0:int,1:int}>  $catchRanges
+     */
+    private function domainValueInCatchViolation(array $tokens, int $i, string $file, array $catchRanges): ?Violation
+    {
+        $isArrow = $tokens[$i][0] === T_DOUBLE_ARROW;
+        $isAssign = $tokens[$i][0] === -1 && $tokens[$i][1] === '=';
+
+        if (! $isArrow && ! $isAssign) {
+            return null;
+        }
+
+        if (! $this->indexInRanges($i, $catchRanges)) {
+            return null;
+        }
+
+        $next = $tokens[$i + 1] ?? null;
+        if ($next !== null && ($next[1] === '-' || $next[1] === '+')) {
+            $next = $tokens[$i + 2] ?? null;
+        }
+        if ($next === null || ($next[0] !== T_LNUMBER && $next[0] !== T_DNUMBER)) {
+            return null;
+        }
+
+        $prev = $tokens[$i - 1] ?? null;
+        $name = match ($prev[0] ?? null) {
+            T_VARIABLE => strtolower(ltrim($prev[1], '$')),
+            T_STRING => strtolower($prev[1]),
+            T_CONSTANT_ENCAPSED_STRING => strtolower(trim($prev[1], "'\"")),
+            default => null,
+        };
+
+        if ($name === null) {
+            return null;
+        }
+
+        foreach (self::CERTAINTY_VOCAB as $vocab) {
+            if (str_contains($name, $vocab)) {
+                return new Violation(
+                    file: $file,
+                    line: $tokens[$i][2],
+                    mechanism: "domain value '{$vocab}' constructed in an error-handling branch",
+                    reason: "A catch block assigns '{$vocab}' a hardcoded literal. An error-handling "
+                        .'branch may log, translate the exception, or rethrow — it may not produce a '
+                        .'value the user reads as a finding, because an error is visible and recoverable '
+                        .'while an invented finding may be recorded as family history that outlives the '
+                        .'software. Propagate the failure or return a typed Unavailable instead.',
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<array{0:int,1:int}>  $ranges
+     */
+    private function indexInRanges(int $i, array $ranges): bool
+    {
+        foreach ($ranges as [$start, $end]) {
+            if ($i >= $start && $i <= $end) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/FabricationGateTest.php
+++ b/tests/Unit/FabricationGateTest.php
@@ -69,7 +69,7 @@ final class FabricationGateTest extends TestCase
         ];
     }
 
-    public function test_the_application_source_generates_no_unexcused_randomness(): void
+    public function test_the_application_source_is_free_of_fabrication(): void
     {
         $scanner = new FabricationScanner($this->allowlist());
 
@@ -152,6 +152,40 @@ final class FabricationGateTest extends TestCase
         $scanner = new FabricationScanner;
 
         $this->assertSame([], $scanner->scanSource("<?php\n\$n = \$stats['people_count'] ?? 0;\n", 'Ok.php'));
+    }
+
+    public function test_it_flags_a_domain_value_constructed_in_a_catch_block(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $source = "<?php\ntry {\n  compare();\n} catch (\\Exception \$e) {\n  return ['confidence' => 0.85];\n}\n";
+
+        $violations = $scanner->scanSource($source, 'Bad.php');
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('error-handling', $violations[0]->reason);
+    }
+
+    public function test_an_honest_catch_block_passes(): void
+    {
+        $scanner = new FabricationScanner;
+
+        // Log, translate/rethrow, and return the typed unavailable result are all
+        // legitimate — none constructs a finding.
+        $source = "<?php\ntry {\n  compare();\n} catch (\\Exception \$e) {\n  log(\$e);\n  return new Unavailable(\$e->getMessage());\n}\n";
+
+        $this->assertSame([], $scanner->scanSource($source, 'Ok.php'));
+    }
+
+    public function test_a_domain_literal_outside_a_catch_block_is_not_flagged(): void
+    {
+        $scanner = new FabricationScanner;
+
+        // A confidence literal in ordinary code may be a legitimate rule output;
+        // only its construction inside an error-handling branch is banned here.
+        $source = "<?php\n\$row = ['confidence' => 0.95];\n";
+
+        $this->assertSame([], $scanner->scanSource($source, 'Ok.php'));
     }
 
     public function test_an_allowlist_entry_without_a_justification_is_rejected(): void

--- a/tests/Unit/FabricationGateTest.php
+++ b/tests/Unit/FabricationGateTest.php
@@ -166,6 +166,18 @@ final class FabricationGateTest extends TestCase
         $this->assertStringContainsString('error-handling', $violations[0]->reason);
     }
 
+    public function test_it_flags_a_bracketed_field_assignment_in_a_catch_block(): void
+    {
+        $scanner = new FabricationScanner;
+
+        $source = "<?php\ntry {\n  compare();\n} catch (\\Exception \$e) {\n  \$result['confidence'] = 0.85;\n  return \$result;\n}\n";
+
+        $violations = $scanner->scanSource($source, 'Bad.php');
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('error-handling', $violations[0]->reason);
+    }
+
     public function test_an_honest_catch_block_passes(): void
     {
         $scanner = new FabricationScanner;


### PR DESCRIPTION
Ticket 09 of the *no-fabricated-data* feature — the contract phase that completes the gate. Now that every provider-backed service returns the typed `Unavailable` (tickets 06–08), the gate enforces the rule that made all of this necessary.

## The rule
An error-handling branch may **log**, **translate the exception**, or **rethrow**. It may **not** construct a value the user reads as a finding — a centimorgan count, a confidence score, a detected face, a matched record, a relationship estimate.

## Change
`FabricationScanner` now:
- `catchBlockRanges()` — brace-matches each `catch` block over the significant-token stream (handles nesting, multiple/nested catches; braces inside strings aren't single-char tokens so they don't confuse it).
- `domainValueInCatchViolation()` — inside a catch, flags a certainty/finding-vocabulary key or variable assigned a hardcoded numeric literal, including the bracketed form `$result['confidence'] = 0.85` (caught in review). A domain literal **outside** a catch is not flagged — it may be a legitimate rule output; only its construction on an error path is banned.
- The failure message explains **why** the pattern is prohibited, not merely that it is: an error is visible and recoverable, while an invented finding may be recorded as family history that outlives the software.

Verified against known-bad fixtures (array-literal, bracketed-assignment) and an honest-catch fixture (log + return `Unavailable`), so the gate cannot silently stop gating.

The tree is **green**: tickets 06–08 already turned the fabricating catches into typed-`Unavailable` returns.

## Docs
`docs/no-fabricated-data.md` records the project position — the three rules and why a fallback that invents a plausible value is worse than an error.

## Gates
- `php artisan test` — **838 passed, 12 skipped, 0 failures**.
- Pint clean; PHPStan clean (scanner lives in `tests/`, outside `paths: app` — no baseline change).
- Correctness review caught the bracketed-assignment false-negative (fixed + tested); over-engineering review: lean.