### PR TITLE
chore(nav): pin the app-panel navigation taxonomy and record its rationale

### DIFF
--- a/app/Filament/App/Pages/TeamMembers.php
+++ b/app/Filament/App/Pages/TeamMembers.php
@@ -60,6 +60,11 @@ class TeamMembers extends Page
     #[\Override]
     protected static ?string $navigationLabel = 'Members';
 
+    // Team membership is account/team administration — without this the page
+    // floated as an ungrouped nav item outside the ten-group taxonomy.
+    #[\Override]
+    protected static string|\UnitEnum|null $navigationGroup = '👤 Account & Settings';
+
     #[\Override]
     public static function canAccess(): bool
     {

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -131,6 +131,26 @@ class AppPanelProvider extends PanelProvider
             ->brandName(fn () => app(GeneralSettings::class)->site_name)
             ->brandLogo(asset('build/images/logo.svg')) // vite-plugin-static-copy writes to build/images/; asset('images/..') was 404 on every panel page
             ->favicon(asset('favicon.ico')) // public/favicon.ico is the only .ico that exists; images/favicon.ico was 404
+            // The app-panel navigation taxonomy. Ten groups, in this order — the
+            // single source of truth for which groups exist; each resource/page
+            // names one in its own $navigationGroup. tests/Feature/Filament/
+            // AppNavigationGroupsTest pins this exact set (a stray string cannot
+            // silently add an eleventh group; a rename here cannot orphan a file).
+            //
+            // Decisions worth their own line, because they were judgement calls:
+            //   - Research is ONE group ('📋 Research Workspace'), not two. The
+            //     earlier split into '🔍 Research & Analysis' (evidence/tools) and
+            //     '📋 Research Management' (workflow) read to users as duplicates —
+            //     both are "research" and the distinction only made sense to
+            //     someone who already knew the data model. Collapsed into one;
+            //     ordering within it carries the evidence-then-workflow intent.
+            //   - No group holds one item except '🏠 Dashboard', which is the
+            //     landing group by convention and accepted as a deliberate
+            //     singleton. The former one-item '👥 Family Reunions' group was
+            //     folded into '🎉 Community'.
+            //   - Emoji prefixes are kept but each is now distinct; the old
+            //     duplicate '👥' (Family Tree and Family Reunions) is gone, which
+            //     is what made the duplication invisible when reading one file.
             ->navigationGroups([
                 NavigationGroup::make()
                     ->label('🏠 Dashboard'),

--- a/tests/Feature/Filament/AppNavigationGroupsTest.php
+++ b/tests/Feature/Filament/AppNavigationGroupsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use Filament\Facades\Filament;
+use Tests\TestCase;
+
+/**
+ * Pins the app-panel navigation taxonomy so a stray $navigationGroup string
+ * cannot silently create an eleventh group, and a rename in the central list
+ * cannot orphan the resources that name the old string.
+ *
+ * The agreed group set and the reasoning behind it are documented above
+ * AppPanelProvider::navigationGroups().
+ */
+final class AppNavigationGroupsTest extends TestCase
+{
+    /**
+     * The one true list, in sidebar order. Editing the central list without
+     * editing this array (or vice versa) fails the build on purpose.
+     *
+     * @var list<string>
+     */
+    private const GROUPS = [
+        '🏠 Dashboard',
+        '👥 Family Tree',
+        '🗂️ GEDCOM Detail',
+        '📚 Sources & Citations',
+        '🧬 DNA & Matching',
+        '📊 Charts & Reports',
+        '📋 Research Workspace',
+        '🛠️ Data & Import',
+        '🎉 Community',
+        '👤 Account & Settings',
+    ];
+
+    public function test_the_app_panel_declares_exactly_the_agreed_groups_in_order(): void
+    {
+        $labels = array_values(array_map(
+            fn ($group): ?string => $group->getLabel(),
+            Filament::getPanel('app')->getNavigationGroups(),
+        ));
+
+        $this->assertSame(self::GROUPS, $labels);
+    }
+
+    public function test_no_resource_or_page_names_a_group_outside_the_list(): void
+    {
+        $dir = app_path('Filament/App');
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS));
+
+        $offenders = [];
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $source = (string) file_get_contents($file->getPathname());
+
+            if (! preg_match_all('/\$navigationGroup\s*=\s*[\'"]([^\'"]+)[\'"]/', $source, $matches)) {
+                continue;
+            }
+
+            foreach ($matches[1] as $group) {
+                if (! in_array($group, self::GROUPS, true)) {
+                    $offenders[] = str_replace($dir.'/', '', $file->getPathname()).": {$group}";
+                }
+            }
+        }
+
+        $this->assertSame([], $offenders, "\nGroups not in the central list:\n".implode("\n", $offenders));
+    }
+}


### PR DESCRIPTION
## What

The app-panel group taxonomy had already been consolidated in code by the time this ticket was picked up — ten clean groups, the two Research groups already merged into one `📋 Research Workspace`, the one-item `👥 Family Reunions` already folded into `🎉 Community`, the duplicate `👥` emoji gone, and every `$navigationGroup` string mapping to a group that exists (no orphans).

Rather than re-litigate a settled taxonomy, this slice **records the reasoning and pins it**, and fixes the one genuinely-ungrouped item.

## Changes

- **`AppPanelProvider`** — a comment block above `navigationGroups()` documenting the judgement calls (Research is one group, `🏠 Dashboard` is an accepted singleton, emoji kept-but-distinct), where the next person editing groups will read it.
- **`AppNavigationGroupsTest`** — the guard:
  - pins the exact ten-group set in sidebar order (a rename, reorder, or eleventh group fails the build);
  - source-scans every `$navigationGroup` string so none names a group outside the central list — checked, not eyeballed. Revert-sensitive both ways.
- **`TeamMembers` page** — had no `$navigationGroup` and floated as an ungrouped nav item; assigned to `👤 Account & Settings`.

## Verification

`php artisan test` — 850 passed, 12 skipped. Pint + PHPStan clean. Guard test confirmed to fail when a stray group string is introduced and when the central list is reordered.