### PR TITLE
fix(security-headers): only send upgrade-insecure-requests over HTTPS

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -42,7 +42,7 @@ final class SecurityHeaders
 
         // Content Security Policy
         // Allow inline styles/scripts for Filament/Livewire compatibility; tighten per route if needed
-        $response->headers->set('Content-Security-Policy', implode('; ', [
+        $csp = [
             "default-src 'self'",
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
@@ -53,8 +53,16 @@ final class SecurityHeaders
             "object-src 'none'",
             "base-uri 'self'",
             "form-action 'self'",
-            'upgrade-insecure-requests',
-        ]));
+        ];
+
+        // Only over HTTPS: on a plain-http host this directive makes the browser
+        // refetch http-served assets (Vite build output) over https, which the
+        // http dev environment does not serve — assets fail to load.
+        if ($request->isSecure()) {
+            $csp[] = 'upgrade-insecure-requests';
+        }
+
+        $response->headers->set('Content-Security-Policy', implode('; ', $csp));
 
         // HSTS — only set over HTTPS
         if ($request->isSecure()) {

--- a/tests/Feature/Http/SecurityHeadersTest.php
+++ b/tests/Feature/Http/SecurityHeadersTest.php
@@ -52,4 +52,27 @@ class SecurityHeadersTest extends TestCase
 
         $this->assertNull($response->headers->get('X-Powered-By'));
     }
+
+    public function test_plain_http_does_not_force_insecure_request_upgrades(): void
+    {
+        // upgrade-insecure-requests on a plain-http response makes the browser
+        // refetch http-served assets over https, which the http dev host does not
+        // serve — the reported CORS/blocked asset. It only belongs on https.
+        $response = $this->get('http://localhost/');
+
+        $this->assertStringNotContainsString(
+            'upgrade-insecure-requests',
+            (string) $response->headers->get('Content-Security-Policy')
+        );
+    }
+
+    public function test_https_still_upgrades_insecure_requests(): void
+    {
+        $response = $this->get('https://localhost/');
+
+        $this->assertStringContainsString(
+            'upgrade-insecure-requests',
+            (string) $response->headers->get('Content-Security-Policy')
+        );
+    }
 }


### PR DESCRIPTION
## Symptom

```
Access to script at 'https://genealogy.test/build/assets/app-*.js' from origin
'http://genealogy.test' has been blocked by CORS policy: No 'Access-Control-Allow-Origin'…
```

## Cause

`SecurityHeaders` set the CSP `upgrade-insecure-requests` directive **unconditionally**. On a plain-http host (the dev environment serves `genealogy.test` over http), that directive makes the browser refetch the Vite build assets over **https** — which nothing serves there — so the http page treats the https asset as cross-origin and blocks it. The app itself emits correct http asset URLs (verified); the browser upgrade is what breaks it.

## Fix

`upgrade-insecure-requests` only makes sense over https — exactly like the HSTS header two lines below, which was already gated on `isSecure()`. Gate the directive the same way. HTTPS behaviour is unchanged.

## Tests

`SecurityHeadersTest` — plain-http response has no `upgrade-insecure-requests`; https response still does.

`php artisan test` — 870 passed, 12 skipped. Pint + PHPStan clean.

## After merge

Reload with a hard refresh — the browser may have cached the upgraded https asset request.