### PR TITLE
feat(billing): add a Stripe Billing portal link for subscribers (stripe-02)

### DIFF
--- a/app/Filament/App/Pages/PremiumDashboardPage.php
+++ b/app/Filament/App/Pages/PremiumDashboardPage.php
@@ -78,6 +78,16 @@ class PremiumDashboardPage extends Page
                 ->action('cancelSubscription');
         }
 
+        // Only a real Stripe customer has a portal; a local-trial premium user
+        // has no stripe_id, so offering it would try to create a customer / fail.
+        if ($user->hasStripeId()) {
+            $actions[] = Action::make('manageBilling')
+                ->label('Manage Billing')
+                ->icon('heroicon-o-credit-card')
+                ->color('primary')
+                ->action('manageBilling');
+        }
+
         $actions[] = Action::make('downgrade')
             ->label('Downgrade to Free')
             ->icon('heroicon-o-arrow-down-circle')
@@ -89,6 +99,21 @@ class PremiumDashboardPage extends Page
             ->action('downgradeToFree');
 
         return $actions;
+    }
+
+    public function manageBilling(): void
+    {
+        try {
+            $portal = app(SubscriptionService::class)->createBillingPortalRedirect(Auth::user());
+
+            $this->redirect($portal->getTargetUrl());
+        } catch (Exception) {
+            Notification::make()
+                ->title('Billing Error')
+                ->body('Unable to open the billing portal. Please try again.')
+                ->danger()
+                ->send();
+        }
     }
 
     public function cancelSubscription(): void

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\User;
+use Illuminate\Http\RedirectResponse;
 use Laravel\Cashier\Subscription;
 
 class SubscriptionService
@@ -151,6 +152,18 @@ class SubscriptionService
                 'success_url' => route('filament.app.pages.premium-dashboard'),
                 'cancel_url' => route('filament.app.pages.subscription'),
             ]);
+    }
+
+    /**
+     * Redirect the user to Stripe's hosted Billing portal to manage their card,
+     * view invoices, and cancel (ADR 0001 — the app does not render these). Only
+     * meaningful for a user who is already a Stripe customer.
+     */
+    public function createBillingPortalRedirect(User $user): RedirectResponse
+    {
+        return $user->redirectToBillingPortal(
+            route('filament.app.pages.premium-dashboard')
+        );
     }
 
     /**

--- a/tests/Feature/Filament/BillingPortalTest.php
+++ b/tests/Feature/Filament/BillingPortalTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Pages\PremiumDashboardPage;
+use App\Models\User;
+use App\Services\SubscriptionService;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\RedirectResponse;
+use Livewire\Livewire;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * A subscriber manages their card and views invoices in Stripe's hosted Billing
+ * portal (ADR 0001), reached from the premium dashboard. This asserts the action
+ * hands off to the portal; the actual portal is Stripe's, so the Cashier call is
+ * stubbed at the service seam (mirroring the checkout test).
+ */
+final class BillingPortalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_manage_billing_redirects_to_the_stripe_billing_portal(): void
+    {
+        // premium.enabled short-circuits the dashboard's mount() redirects so the
+        // page renders; stripe_id makes the user a real Stripe customer.
+        config(['premium.enabled' => true]);
+        $user = User::factory()->withPersonalTeam()->create(['stripe_id' => 'cus_test']);
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        $mock = Mockery::mock(SubscriptionService::class)->makePartial();
+        $mock->shouldReceive('createBillingPortalRedirect')
+            ->once()
+            ->andReturn(new RedirectResponse('https://billing.stripe.test/session'));
+        $this->app->instance(SubscriptionService::class, $mock);
+
+        Livewire::actingAs($user)
+            ->test(PremiumDashboardPage::class)
+            ->call('manageBilling')
+            ->assertRedirect('https://billing.stripe.test/session');
+    }
+}


### PR DESCRIPTION
Stripe production board, slice 02 of 4. Spec: `.scratch/stripe-production/spec.md`, ADR 0001.

## What

Subscribers had no way to update their card or view invoices in-app. Per **ADR 0001**, a **"Manage Billing"** action redirects to Stripe's hosted **Billing portal** (`redirectToBillingPortal`) — no in-app card forms or invoice list.

## Where

`PremiumDashboardPage`, beside cancel/resume/downgrade — where existing subscribers manage their subscription. (`SubscriptionPage` is the subscribe/trial page and redirects premium users away, so the portal does not belong there — a correction to the ticket's wording.)

Gated on `hasStripeId()` so a local-trial premium user (no Stripe customer) is not offered a portal that would fail.

## Tests

`BillingPortalTest` — the action redirects to the portal URL, Cashier call stubbed at the `SubscriptionService` seam (mirrors the checkout test), no live Stripe call.

`php artisan test` — 853 passed, 12 skipped. Pint + PHPStan clean.