### PR TITLE
feat(billing): fail closed on the Stripe webhook when no secret is configured (stripe-01)

### DIFF
--- a/app/Http/Middleware/EnsureStripeWebhookIsVerifiable.php
+++ b/app/Http/Middleware/EnsureStripeWebhookIsVerifiable.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Fail closed on the Stripe webhook.
+ *
+ * Cashier's controller verifies the Stripe signature only when
+ * cashier.webhook.secret is set — with no secret it attaches no middleware and
+ * accepts every request, so a deploy that forgets STRIPE_WEBHOOK_SECRET would
+ * honour forged, unsigned events that change subscription state. This rejects
+ * the request outright when no secret is configured, so a missing secret is a
+ * hard failure rather than an open door. When a secret IS configured, Cashier's
+ * own VerifyWebhookSignature does the actual signature check.
+ */
+class EnsureStripeWebhookIsVerifiable
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (blank(config('cashier.webhook.secret'))) {
+            abort(403, 'Stripe webhook signature verification is not configured.');
+        }
+
+        return $next($request);
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -42,5 +42,6 @@
         <env name="REVERB_APP_ID" value="test"/>
         <env name="REVERB_APP_KEY" value="test"/>
         <env name="REVERB_APP_SECRET" value="test"/>
+        <env name="STRIPE_WEBHOOK_SECRET" value="whsec_test_secret"/>
     </php>
 </phpunit>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\AIMatchController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\FanChartController;
 use App\Http\Controllers\PedigreeChartController;
+use App\Http\Middleware\EnsureStripeWebhookIsVerifiable;
 use App\Livewire\DocumentTranscriptionComponent;
 use App\Livewire\FamilyTreeBuilder;
 use App\Livewire\GamificationDashboard;
@@ -61,5 +62,9 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::post('/ai/matches/{suggestion}/reject', [AIMatchController::class, 'reject'])->name('ai.matches.reject');
 });
 
-// Stripe webhook endpoint used by Laravel Cashier
-Route::post('/stripe/webhook', '\\Laravel\\Cashier\\Http\\Controllers\\WebhookController@handleWebhook');
+// Stripe webhook endpoint used by Laravel Cashier. The guard middleware makes it
+// fail closed: with no configured webhook secret the endpoint rejects everything
+// rather than accepting unsigned (forgeable) events. Cashier verifies the
+// signature itself once a secret is present.
+Route::post('/stripe/webhook', '\\Laravel\\Cashier\\Http\\Controllers\\WebhookController@handleWebhook')
+    ->middleware(EnsureStripeWebhookIsVerifiable::class);

--- a/tests/Feature/Billing/StripeWebhookSignatureTest.php
+++ b/tests/Feature/Billing/StripeWebhookSignatureTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Billing;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+/**
+ * The /stripe/webhook endpoint changes subscription state, so only genuinely
+ * Stripe-signed requests may reach it.
+ *
+ * Cashier's controller applies its signature check only when
+ * cashier.webhook.secret is set. That is fail-open: a deploy that forgets
+ * STRIPE_WEBHOOK_SECRET attaches no middleware, so a forged, unsigned event is
+ * accepted and can flip a user's subscription. A guard middleware makes the
+ * endpoint fail closed — no configured secret means no webhook is honoured.
+ *
+ * STRIPE_WEBHOOK_SECRET is set in phpunit.xml so the signature path is live for
+ * the signed/unsigned cases; the last test clears it to prove the fail-closed
+ * guard.
+ */
+final class StripeWebhookSignatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SECRET = 'whsec_test_secret';
+
+    public function test_an_unsigned_webhook_is_rejected(): void
+    {
+        $this->postJson('/stripe/webhook', ['type' => 'invoice.payment_succeeded'])
+            ->assertForbidden();
+    }
+
+    public function test_a_wrongly_signed_webhook_is_rejected(): void
+    {
+        $payload = json_encode(['type' => 'invoice.payment_succeeded', 'data' => ['object' => []]]);
+
+        $this->postWebhook($payload, 't='.time().',v1=deadbeefdeadbeef')->assertForbidden();
+    }
+
+    public function test_a_correctly_signed_webhook_is_accepted(): void
+    {
+        // An event type Cashier has no handler for -> its missingMethod() path
+        // returns 200 without touching the database, isolating this test to the
+        // signature check alone.
+        $payload = json_encode(['id' => 'evt_test', 'type' => 'charge.succeeded', 'data' => ['object' => []]]);
+        $timestamp = time();
+        $signature = hash_hmac('sha256', "{$timestamp}.{$payload}", self::SECRET);
+
+        $this->postWebhook($payload, "t={$timestamp},v1={$signature}")->assertOk();
+    }
+
+    public function test_the_endpoint_fails_closed_when_no_secret_is_configured(): void
+    {
+        config(['cashier.webhook.secret' => null]);
+
+        // A perfectly-formed but unverifiable request must still be rejected,
+        // not accepted — a missing secret is a misconfiguration, not permission.
+        $payload = json_encode(['id' => 'evt_test', 'type' => 'charge.succeeded', 'data' => ['object' => []]]);
+
+        $this->postWebhook($payload, 't='.time().',v1=whatever')->assertForbidden();
+    }
+
+    /**
+     * POST a raw body so the bytes match what the signature was computed over —
+     * postJson would re-encode and break the signature.
+     */
+    private function postWebhook(string $rawBody, string $signature): TestResponse
+    {
+        return $this->call(
+            'POST',
+            '/stripe/webhook',
+            [], [], [],
+            ['HTTP_STRIPE_SIGNATURE' => $signature, 'CONTENT_TYPE' => 'application/json'],
+            $rawBody,
+        );
+    }
+}


### PR DESCRIPTION
Stripe production board, slice 01 of 4. Spec: `.scratch/stripe-production/spec.md`.

## Problem

The `/stripe/webhook` endpoint changes subscription state. Cashier attaches its `VerifyWebhookSignature` middleware **only when `cashier.webhook.secret` is set** — with no secret it attaches nothing and accepts every request. A deploy that forgets `STRIPE_WEBHOOK_SECRET` therefore honours forged, unsigned events (verified: an unsigned POST returned **200**).

The ticket's original premise (published `config/cashier.php` dropped the webhook block) was **wrong** — Cashier's `mergeConfigFrom` backfills it, so the secret already reads from env. The actual hole is **fail-open when the secret is absent**.

## Fix

A guard middleware `EnsureStripeWebhookIsVerifiable` on the route rejects the request when no secret is configured — the endpoint now **fails closed**. When a secret is present, Cashier's own signature check runs unchanged. No config-file change needed.

## Tests

`StripeWebhookSignatureTest` — unsigned rejected, wrongly-signed rejected, correctly-signed accepted, and (revert-sensitive) rejected when the secret is unset. `STRIPE_WEBHOOK_SECRET` set in `phpunit.xml` so the signature path is live.

`php artisan test` — 856 passed, 12 skipped. Pint + PHPStan clean.