### PR TITLE
Constrain the predicted-relationship field so the prune marker cannot be forged (ticket 20)

### DIFF
--- a/app/Console/Commands/PruneNoComparisonMatchesCommand.php
+++ b/app/Console/Commands/PruneNoComparisonMatchesCommand.php
@@ -52,12 +52,11 @@ class PruneNoComparisonMatchesCommand extends Command
      * Labels that mark a row as recording something other than a real
      * comparison.
      *
-     * Caveat worth knowing before running this: predicted_relationship is a
-     * free-text TextInput on DnaMatchingResource, so a user with edit rights
-     * could in principle type one of these strings into a hand-curated row and
-     * have it pruned. Constraining that field to the estimator's own labels
-     * would close the gap; until then --dry-run and --export exist so nothing
-     * disappears unseen.
+     * predicted_relationship on DnaMatchingResource is now a Select over the
+     * estimator's own labels (RelationshipEstimator::labels()), which do not
+     * include either marker below — so a user can no longer type one of these
+     * strings into a hand-curated row and have it pruned. --dry-run and --export
+     * remain for auditing what a run would remove.
      *
      * 'Unknown (Basic Analysis)' — performBasicMatching(), when a kit could not
      * be read. This is the population this command exists for.

--- a/app/Filament/App/Resources/DnaMatchingResource.php
+++ b/app/Filament/App/Resources/DnaMatchingResource.php
@@ -7,12 +7,14 @@ use App\Filament\App\Resources\DnaMatchingResource\Pages\EditDnaMatching;
 use App\Filament\App\Resources\DnaMatchingResource\Pages\ListDnaMatchings;
 use App\Filament\App\Resources\DnaMatchingResource\Pages\ViewDnaMatching;
 use App\Models\DnaMatching;
+use App\Services\Dna\RelationshipEstimator;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
@@ -85,9 +87,25 @@ class DnaMatchingResource extends AppResource
                             ->numeric()
                             ->suffix('%')
                             ->label('Confidence Level'),
-                        TextInput::make('predicted_relationship')
-                            ->maxLength(255)
-                            ->label('Predicted Relationship'),
+                        // A Select over the estimator's own labels, not free text.
+                        // The prune command deletes rows whose predicted_relationship
+                        // matches its no-comparison marker; free text let a user forge
+                        // that marker into a hand-curated row and have it deleted.
+                        Select::make('predicted_relationship')
+                            ->label('Predicted Relationship')
+                            ->searchable()
+                            ->options(function (?DnaMatching $record): array {
+                                $labels = array_combine(RelationshipEstimator::labels(), RelationshipEstimator::labels());
+
+                                // Keep a legacy/out-of-set value selectable so editing an
+                                // old row does not blank it.
+                                $current = $record?->predicted_relationship;
+                                if ($current !== null && ! isset($labels[$current])) {
+                                    $labels[$current] = $current;
+                                }
+
+                                return $labels;
+                            }),
                         TextInput::make('shared_segments_count')
                             ->numeric()
                             ->label('Shared Segments Count'),

--- a/tests/Feature/Filament/DnaMatchingRelationshipFieldTest.php
+++ b/tests/Feature/Filament/DnaMatchingRelationshipFieldTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\DnaMatchingResource\Pages\CreateDnaMatching;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * predicted_relationship was free text, so a user could type the exact string the
+ * prune command uses as its "no comparison ran" marker into a hand-curated row and
+ * have it deleted (with its reciprocal) on the next prune. It is now a Select over
+ * the estimator's own labels, which do not include the marker.
+ */
+final class DnaMatchingRelationshipFieldTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actAsTeamMember(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    public function test_the_prune_marker_cannot_be_submitted_as_a_predicted_relationship(): void
+    {
+        $user = $this->actAsTeamMember();
+
+        Livewire::test(CreateDnaMatching::class)
+            ->fillForm([
+                'user_id' => $user->id,
+                'predicted_relationship' => 'Unknown (Basic Analysis)',
+            ])
+            ->call('create')
+            ->assertHasFormErrors(['predicted_relationship']);
+
+        $this->assertDatabaseCount('dna_matchings', 0);
+    }
+}


### PR DESCRIPTION
Ticket 20 of the *no-fabricated-data* feature.

## Problem
`predicted_relationship` was a free-text `TextInput` on `DnaMatchingResource`. The prune command (`dna:prune-no-comparison-matches`) deletes rows whose `predicted_relationship` equals its no-comparison markers (`'Unknown (Basic Analysis)'` / `'Unknown (Fallback Analysis)'`). A user who typed one of those strings into a hand-curated row — plausibly as a note that their own analysis was inconclusive — had the row deleted, **with its reciprocal**, on the next prune. The table has no soft deletes, so it is unrecoverable.

## Change
The field is now a `Select` over `RelationshipEstimator::labels()` — the estimator's own vocabulary, which does **not** include either marker — so those strings can't be entered through the form. A legacy or out-of-set stored value is added to the options for the row being edited, so **editing an old row does not blank it**. The prune command's caveat comment is updated now that the gap is closed.

Only the **App** resource had a free-text input for this field; the Admin resource exposes it as a column + filter only.

## Test
`DnaMatchingRelationshipFieldTest` — submitting the marker through the create form is rejected (`assertHasFormErrors`) and nothing is persisted. Revert-sensitive: a `TextInput` accepts the string.

## Gates
- `php artisan test` — **840 passed, 12 skipped, 0 failures**.
- Pint clean; PHPStan clean (no baseline change).
- Over-engineering review (ponytail): lean.