### PR TITLE
feat(billing): pause and resume a subscription, revoking access while paused (stripe-04)

### DIFF
--- a/app/Filament/App/Pages/PremiumDashboardPage.php
+++ b/app/Filament/App/Pages/PremiumDashboardPage.php
@@ -78,6 +78,27 @@ class PremiumDashboardPage extends Page
                 ->action('cancelSubscription');
         }
 
+        // Pause/resume: a paused subscription can be resumed; an active,
+        // unpaused one can be paused. Pausing stops billing AND access (ADR 0002).
+        $subscription = $user->subscription('premium');
+        if ($subscription && $subscription->paused_at !== null) {
+            $actions[] = Action::make('unpause')
+                ->label('Resume from Pause')
+                ->icon('heroicon-o-play')
+                ->color('success')
+                ->action('unpauseSubscription');
+        } elseif ($subscription && $subscription->stripe_status === 'active' && ! $subscription->canceled()) {
+            $actions[] = Action::make('pause')
+                ->label('Pause Subscription')
+                ->icon('heroicon-o-pause')
+                ->color('warning')
+                ->requiresConfirmation()
+                ->modalHeading('Pause Subscription')
+                ->modalDescription('Billing stops and premium access is paused until you resume. Your data is kept.')
+                ->modalSubmitActionLabel('Yes, pause')
+                ->action('pauseSubscription');
+        }
+
         // Only a real Stripe customer has a portal; a local-trial premium user
         // has no stripe_id, so offering it would try to create a customer / fail.
         if ($user->hasStripeId()) {
@@ -111,6 +132,44 @@ class PremiumDashboardPage extends Page
             Notification::make()
                 ->title('Billing Error')
                 ->body('Unable to open the billing portal. Please try again.')
+                ->danger()
+                ->send();
+        }
+    }
+
+    public function pauseSubscription(): void
+    {
+        try {
+            app(SubscriptionService::class)->pausePremiumSubscription(Auth::user());
+
+            Notification::make()
+                ->title('Subscription Paused')
+                ->body('Billing and premium access are paused until you resume.')
+                ->warning()
+                ->send();
+        } catch (Exception) {
+            Notification::make()
+                ->title('Pause Error')
+                ->body('There was an error pausing your subscription. Please try again.')
+                ->danger()
+                ->send();
+        }
+    }
+
+    public function unpauseSubscription(): void
+    {
+        try {
+            app(SubscriptionService::class)->unpausePremiumSubscription(Auth::user());
+
+            Notification::make()
+                ->title('Subscription Resumed')
+                ->body('Your subscription is active again and premium access is restored.')
+                ->success()
+                ->send();
+        } catch (Exception) {
+            Notification::make()
+                ->title('Resume Error')
+                ->body('There was an error resuming your subscription. Please try again.')
                 ->danger()
                 ->send();
         }

--- a/app/Listeners/SyncSubscriptionPauseState.php
+++ b/app/Listeners/SyncSubscriptionPauseState.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use Laravel\Cashier\Events\WebhookReceived;
+use Laravel\Cashier\Subscription;
+
+/**
+ * Keeps the local paused_at marker in step with Stripe's pause_collection.
+ *
+ * Stripe leaves a paused subscription's status as "active", so Cashier's own
+ * sync does not record the pause. isPremium() revokes access while paused
+ * (ADR 0002), and this is how it learns the state — from every
+ * customer.subscription.updated, whether the pause was triggered by the app's
+ * button or in the Stripe dashboard, so Stripe stays the source of truth.
+ */
+class SyncSubscriptionPauseState
+{
+    public function handle(WebhookReceived $event): void
+    {
+        if (($event->payload['type'] ?? null) !== 'customer.subscription.updated') {
+            return;
+        }
+
+        $object = $event->payload['data']['object'] ?? [];
+        $stripeId = $object['id'] ?? null;
+
+        if ($stripeId === null) {
+            return;
+        }
+
+        $subscription = Subscription::where('stripe_id', $stripeId)->first();
+
+        if ($subscription === null) {
+            return;
+        }
+
+        $isPaused = ($object['pause_collection'] ?? null) !== null;
+        $subscription->update(['paused_at' => $isPaused ? now() : null]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -331,9 +331,11 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
             return true;
         }
 
-        // Active Stripe subscription (not cancelled / not expired)
+        // Active Stripe subscription (not cancelled / not expired). A paused
+        // subscription keeps Stripe status "active" but must not confer access
+        // (ADR 0002) — billing and access are held together while paused.
         if ($this->subscribed('premium')) {
-            return true;
+            return $this->subscription('premium')?->paused_at === null;
         }
 
         // Local trial still running

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -8,6 +8,7 @@ use App\Events\AchievementUnlocked;
 use App\Events\UserLeveledUp;
 use App\Listeners\AchievementUnlockedListener;
 use App\Listeners\SendSubscriptionWebhookNotifications;
+use App\Listeners\SyncSubscriptionPauseState;
 use App\Listeners\UserLeveledUpListener;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -30,6 +31,7 @@ class EventServiceProvider extends ServiceProvider
         ],
         WebhookReceived::class => [
             SendSubscriptionWebhookNotifications::class,
+            SyncSubscriptionPauseState::class,
         ],
     ];
 

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -155,6 +155,36 @@ class SubscriptionService
     }
 
     /**
+     * Pause the user's premium subscription (Stripe pause_collection). Billing
+     * stops and premium access is revoked while paused (ADR 0002). The local
+     * paused_at marker is set here for immediate effect; the webhook keeps it in
+     * sync if the pause is also changed from Stripe's side.
+     */
+    public function pausePremiumSubscription(User $user): void
+    {
+        $subscription = $user->subscription('premium');
+
+        if ($subscription && $subscription->paused_at === null) {
+            $subscription->updateStripeSubscription(['pause_collection' => ['behavior' => 'void']]);
+            $subscription->update(['paused_at' => now()]);
+        }
+    }
+
+    /**
+     * Resume a paused subscription: clear Stripe's pause_collection and the local
+     * marker, restoring billing and premium access.
+     */
+    public function unpausePremiumSubscription(User $user): void
+    {
+        $subscription = $user->subscription('premium');
+
+        if ($subscription && $subscription->paused_at !== null) {
+            $subscription->updateStripeSubscription(['pause_collection' => '']);
+            $subscription->update(['paused_at' => null]);
+        }
+    }
+
+    /**
      * Redirect the user to Stripe's hosted Billing portal to manage their card,
      * view invoices, and cancel (ADR 0001 — the app does not render these). Only
      * meaningful for a user who is already a Stripe customer.

--- a/database/migrations/2026_07_20_000001_add_paused_at_to_subscriptions_table.php
+++ b/database/migrations/2026_07_20_000001_add_paused_at_to_subscriptions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Records when a subscription is paused (Stripe pause_collection). Stripe leaves
+ * a paused subscription's status as "active", so this local marker is how the
+ * app knows to revoke premium access while paused (ADR 0002). Kept in sync from
+ * the customer.subscription.updated webhook.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('subscriptions', function (Blueprint $table): void {
+            if (! Schema::hasColumn('subscriptions', 'paused_at')) {
+                $table->timestamp('paused_at')->nullable()->after('ends_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('subscriptions', function (Blueprint $table): void {
+            if (Schema::hasColumn('subscriptions', 'paused_at')) {
+                $table->dropColumn('paused_at');
+            }
+        });
+    }
+};

--- a/tests/Feature/Billing/PausedSubscriptionAccessTest.php
+++ b/tests/Feature/Billing/PausedSubscriptionAccessTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Billing;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Subscription;
+use Tests\TestCase;
+
+/**
+ * ADR 0002: a paused subscription revokes premium access. Stripe leaves a paused
+ * subscription's status as "active", so isPremium() must consult the local
+ * paused_at marker rather than trusting subscribed() alone.
+ */
+final class PausedSubscriptionAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function subscribe(User $user): Subscription
+    {
+        return $user->subscriptions()->create([
+            'type' => 'premium',
+            'stripe_id' => 'sub_'.$user->id,
+            'stripe_status' => 'active',
+            'stripe_price' => 'price_premium_monthly',
+            'quantity' => 1,
+        ]);
+    }
+
+    public function test_an_active_subscription_is_premium(): void
+    {
+        $user = User::factory()->create();
+        $this->subscribe($user);
+
+        $this->assertTrue($user->fresh()->isPremium());
+    }
+
+    public function test_a_paused_subscription_is_not_premium(): void
+    {
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user);
+
+        $subscription->update(['paused_at' => now()]);
+
+        $this->assertFalse($user->fresh()->isPremium());
+    }
+
+    public function test_resuming_from_pause_restores_premium(): void
+    {
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user);
+        $subscription->update(['paused_at' => now()]);
+
+        $subscription->update(['paused_at' => null]);
+
+        $this->assertTrue($user->fresh()->isPremium());
+    }
+}

--- a/tests/Feature/Billing/SubscriptionPauseWebhookTest.php
+++ b/tests/Feature/Billing/SubscriptionPauseWebhookTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Billing;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Events\WebhookReceived;
+use Laravel\Cashier\Subscription;
+use Tests\TestCase;
+
+/**
+ * Stripe is the source of truth for pause state, so a pause (or resume) done
+ * anywhere — the app's own button or the Stripe dashboard — arrives as
+ * customer.subscription.updated and must be reflected in the local paused_at
+ * marker that isPremium() reads (ADR 0002).
+ *
+ * Driven by dispatching WebhookReceived rather than posting to the endpoint:
+ * Cashier's own customer.subscription.updated handler expects a full Stripe
+ * subscription object (items, price, …), which is not what is under test here.
+ * The signed-endpoint path itself is covered by StripeWebhookSignatureTest; this
+ * isolates the pause-sync listener.
+ */
+final class SubscriptionPauseWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function subscribe(User $user): Subscription
+    {
+        return $user->subscriptions()->create([
+            'type' => 'premium',
+            'stripe_id' => 'sub_x',
+            'stripe_status' => 'active',
+            'stripe_price' => 'price_premium_monthly',
+            'quantity' => 1,
+        ]);
+    }
+
+    public function test_a_pause_collection_update_marks_the_subscription_paused(): void
+    {
+        $subscription = $this->subscribe(User::factory()->create());
+
+        event(new WebhookReceived([
+            'type' => 'customer.subscription.updated',
+            'data' => ['object' => ['id' => 'sub_x', 'pause_collection' => ['behavior' => 'void']]],
+        ]));
+
+        $this->assertNotNull($subscription->fresh()->paused_at);
+    }
+
+    public function test_clearing_pause_collection_unpauses_the_subscription(): void
+    {
+        $subscription = $this->subscribe(User::factory()->create());
+        $subscription->update(['paused_at' => now()]);
+
+        event(new WebhookReceived([
+            'type' => 'customer.subscription.updated',
+            'data' => ['object' => ['id' => 'sub_x', 'pause_collection' => null]],
+        ]));
+
+        $this->assertNull($subscription->fresh()->paused_at);
+    }
+
+    public function test_an_update_for_an_unknown_subscription_is_ignored(): void
+    {
+        event(new WebhookReceived([
+            'type' => 'customer.subscription.updated',
+            'data' => ['object' => ['id' => 'sub_missing', 'pause_collection' => ['behavior' => 'void']]],
+        ]));
+
+        $this->assertDatabaseCount('subscriptions', 0);
+    }
+}

--- a/tests/Feature/Filament/SubscriptionPauseButtonsTest.php
+++ b/tests/Feature/Filament/SubscriptionPauseButtonsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Pages\PremiumDashboardPage;
+use App\Models\User;
+use App\Services\SubscriptionService;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * A subscriber pauses/resumes from the premium dashboard. The Stripe call is
+ * stubbed at the service seam (it would hit the Stripe API); the buttons only
+ * need to delegate to it.
+ */
+final class SubscriptionPauseButtonsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function premiumUser(bool $paused): User
+    {
+        config(['premium.enabled' => true]);
+        $user = User::factory()->withPersonalTeam()->create(['stripe_id' => 'cus_x']);
+        $user->subscriptions()->create([
+            'type' => 'premium',
+            'stripe_id' => 'sub_x',
+            'stripe_status' => 'active',
+            'stripe_price' => 'price_premium_monthly',
+            'quantity' => 1,
+            'paused_at' => $paused ? now() : null,
+        ]);
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    public function test_the_pause_button_pauses_via_the_service(): void
+    {
+        $this->premiumUser(paused: false);
+
+        $mock = Mockery::mock(SubscriptionService::class)->makePartial();
+        $mock->shouldReceive('pausePremiumSubscription')->once();
+        $this->app->instance(SubscriptionService::class, $mock);
+
+        Livewire::test(PremiumDashboardPage::class)->call('pauseSubscription');
+    }
+
+    public function test_the_resume_button_unpauses_via_the_service(): void
+    {
+        $this->premiumUser(paused: true);
+
+        $mock = Mockery::mock(SubscriptionService::class)->makePartial();
+        $mock->shouldReceive('unpausePremiumSubscription')->once();
+        $this->app->instance(SubscriptionService::class, $mock);
+
+        Livewire::test(PremiumDashboardPage::class)->call('unpauseSubscription');
+    }
+}


### PR DESCRIPTION
Stripe production board, slice 04 of 4 (final). Spec: `.scratch/stripe-production/spec.md`, ADR 0002.

## What

A subscriber who needed a break could only cancel and lose their place. They can now **pause** and **resume** from the premium dashboard. While paused, billing stops and **premium access is revoked** (ADR 0002) — a hold on both, not free access.

## How

- Pause/resume use Stripe `pause_collection` (Cashier has no first-class pause), set via `SubscriptionService`, reflected immediately in a local `paused_at` marker (new nullable column on `subscriptions`).
- `isPremium()` consults `paused_at`: Stripe leaves a paused subscription's status `active`, so `subscribed()` alone would wrongly grant access. **Do not simplify back to a bare `subscribed()` check.**
- `SyncSubscriptionPauseState` keeps `paused_at` in step with Stripe on every `customer.subscription.updated`, so a pause done in the Stripe dashboard is reflected too — Stripe stays the source of truth.
- Pause is offered only for an active, non-cancelled subscription.

## Tests

- `PausedSubscriptionAccessTest` — paused → not premium; active → premium; resume restores.
- `SubscriptionPauseWebhookTest` — the pause-sync listener sets/clears `paused_at` (event seam; Cashier's `updated` handler needs a full object, so the signed-endpoint path is covered separately in slice 01).
- `SubscriptionPauseButtonsTest` — the dashboard buttons delegate to the service.

`php artisan test` — 868 passed, 12 skipped. Pint + PHPStan clean.

Depends on #1604 (slice 03, merged) for the webhook listener plumbing.