### PR TITLE
fix(trees): stamp the authenticated owner on create so imports don't fail (#1548)

### DIFF
--- a/app/Models/Tree.php
+++ b/app/Models/Tree.php
@@ -45,6 +45,29 @@ class Tree extends Model
     ];
 
     /**
+     * trees.user_id is NOT NULL with no database default. Stamp the
+     * authenticated owner when a create omits it — mirroring how
+     * BelongsToTenant stamps team_id — so an import or form that forgets
+     * user_id fails safe instead of throwing "Field 'user_id' doesn't have a
+     * default value" (issue #1548). An explicit user_id (e.g. an admin acting
+     * for another user) is left untouched.
+     *
+     * Overrides boot(), not booted(): BelongsToTenant owns booted() for the
+     * global scope + team_id stamping, and a class-level booted() would shadow
+     * the trait's copy. boot() is a separate hook, so both run.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (self $tree): void {
+            if (empty($tree->user_id) && auth()->check()) {
+                $tree->user_id = auth()->id();
+            }
+        });
+    }
+
+    /**
      * Only trees the owner has opted to share publicly.
      */
     public function scopePublic(Builder $query): Builder

--- a/tests/Feature/Models/TreeStampsOwnerTest.php
+++ b/tests/Feature/Models/TreeStampsOwnerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\Tree;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * trees.user_id is NOT NULL with no database default, so a create that omits it
+ * throws "Field 'user_id' doesn't have a default value" (issue #1548, during a
+ * GEDCOM import). BelongsToTenant already stamps team_id for exactly this
+ * reason; the owner is stamped the same way from the authenticated user.
+ */
+final class TreeStampsOwnerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actAsTeamMember(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    public function test_creating_a_tree_without_a_user_id_stamps_the_authenticated_owner(): void
+    {
+        $user = $this->actAsTeamMember();
+
+        $tree = Tree::create(['name' => 'Royal92', 'description' => 'Imported tree']);
+
+        $this->assertSame($user->id, $tree->fresh()->user_id);
+    }
+
+    public function test_an_explicit_user_id_is_left_untouched(): void
+    {
+        $actor = $this->actAsTeamMember();
+        $owner = User::factory()->create();
+
+        $tree = Tree::create(['name' => 'Owned', 'description' => 'x', 'user_id' => $owner->id]);
+
+        $this->assertSame($owner->id, $tree->fresh()->user_id);
+        $this->assertNotSame($actor->id, $tree->fresh()->user_id);
+    }
+}


### PR DESCRIPTION
Fixes #1548 (the SQL error).

## Problem

`trees.user_id` is `NOT NULL` with no database default. Any create that omits it throws:

```
SQLSTATE[HY000]: General error: 1364 Field 'user_id' doesn't have a default value
(... insert into trees (is_public, name, description, team_id, ...) ...)
```

— the error reported when importing `Royal92.ged`. Note `team_id` is present in that insert (BelongsToTenant stamped it) but `user_id` is not.

## Fix

`BelongsToTenant` already auto-stamps `team_id` for exactly this reason. Stamp the owner the same way: when a `Tree` create leaves `user_id` unset and a user is authenticated, stamp `auth()->id()`. An explicit `user_id` (an admin acting for another user) is left untouched.

Implemented by overriding `boot()`, **not** `booted()` — `BelongsToTenant` owns `booted()` for the team global scope and `team_id` stamping, and a class-level `booted()` would shadow the trait's copy. `boot()` is a separate lifecycle hook, so both run (verified: tenant tests stay green).

## Tests

`TreeStampsOwnerTest` — a create without `user_id` while authenticated persists with the current user as owner (fails with the reported SQL error before the fix); an explicit `user_id` is preserved. Full suite 852 pass, 12 skipped; Pint + PHPStan clean.

## Not covered here

The issue also reports import UX ("uploads to 100%, no redirect, no job started") and data-quality wishes ("better format, names and children"). Those are separate from the SQL crash and are not reproducible from the current code's tree-creation paths — worth their own issue with a repro. This PR fixes the concrete, reproduced database error.