### PR TITLE
feat(notifications): show stored notifications in an in-app bell (ticket 19)

### DIFF
--- a/app/Notifications/AchievementUnlockedNotification.php
+++ b/app/Notifications/AchievementUnlockedNotification.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Achievement;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -49,15 +50,18 @@ class AchievementUnlockedNotification extends Notification implements ShouldQueu
      */
     public function toArray(object $notifiable): array
     {
-        return [
-            'type' => 'achievement_unlocked',
-            'achievement_id' => $this->achievement->id,
-            'achievement_key' => $this->achievement->key,
-            'achievement_name' => $this->achievement->name,
-            'achievement_description' => $this->achievement->description,
-            'achievement_icon' => $this->achievement->icon,
-            'points_awarded' => $this->achievement->points,
-            'message' => "🎉 Achievement Unlocked: {$this->achievement->name}!",
-        ];
+        return FilamentNotification::make()
+            ->title("🎉 Achievement Unlocked: {$this->achievement->name}")
+            ->icon($this->achievement->icon)
+            ->body($this->achievement->description)
+            ->getDatabaseMessage() + [
+                'type' => 'achievement_unlocked',
+                'achievement_id' => $this->achievement->id,
+                'achievement_key' => $this->achievement->key,
+                'achievement_name' => $this->achievement->name,
+                'achievement_description' => $this->achievement->description,
+                'achievement_icon' => $this->achievement->icon,
+                'points_awarded' => $this->achievement->points,
+            ];
     }
 }

--- a/app/Notifications/DnaMatchFoundNotification.php
+++ b/app/Notifications/DnaMatchFoundNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -38,10 +39,15 @@ class DnaMatchFoundNotification extends Notification implements ShouldQueue
      */
     public function toArray(object $notifiable): array
     {
-        return [
-            'type' => 'dna_match_found',
-            'count' => $this->matchCount,
-            'message' => "{$this->matchCount} new DNA match(es) found.",
-        ];
+        $noun = $this->matchCount === 1 ? 'match' : 'matches';
+
+        return FilamentNotification::make()
+            ->title('New DNA matches found')
+            ->icon('heroicon-o-puzzle-piece')
+            ->body("{$this->matchCount} new DNA {$noun} for your kit.")
+            ->getDatabaseMessage() + [
+                'type' => 'dna_match_found',
+                'count' => $this->matchCount,
+            ];
     }
 }

--- a/app/Notifications/DuplicatePersonDetectedNotification.php
+++ b/app/Notifications/DuplicatePersonDetectedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -38,10 +39,15 @@ class DuplicatePersonDetectedNotification extends Notification implements Should
      */
     public function toArray(object $notifiable): array
     {
-        return [
-            'type' => 'duplicate_person_detected',
-            'count' => $this->count,
-            'message' => "{$this->count} possible duplicate person(s) detected.",
-        ];
+        $noun = $this->count === 1 ? 'a possible duplicate person' : "{$this->count} possible duplicate people";
+
+        return FilamentNotification::make()
+            ->title('Possible duplicate people detected')
+            ->icon('heroicon-o-users')
+            ->body("Our scan found {$noun} in your family tree.")
+            ->getDatabaseMessage() + [
+                'type' => 'duplicate_person_detected',
+                'count' => $this->count,
+            ];
     }
 }

--- a/app/Notifications/RecordSuggestionNotification.php
+++ b/app/Notifications/RecordSuggestionNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -38,10 +39,15 @@ class RecordSuggestionNotification extends Notification implements ShouldQueue
      */
     public function toArray(object $notifiable): array
     {
-        return [
-            'type' => 'record_suggestion',
-            'count' => $this->count,
-            'message' => "{$this->count} new record suggestion(s) found.",
-        ];
+        $noun = $this->count === 1 ? 'a new record suggestion' : "{$this->count} new record suggestions";
+
+        return FilamentNotification::make()
+            ->title('New record suggestions')
+            ->icon('heroicon-o-document-magnifying-glass')
+            ->body("We found {$noun} for people in your tree.")
+            ->getDatabaseMessage() + [
+                'type' => 'record_suggestion',
+                'count' => $this->count,
+            ];
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -118,6 +118,10 @@ class AppPanelProvider extends PanelProvider
             // and no contrast verification.
             ->darkMode(false)
             ->emailVerification()
+            // Renders the bell that reads the notifications table. The four
+            // database-channel notifications store a Filament-shaped payload
+            // (see their toArray) so they render here instead of as empty rows.
+            ->databaseNotifications()
             ->plugin(new SocialstreamPlugin)
             ->viteTheme('resources/css/filament/app/theme.css')
             ->colors([

--- a/tests/Feature/Notifications/NotificationBellTest.php
+++ b/tests/Feature/Notifications/NotificationBellTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\Achievement;
+use App\Models\User;
+use App\Notifications\AchievementUnlockedNotification;
+use App\Notifications\DnaMatchFoundNotification;
+use App\Notifications\DuplicatePersonDetectedNotification;
+use App\Notifications\RecordSuggestionNotification;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Storing a notification is not delivering it. The database channel writes rows
+ * (see DatabaseNotificationChannelTest), but Filament's bell only renders a row
+ * whose `data` is in Filament's own shape — a bare {type, count, message} payload
+ * renders as an empty, untitled entry. Two things had to be true for a recipient
+ * to actually see their notifications: the app panel enables the bell, and every
+ * database-channel notification stores a Filament-renderable payload.
+ */
+class NotificationBellTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_the_app_panel_shows_the_notification_bell(): void
+    {
+        $this->assertTrue(Filament::getPanel('app')->hasDatabaseNotifications());
+    }
+
+    /**
+     * @return array<string, array{0: \Closure}>
+     */
+    public static function databaseNotifications(): array
+    {
+        return [
+            'dna match' => [fn () => new DnaMatchFoundNotification(3)],
+            'duplicate person' => [fn () => new DuplicatePersonDetectedNotification(2)],
+            'record suggestion' => [fn () => new RecordSuggestionNotification(4)],
+            'achievement' => [fn () => new AchievementUnlockedNotification(Achievement::create([
+                'key' => 'first_person', 'name' => 'First Person',
+                'description' => 'Added your first person.', 'icon' => 'heroicon-o-user',
+                'category' => 'tree', 'points' => 10, 'requirements' => [], 'badge_color' => 'green',
+            ]))],
+        ];
+    }
+
+    #[DataProvider('databaseNotifications')]
+    public function test_a_stored_notification_is_renderable_by_the_bell(\Closure $make): void
+    {
+        $user = User::factory()->create();
+
+        $user->notify($make());
+
+        $data = DatabaseNotification::query()->firstOrFail()->data;
+
+        // Filament reads these; without them the bell renders an empty entry.
+        $this->assertSame('filament', $data['format']);
+        $this->assertNotEmpty($data['title']);
+    }
+}


### PR DESCRIPTION
## What

In-app notifications stored correctly but nothing displayed them — no bell, no view, no route. A researcher who received a DNA match, record suggestion, duplicate alert or unlocked achievement had no way to see any of it.

**Decision: keep in-app notifications.** Enable Filament's own `databaseNotifications()` bell on the app panel (read/unread handling for free), and have the four database-channel notifications store a Filament-shaped payload (title, body, icon) so they render in the bell instead of as empty, untitled rows.

## Changes

- `AppPanelProvider`: `->databaseNotifications()`
- `DnaMatchFound`, `DuplicatePersonDetected`, `RecordSuggestion`, `AchievementUnlocked`: `toArray` now returns `FilamentNotification::make()->title()->body()->icon()->getDatabaseMessage()` merged with the domain keys existing tests/consumers rely on (`type`, `count`, `achievement_*`). The now-redundant `message` key (superseded by `body`, read by nothing) is dropped.
- `tests/Feature/Notifications/NotificationBellTest.php`: panel enables the bell; all four notifications store a renderable payload (data-provider).

## Tests

`php artisan test` — 845 passed, 12 skipped. Pint + PHPStan clean.