### PR TITLE
feat(gedcom): start import on upload and show live progress in Import Logs

### DIFF
--- a/app/Filament/App/Resources/GedcomResource.php
+++ b/app/Filament/App/Resources/GedcomResource.php
@@ -70,7 +70,8 @@ class GedcomResource extends AppResource
                 Section::make('Import Family Tree')
                     ->description(
                         'Import your family tree data by uploading a GEDCOM (.ged) or GrampsXML (.gramps, .xml) file. '
-                        .'The file will be processed in the background and you will be redirected to the Import Logs page to monitor progress.'
+                        .'The import starts as soon as the upload finishes — no need to click a button — and you are '
+                        .'taken to the Import Logs page to monitor progress.'
                     )
                     ->schema([
                         FileUpload::make('filename')
@@ -103,13 +104,24 @@ class GedcomResource extends AppResource
                             ->directory('gedcom-form-imports')
                             ->visibility('private')
                             ->helperText('Supported formats: GEDCOM (.ged), GrampsXML (.gramps, .xml) — max 100 MB')
+                            // Submit as soon as the file finishes uploading — no
+                            // "Create" click. Reuses the create action, so the file
+                            // is stored and the import dispatched by the same path as
+                            // before, then getRedirectUrl() sends the user to the
+                            // Import Logs page. Only on the create page (this form is
+                            // shared with editing).
+                            ->afterStateUpdated(function ($state, $livewire): void {
+                                if (filled($state) && $livewire instanceof CreateGedcom) {
+                                    $livewire->create();
+                                }
+                            })
                             ->columnSpanFull(),
                     ])
                     ->columnSpanFull(),
 
                 Section::make('Processing note')
                     ->description(
-                        'After submitting, your file will be queued for processing and you will be redirected to the '
+                        'Once the upload finishes, your file is queued for processing and you are redirected to the '
                         .'Import Logs page where you can monitor the import progress in real time. '
                         .'Large files may take several minutes to process.'
                     )

--- a/app/Filament/App/Resources/ImportJobResource.php
+++ b/app/Filament/App/Resources/ImportJobResource.php
@@ -96,6 +96,12 @@ class ImportJobResource extends AppResource
                     ->since(),
             ])
             ->defaultSort('created_at', 'desc')
+            // Live progress: re-query every few seconds so status (queue ->
+            // processing -> complete) and the progress % update on screen while
+            // the queued import job advances them, without a manual refresh.
+            // ponytail: polling, not push. A real-time channel already exists
+            // (GedComProgressSent) but needs Reverb, which is off by default.
+            ->poll('5s')
             ->filters([])
             ->recordActions([])
             ->toolbarActions([]);

--- a/tests/Feature/Filament/GedcomUploadRedirectTest.php
+++ b/tests/Feature/Filament/GedcomUploadRedirectTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\GedcomResource\Pages\CreateGedcom;
+use App\Filament\App\Resources\ImportJobResource;
+use App\Jobs\ImportGedcom;
+use App\Jobs\ImportGrampsXml;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * The import should start — and the user should land on the Import Logs page —
+ * the moment the file finishes uploading, without a "Create" click.
+ */
+final class GedcomUploadRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actAsTeamMember(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    public function test_uploading_a_gedcom_queues_the_import_and_redirects_to_import_logs(): void
+    {
+        Storage::fake('private');
+        Bus::fake();
+        $user = $this->actAsTeamMember();
+
+        Livewire::test(CreateGedcom::class)
+            ->set('data.filename', [UploadedFile::fake()->create('tree.ged', 10)])
+            ->assertRedirect(ImportJobResource::getUrl('index'));
+
+        // Exactly one import per upload — the auto-submit must not re-fire.
+        Bus::assertDispatchedTimes(ImportGedcom::class, 1);
+        $this->assertDatabaseCount('importjobs', 1);
+        $this->assertDatabaseHas('importjobs', ['user_id' => $user->id]);
+    }
+
+    public function test_uploading_a_gramps_file_dispatches_the_gramps_import(): void
+    {
+        Storage::fake('private');
+        Bus::fake();
+        $this->actAsTeamMember();
+
+        Livewire::test(CreateGedcom::class)
+            ->set('data.filename', [UploadedFile::fake()->create('tree.gramps', 10)])
+            ->assertRedirect(ImportJobResource::getUrl('index'));
+
+        Bus::assertDispatched(ImportGrampsXml::class);
+    }
+}

--- a/tests/Feature/Filament/Resources/GedcomResourceTest.php
+++ b/tests/Feature/Filament/Resources/GedcomResourceTest.php
@@ -60,9 +60,9 @@ class GedcomResourceTest extends TestCase
 
         $this->actAsTeamMember();
 
+        // The upload itself submits (afterStateUpdated -> create), no button click.
         Livewire::test(CreateGedcom::class)
             ->set('data.filename', [UploadedFile::fake()->createWithContent($filename, $contents)])
-            ->call('create')
             ->assertHasNoFormErrors();
 
         $this->assertSame(1, Gedcom::count(), "Uploading {$filename} created no record.");
@@ -134,9 +134,9 @@ class GedcomResourceTest extends TestCase
 
         $this->actAsTeamMember();
 
+        // Redirect follows the upload directly — no "Create" click.
         Livewire::test(CreateGedcom::class)
             ->set('data.filename', [UploadedFile::fake()->createWithContent('tree.ged', self::GEDCOM)])
-            ->call('create')
             ->assertRedirect(ImportJobResource::getUrl('index'));
     }
 


### PR DESCRIPTION
Two UX changes to the GEDCOM/GRAMPS import flow.

## 1. Import starts on upload (no "Create" click)

The FileUpload's `afterStateUpdated` triggers the create action — guarded to the create page, since the form is shared with editing. This reuses the existing, tested save path (store file → dispatch import → `getRedirectUrl`), so the user lands on the **Import Logs** page the moment the upload finishes.

## 2. Live progress in Import Logs

The Import Logs table already had a status badge and a progress %, but never refreshed. Added `->poll('5s')` so status (`queue → processing → complete`) and progress update on screen while the queued job advances them — no manual refresh.

> Polling, not push. A real-time channel (`GedComProgressSent`) exists but needs Reverb, which is off by default — polling works today with no infra.

## Tests

- `GedcomUploadRedirectTest` — upload of a `.ged` / `.gramps` dispatches the right job **exactly once** (no re-fire) and redirects to Import Logs.
- The two existing set-then-create tests updated to the new upload-submits behaviour.

`php artisan test` — 872 passed, 12 skipped. Pint + PHPStan clean.