### PR TITLE
feat(billing): notify subscribers of failed payments and ended subscriptions (stripe-03)

### DIFF
--- a/app/Listeners/SendSubscriptionWebhookNotifications.php
+++ b/app/Listeners/SendSubscriptionWebhookNotifications.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Models\User;
+use App\Notifications\SubscriptionEndedNotification;
+use App\Notifications\SubscriptionPaymentFailedNotification;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Events\WebhookReceived;
+
+/**
+ * Notifies a subscriber about the two Stripe events that affect them directly.
+ * Cashier's controller already keeps subscription state in sync; this only adds
+ * the user-facing notification. Payment retries and dunning stay with Stripe.
+ */
+class SendSubscriptionWebhookNotifications
+{
+    public function handle(WebhookReceived $event): void
+    {
+        $type = $event->payload['type'] ?? null;
+
+        $notification = match ($type) {
+            'invoice.payment_failed' => new SubscriptionPaymentFailedNotification,
+            'customer.subscription.deleted' => new SubscriptionEndedNotification,
+            default => null,
+        };
+
+        if ($notification === null) {
+            return;
+        }
+
+        $customerId = $event->payload['data']['object']['customer'] ?? null;
+
+        // Cashier types findBillable() as the Billable trait; in this app the only
+        // billable model is User, which is what carries Notifiable.
+        /** @var User|null $user */
+        $user = $customerId ? Cashier::findBillable($customerId) : null;
+
+        $user?->notify($notification);
+    }
+}

--- a/app/Notifications/SubscriptionEndedNotification.php
+++ b/app/Notifications/SubscriptionEndedNotification.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class SubscriptionEndedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database', 'mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your premium subscription has ended')
+            ->greeting('Subscription ended')
+            ->line('Your premium subscription has ended and your account is now on the free tier.')
+            ->line('All your family tree data is kept — you can resubscribe any time to restore premium features.')
+            ->action('Resubscribe', url('/app'))
+            ->line('Thanks for being a premium member.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return FilamentNotification::make()
+            ->title('Subscription ended')
+            ->icon('heroicon-o-x-circle')
+            ->body('Your premium subscription has ended. Your data is kept; resubscribe any time.')
+            ->getDatabaseMessage() + [
+                'type' => 'subscription_ended',
+            ];
+    }
+}

--- a/app/Notifications/SubscriptionPaymentFailedNotification.php
+++ b/app/Notifications/SubscriptionPaymentFailedNotification.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class SubscriptionPaymentFailedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database', 'mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your subscription payment failed')
+            ->greeting('Action needed')
+            ->line('We could not process the payment for your premium subscription.')
+            ->line('Stripe will retry automatically, but updating your card now avoids losing access.')
+            ->action('Update your card', url('/app'))
+            ->line('If your card is fine, you can ignore this — the retry may already have succeeded.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return FilamentNotification::make()
+            ->title('Payment failed')
+            ->icon('heroicon-o-exclamation-triangle')
+            ->body('Your premium subscription payment failed. Update your card to keep access.')
+            ->getDatabaseMessage() + [
+                'type' => 'subscription_payment_failed',
+            ];
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -7,10 +7,12 @@ namespace App\Providers;
 use App\Events\AchievementUnlocked;
 use App\Events\UserLeveledUp;
 use App\Listeners\AchievementUnlockedListener;
+use App\Listeners\SendSubscriptionWebhookNotifications;
 use App\Listeners\UserLeveledUpListener;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Laravel\Cashier\Events\WebhookReceived;
 use Override;
 
 class EventServiceProvider extends ServiceProvider
@@ -25,6 +27,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         UserLeveledUp::class => [
             UserLeveledUpListener::class,
+        ],
+        WebhookReceived::class => [
+            SendSubscriptionWebhookNotifications::class,
         ],
     ];
 

--- a/tests/Feature/Billing/SubscriptionWebhookNotificationsTest.php
+++ b/tests/Feature/Billing/SubscriptionWebhookNotificationsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Billing;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+/**
+ * When a payment fails or a subscription ends, the affected user is told nothing
+ * — a lapsed card silently drops them to the free tier. A listener on Cashier's
+ * WebhookReceived turns the two user-facing Stripe events into notifications.
+ *
+ * Driven through the real signed webhook endpoint (STRIPE_WEBHOOK_SECRET is set
+ * in phpunit.xml) rather than dispatching the event directly, so the whole path
+ * — signature, Cashier controller, listener — is exercised.
+ */
+final class SubscriptionWebhookNotificationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SECRET = 'whsec_test_secret';
+
+    public function test_a_failed_payment_notifies_the_customer(): void
+    {
+        $user = User::factory()->create(['stripe_id' => 'cus_failed']);
+
+        $this->postSignedWebhook([
+            'id' => 'evt_1',
+            'type' => 'invoice.payment_failed',
+            'data' => ['object' => ['customer' => 'cus_failed']],
+        ])->assertOk();
+
+        $notification = $user->fresh()->notifications->firstOrFail();
+        $this->assertSame('subscription_payment_failed', $notification->data['type']);
+        $this->assertSame('filament', $notification->data['format']);
+    }
+
+    public function test_a_deleted_subscription_notifies_the_customer(): void
+    {
+        $user = User::factory()->create(['stripe_id' => 'cus_ended']);
+
+        $this->postSignedWebhook([
+            'id' => 'evt_2',
+            'type' => 'customer.subscription.deleted',
+            'data' => ['object' => ['customer' => 'cus_ended']],
+        ])->assertOk();
+
+        $notification = $user->fresh()->notifications->firstOrFail();
+        $this->assertSame('subscription_ended', $notification->data['type']);
+        $this->assertSame('filament', $notification->data['format']);
+    }
+
+    public function test_an_event_for_an_unknown_customer_notifies_no_one(): void
+    {
+        $this->postSignedWebhook([
+            'id' => 'evt_3',
+            'type' => 'invoice.payment_failed',
+            'data' => ['object' => ['customer' => 'cus_nobody']],
+        ])->assertOk();
+
+        $this->assertDatabaseCount('notifications', 0);
+    }
+
+    private function postSignedWebhook(array $payload): TestResponse
+    {
+        $body = json_encode($payload);
+        $timestamp = time();
+        $signature = hash_hmac('sha256', "{$timestamp}.{$body}", self::SECRET);
+
+        return $this->call(
+            'POST',
+            '/stripe/webhook',
+            [], [], [],
+            ['HTTP_STRIPE_SIGNATURE' => "t={$timestamp},v1={$signature}", 'CONTENT_TYPE' => 'application/json'],
+            $body,
+        );
+    }
+}


### PR DESCRIPTION
Stripe production board, slice 03 of 4. Spec: `.scratch/stripe-production/spec.md`.

## What

When a payment failed or a subscription ended, the affected user was told nothing — a lapsed card silently dropped them to the free tier. A listener on Cashier's `WebhookReceived` turns the two user-facing Stripe events into notifications:

- `invoice.payment_failed` → "payment failed, update your card"
- `customer.subscription.deleted` → "your subscription has ended"

Cashier's controller keeps doing the state sync; the listener only adds the notification. Retries and dunning stay with Stripe. Both notifications go on `database` + `mail` with a Filament-shaped payload, so they render in the in-app bell like the existing notifications.

## Tests

Driven through the **real signed webhook endpoint**: a failed-payment and a deleted-subscription event each store the right notification for the customer resolved from the Stripe id; an event for an unknown customer notifies no one.

`php artisan test` — 859 passed, 12 skipped. Pint + PHPStan clean.

Depends on #1602 (slice 01, merged) for signed webhooks.