### PR TITLE
feat(billing): configurable card-required premium with managed prices (#1614)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,23 +73,27 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 STRIPE_KEY=pk_test_your_stripe_publishable_key_here
 STRIPE_SECRET=sk_test_your_stripe_secret_key_here
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
-# the variable below is provided for legacy compatibility; the code now
-# reads from SUBSCRIPTION_PREMIUM_STRIPE_PRICE_ID first but will fall back
-# to STRIPE_PREMIUM_PRICE_ID if the newer name is not set.
-STRIPE_PREMIUM_PRICE_ID=price_premium_monthly
-STRIPE_PREMIUM_PRODUCT_ID=prod_premium
 
 # Premium Feature Configuration
 PREMIUM_ENABLED=false
-SUBSCRIPTION_PREMIUM_PRICE=$2.99
-SUBSCRIPTION_PREMIUM_INTERVAL=month
+
+# Require a card before granting premium access. When true (default), the no-card
+# trial is disabled and premium is only reachable via a card checkout (issue #1614).
+SUBSCRIPTION_REQUIRE_CARD=true
+
+# Trial length in days. 0 = no trial: the subscriber is charged immediately.
 SUBSCRIPTION_PREMIUM_TRIAL_DAYS=14
-SUBSCRIPTION_PREMIUM_STRIPE_PRICE_ID=price_premium_monthly
+
+# The app creates and owns the Stripe Product/Price from these amounts — no Stripe
+# Dashboard setup required. Amounts are in minor units (cents); the displayed price
+# is derived from them so it can't drift from the charge. Currency = CASHIER_CURRENCY.
+SUBSCRIPTION_PREMIUM_PRODUCT_NAME=Premium
+SUBSCRIPTION_PREMIUM_MONTHLY_AMOUNT=299
+SUBSCRIPTION_PREMIUM_YEARLY_AMOUNT=2999
 
 # Cashier Configuration
 CASHIER_CURRENCY=usd
 CASHIER_CURRENCY_LOCALE=en_US
-CASHIER_STRIPE_SUBSCRIPTION_DEFAULT_PRICE_ID=price_premium_monthly
 
 # Social Media OAuth Configuration
 # Facebook

--- a/app/Filament/App/Pages/SubscriptionPage.php
+++ b/app/Filament/App/Pages/SubscriptionPage.php
@@ -4,7 +4,6 @@ namespace App\Filament\App\Pages;
 
 use App\Services\SubscriptionService;
 use Exception;
-use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Http\RedirectResponse;
@@ -32,6 +31,9 @@ class SubscriptionPage extends Page
 
     #[\Override]
     protected static ?string $slug = 'subscription';
+
+    /** Chosen billing interval for checkout: 'month' or 'year'. */
+    public string $interval = 'month';
 
     public function mount(): void
     {
@@ -74,25 +76,33 @@ class SubscriptionPage extends Page
     #[\Override]
     protected function getHeaderActions(): array
     {
-        return [
-            Action::make('checkout')
-                ->label('Subscribe with Card')
-                ->icon('heroicon-o-credit-card')
-                ->color('success')
-                ->size('lg')
-                ->action('redirectToCheckout'),
+        // CTAs live in the page body (interval toggle + Subscribe, plus the
+        // optional no-card trial button); no header actions.
+        return [];
+    }
 
-            Action::make('subscribe')
-                ->label('Start Premium Trial')
-                ->icon('heroicon-o-star')
-                ->color('primary')
-                ->size('lg')
-                ->action('startTrial'),
-        ];
+    /** Whether the no-card trial button should be shown/allowed. */
+    public function showTrialButton(): bool
+    {
+        $service = app(SubscriptionService::class);
+
+        return ! $service->requiresCard() && $service->trialDays() > 0;
     }
 
     public function startTrial(): void
     {
+        // Server-side guard: even if the button is hidden, the Livewire action
+        // must not grant premium without a card when the deployment requires one.
+        if (! $this->showTrialButton()) {
+            Notification::make()
+                ->title('Card required')
+                ->body('A payment method is required to start Premium. Please subscribe with a card.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
         try {
             $subscriptionService = app(SubscriptionService::class);
             $user = Auth::user();
@@ -140,9 +150,13 @@ class SubscriptionPage extends Page
     {
         $user = Auth::user();
 
-        // delegate the heavy lifting to our service which already knows about
-        // configuration and the proper price identifier
-        $checkout = app(SubscriptionService::class)->createCheckoutRedirect($user);
+        $interval = in_array($this->interval, SubscriptionService::INTERVALS, true)
+            ? $this->interval
+            : 'month';
+
+        // delegate the heavy lifting to our service which resolves the managed
+        // price for the chosen interval
+        $checkout = app(SubscriptionService::class)->createCheckoutRedirect($user, $interval);
 
         if (is_object($checkout) && property_exists($checkout, 'url') && $checkout->url) {
             $this->redirect($checkout->url);

--- a/app/Filament/App/Pages/TrialExpiredPage.php
+++ b/app/Filament/App/Pages/TrialExpiredPage.php
@@ -61,7 +61,7 @@ class TrialExpiredPage extends Page
     {
         return [
             Action::make('subscribe')
-                ->label('Subscribe Now – $2.99/month')
+                ->label('Subscribe Now – '.app(SubscriptionService::class)->formatPrice('month').'/month')
                 ->icon('heroicon-o-credit-card')
                 ->color('primary')
                 ->size('lg')
@@ -83,19 +83,11 @@ class TrialExpiredPage extends Page
     {
         try {
             $user = Auth::user();
-            $priceId = config('subscription.premium.stripe_price_id', 'price_premium_monthly');
 
-            $successUrl = route('filament.app.pages.premium-dashboard', ['tenant' => auth()->user()->currentTeam]);
-            $cancelUrl = route('filament.app.pages.trial-expired', ['tenant' => auth()->user()->currentTeam]);
+            // Reuse the managed-price checkout (monthly); the service resolves the
+            // Stripe price and applies the trial rule.
+            $checkout = app(SubscriptionService::class)->createCheckoutRedirect($user, 'month');
 
-            // Use Cashier to create a Stripe Checkout Session for the subscription
-            $checkout = $user->newSubscription('premium', $priceId)
-                ->checkout([
-                    'success_url' => $successUrl,
-                    'cancel_url' => $cancelUrl,
-                ]);
-
-            // Mark as premium upon successful checkout (webhook will also handle this)
             $this->redirect($checkout->url);
         } catch (Exception) {
             Notification::make()

--- a/app/Models/SubscriptionPrice.php
+++ b/app/Models/SubscriptionPrice.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A managed price: the Stripe Product/Price the app auto-creates for a billing
+ * interval so no Stripe Dashboard setup is required (ADR 0003). Global — not
+ * team-scoped.
+ */
+class SubscriptionPrice extends Model
+{
+    protected $fillable = [
+        'interval',
+        'livemode',
+        'stripe_product_id',
+        'stripe_price_id',
+        'unit_amount',
+        'currency',
+    ];
+
+    protected $casts = [
+        'livemode' => 'boolean',
+        'unit_amount' => 'integer',
+    ];
+}

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -2,47 +2,76 @@
 
 namespace App\Services;
 
+use App\Models\SubscriptionPrice;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
-use Laravel\Cashier\Subscription;
+use InvalidArgumentException;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\SubscriptionBuilder;
+use RuntimeException;
 
 class SubscriptionService
 {
-    // Price/product identifiers are stored in configuration/environment so they can
-    // be adjusted without changing code. Constants remain as fallbacks primarily for
-    // legacy usage.
-    public const PREMIUM_PRICE_ID = 'price_premium_monthly'; // default, override via env
-
-    public const PREMIUM_PRODUCT_ID = 'prod_premium'; // default, override via env
+    /** The billing intervals the premium tier is offered at. */
+    public const INTERVALS = ['month', 'year'];
 
     /**
-     * Create premium subscription with trial
-     *
-     * If a payment method is not provided, enable a local 14-day trial without
-     * contacting Stripe. This sets the user's generic trial and premium flag
-     * so premium checks work immediately. When a payment method is provided,
-     * defer to Cashier to create a real Stripe subscription.
+     * Whether a card must be taken before premium access is granted. When true,
+     * the no-card local-trial path is unavailable (issue #1614). Defaults on.
      */
-    public function createPremiumSubscription(User $user, ?string $paymentMethod = null)
+    public function requiresCard(): bool
     {
-        // Trial-only flow without requiring a payment method / Stripe setup
+        return (bool) config('subscription.premium.require_card', true);
+    }
+
+    /** Configured trial length in days; zero means no trial (immediate charge). */
+    public function trialDays(): int
+    {
+        return (int) config('subscription.premium.trial_days', 14);
+    }
+
+    /**
+     * Trial days to apply at checkout, or null to apply none. A configured length
+     * of zero yields null so Cashier never stamps a trial and Stripe charges
+     * immediately.
+     */
+    public function checkoutTrialDays(): ?int
+    {
+        $days = $this->trialDays();
+
+        return $days > 0 ? $days : null;
+    }
+
+    /**
+     * Create premium subscription.
+     *
+     * With no payment method this is the no-card local trial — granted only when
+     * the deployment does not require a card. With a payment method, defer to
+     * Cashier to create a real Stripe subscription on the managed monthly price.
+     */
+    public function createPremiumSubscription(User $user, ?string $paymentMethod = null, string $interval = 'month')
+    {
+        // No-card local trial.
         if (in_array($paymentMethod, [null, '', '0'], true)) {
-            $trialDays = config('subscription.premium.trial_days', 14);
+            if ($this->requiresCard()) {
+                // Server-side defense: the UI hides this path, but the Livewire
+                // action must not grant premium without a card either.
+                throw new RuntimeException('A payment method is required; the no-card trial is disabled.');
+            }
+
             $user->forceFill([
                 'is_premium' => true,
                 'premium_started_at' => now(),
                 // Generic trial used by Cashier's Billable::onTrial()
-                'trial_ends_at' => now()->addDays($trialDays),
+                'trial_ends_at' => now()->addDays($this->trialDays()),
             ])->save();
 
             return null;
         }
 
-        $priceId = config('subscription.premium.stripe_price_id', self::PREMIUM_PRICE_ID);
-        $trialDays = config('subscription.premium.trial_days', 14);
-
-        $subscriptionBuilder = $user->newSubscription('premium', $priceId)
-            ->trialDays($trialDays);
+        $subscriptionBuilder = $this->applyTrial(
+            $user->newSubscription('premium', $this->resolveManagedPrice($interval))
+        );
 
         $subscription = $subscriptionBuilder->create($paymentMethod);
 
@@ -53,6 +82,50 @@ class SubscriptionService
         ]);
 
         return $subscription;
+    }
+
+    /**
+     * Resolve the Stripe price id for a billing interval, creating and owning the
+     * Stripe Product/Price ourselves so no Dashboard setup is required (managed
+     * prices — ADR 0003). The (interval, livemode) record is reused across
+     * requests; because Stripe Prices are immutable, a changed configured amount
+     * auto-heals: a fresh Price is created, the stale one archived, record updated.
+     */
+    public function resolveManagedPrice(string $interval): string
+    {
+        $amount = $this->amountFor($interval);
+        $currency = $this->currency();
+        $livemode = $this->livemode();
+
+        $record = SubscriptionPrice::query()
+            ->where('interval', $interval)
+            ->where('livemode', $livemode)
+            ->first();
+
+        if ($record && $record->unit_amount === $amount && $record->currency === $currency) {
+            return $record->stripe_price_id;
+        }
+
+        // Reuse the Product across price changes; only the Price is recreated.
+        $productId = $record ? $record->stripe_product_id : $this->createStripeProduct($this->productName());
+        $priceId = $this->createStripePrice($productId, $amount, $currency, $interval);
+
+        if ($record) {
+            // Stripe Prices are immutable, so the superseded one is archived.
+            $this->archiveStripePrice($record->stripe_price_id);
+        }
+
+        SubscriptionPrice::updateOrCreate(
+            ['interval' => $interval, 'livemode' => $livemode],
+            [
+                'stripe_product_id' => $productId,
+                'stripe_price_id' => $priceId,
+                'unit_amount' => $amount,
+                'currency' => $currency,
+            ],
+        );
+
+        return $priceId;
     }
 
     /**
@@ -108,18 +181,26 @@ class SubscriptionService
     }
 
     /**
-     * Get subscription pricing information (display-only).
+     * Get subscription pricing information (display-only). Prices are derived from
+     * the configured amounts so the shown price can never drift from the charge.
      */
     public function getPricingInfo(): array
     {
-        $trialDays = config('subscription.premium.trial_days', 14);
+        $intervals = [];
+        foreach (self::INTERVALS as $interval) {
+            $intervals[$interval] = [
+                'interval' => $interval,
+                'amount' => $this->amountFor($interval),
+                'price' => $this->formatPrice($interval),
+            ];
+        }
 
         return [
             'premium' => [
                 'name' => 'Premium',
-                'price' => config('subscription.premium.price', '$2.99'),
-                'interval' => config('subscription.premium.interval', 'month'),
-                'trial_days' => $trialDays,
+                'trial_days' => $this->trialDays(),
+                'require_card' => $this->requiresCard(),
+                'intervals' => $intervals,
                 'features' => [
                     'Premium user badge',
                     'Unlimited DNA kit uploads',
@@ -128,30 +209,38 @@ class SubscriptionService
                     'Priority support',
                     'Advanced charts and reports',
                 ],
-                'stripe_price_id' => config('subscription.premium.stripe_price_id', self::PREMIUM_PRICE_ID),
             ],
         ];
     }
 
     /**
-     * Build a Stripe Checkout session redirect response.
-     *
-     * This helper is used by the Filament page to send the user straight to
-     * Stripe's hosted checkout form. The returned redirect response may be
-     * inspected or sent directly to the browser.
+     * Build a Stripe Checkout session redirect response for the chosen billing
+     * interval. Used by the Filament page to send the user to Stripe's hosted
+     * checkout form.
      */
-    public function createCheckoutRedirect($user)
+    public function createCheckoutRedirect($user, string $interval = 'month')
     {
-        $priceId = config('subscription.premium.stripe_price_id', self::PREMIUM_PRICE_ID);
-        $trialDays = config('subscription.premium.trial_days', 14);
+        $builder = $this->applyTrial(
+            $user->newSubscription('premium', $this->resolveManagedPrice($interval))
+        );
 
-        return $user
-            ->newSubscription('premium', $priceId)
-            ->trialDays($trialDays)
-            ->checkout([
-                'success_url' => route('filament.app.pages.premium-dashboard'),
-                'cancel_url' => route('filament.app.pages.subscription'),
-            ]);
+        return $builder->checkout([
+            'success_url' => route('filament.app.pages.premium-dashboard'),
+            'cancel_url' => route('filament.app.pages.subscription'),
+        ]);
+    }
+
+    /**
+     * Apply the configured trial to a subscription builder, or none when the
+     * trial length is zero (immediate charge).
+     */
+    private function applyTrial(SubscriptionBuilder $builder): SubscriptionBuilder
+    {
+        if (($trialDays = $this->checkoutTrialDays()) !== null) {
+            $builder->trialDays($trialDays);
+        }
+
+        return $builder;
     }
 
     /**
@@ -238,5 +327,70 @@ class SubscriptionService
                 'advanced_charts' => $isPremium,
             ],
         ];
+    }
+
+    /** Configured amount (minor units) for a billing interval. */
+    public function amountFor(string $interval): int
+    {
+        $this->assertInterval($interval);
+
+        return (int) config("subscription.premium.amounts.{$interval}");
+    }
+
+    /** Human-readable price string derived from amount + currency. */
+    public function formatPrice(string $interval): string
+    {
+        return Cashier::formatAmount($this->amountFor($interval), $this->currency());
+    }
+
+    private function assertInterval(string $interval): void
+    {
+        if (! in_array($interval, self::INTERVALS, true)) {
+            throw new InvalidArgumentException("Unsupported billing interval: {$interval}");
+        }
+    }
+
+    private function currency(): string
+    {
+        return strtolower((string) config('cashier.currency', 'usd'));
+    }
+
+    private function productName(): string
+    {
+        return (string) config('subscription.premium.product_name', 'Premium');
+    }
+
+    /**
+     * Whether we are operating against Stripe live mode, inferred from the secret
+     * key. Both secret (sk_) and restricted (rk_) keys carry a `_live_` / `_test_`
+     * segment, so match on that rather than an `sk_live_` prefix. Keeps test-mode
+     * and live-mode price records apart.
+     */
+    protected function livemode(): bool
+    {
+        return str_contains((string) config('cashier.secret'), '_live_');
+    }
+
+    // --- Stripe SDK seam (overridden in tests so managed-price logic runs without HTTP) ---
+
+    protected function createStripeProduct(string $name): string
+    {
+        return Cashier::stripe()->products->create(['name' => $name])->id;
+    }
+
+    protected function createStripePrice(string $productId, int $amount, string $currency, string $interval): string
+    {
+        return Cashier::stripe()->prices->create([
+            'product' => $productId,
+            'unit_amount' => $amount,
+            'currency' => $currency,
+            'recurring' => ['interval' => $interval],
+        ])->id;
+    }
+
+    protected function archiveStripePrice(string $priceId): void
+    {
+        // Stripe Prices are immutable; a superseded price is deactivated, not edited.
+        Cashier::stripe()->prices->update($priceId, ['active' => false]);
     }
 }

--- a/config/subscription.php
+++ b/config/subscription.php
@@ -4,22 +4,24 @@ declare(strict_types=1);
 
 return [
     'premium' => [
-        // Display-only price string, e.g., "$2.99"
-        'price' => env('SUBSCRIPTION_PREMIUM_PRICE', '$2.99'),
+        // Require a card before granting premium access. When true, the no-card
+        // local-trial path is unavailable and the only route to premium is a
+        // Stripe checkout with a card on file. Default true for this platform.
+        'require_card' => (bool) env('SUBSCRIPTION_REQUIRE_CARD', true),
 
-        // Billing interval label, e.g., "month" or "year"
-        'interval' => env('SUBSCRIPTION_PREMIUM_INTERVAL', 'month'),
-
-        // Trial days for local trial (no payment method)
+        // Trial length in days. Zero is a first-class value meaning "no trial" —
+        // the subscriber is charged immediately at checkout.
         'trial_days' => (int) env('SUBSCRIPTION_PREMIUM_TRIAL_DAYS', 14),
 
-        // Stripe price id for real subscriptions created via Cashier
-        'stripe_price_id' => env(
-            'SUBSCRIPTION_PREMIUM_STRIPE_PRICE_ID',
-            // the `.env.example` file historically used STRIPE_PREMIUM_PRICE_ID; keep
-            // the old name around for backwards compatibility so deployments that
-            // haven't updated yet still work.
-            env('STRIPE_PREMIUM_PRICE_ID', env('CASHIER_STRIPE_SUBSCRIPTION_DEFAULT_PRICE_ID'))
-        ),
+        // Name of the Stripe Product the app auto-creates (managed price, ADR 0003).
+        'product_name' => env('SUBSCRIPTION_PREMIUM_PRODUCT_NAME', 'Premium'),
+
+        // Price amounts in minor units (cents), per billing interval. The app
+        // creates/owns the Stripe Price from these; the displayed price string is
+        // derived from the amount + currency so it can never drift from the charge.
+        'amounts' => [
+            'month' => (int) env('SUBSCRIPTION_PREMIUM_MONTHLY_AMOUNT', 299),
+            'year' => (int) env('SUBSCRIPTION_PREMIUM_YEARLY_AMOUNT', 2999),
+        ],
     ],
 ];

--- a/database/migrations/2026_07_24_120000_create_subscription_prices_table.php
+++ b/database/migrations/2026_07_24_120000_create_subscription_prices_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Records the Stripe Product/Price the application creates and owns for each
+ * billing interval (managed prices — see ADR 0003). Global platform pricing,
+ * so no team_id: every subscriber pays the same amount for a given interval.
+ * Keyed by (interval, livemode) so test-mode and live-mode ids never collide.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subscription_prices', function (Blueprint $table) {
+            $table->id();
+            $table->string('interval'); // 'month' | 'year'
+            $table->boolean('livemode');
+            $table->string('stripe_product_id');
+            $table->string('stripe_price_id');
+            $table->integer('unit_amount'); // minor units (cents)
+            $table->string('currency', 3);
+            $table->timestamps();
+
+            $table->unique(['interval', 'livemode']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscription_prices');
+    }
+};

--- a/resources/views/filament/app/pages/subscription-page.blade.php
+++ b/resources/views/filament/app/pages/subscription-page.blade.php
@@ -1,4 +1,8 @@
 <x-filament-panels::page>
+    @php
+        $pricing = $this->getPricingData()['premium'];
+        $selected = $pricing['intervals'][$this->interval] ?? $pricing['intervals']['month'];
+    @endphp
     <div class="space-y-8">
         <!-- Premium Features Overview -->
         <div class="bg-gradient-to-r from-purple-500 to-pink-500 rounded-lg p-8 text-white">
@@ -12,15 +16,17 @@
                 <p class="text-lg opacity-90 mb-6">Unlock powerful genealogy tools and unlimited features</p>
 
                 <div class="bg-white/10 rounded-lg p-4 inline-block">
-                    <div class="text-4xl font-bold">{{ $this->getPricingData()['premium']['price'] }}</div>
-                    <div class="text-sm opacity-75">per {{ $this->getPricingData()['premium']['interval'] }}</div>
+                    <div class="text-4xl font-bold">{{ $selected['price'] }}</div>
+                    <div class="text-sm opacity-75">per {{ $selected['interval'] }}</div>
                 </div>
 
-                <div class="mt-6">
-                    <div class="bg-yellow-400 text-yellow-900 px-4 py-2 rounded-full inline-block font-semibold">
-                        🎉 {{ $this->getPricingData()['premium']['trial_days'] }}-Day Free Trial
+                @if($pricing['trial_days'] > 0)
+                    <div class="mt-6">
+                        <div class="bg-yellow-400 text-yellow-900 px-4 py-2 rounded-full inline-block font-semibold">
+                            🎉 {{ $pricing['trial_days'] }}-Day Free Trial
+                        </div>
                     </div>
-                </div>
+                @endif
             </div>
         </div>
 
@@ -72,9 +78,39 @@
 
                 <div class="text-center mb-6">
                     <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Premium</h3>
-                    <p class="text-gray-500 dark:text-gray-400">{{ $this->getPricingData()['premium']['trial_days'] }}-day free trial</p>
-                    <div class="text-3xl font-bold text-gray-900 dark:text-white mt-2">{{ $this->getPricingData()['premium']['price'] }}</div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">per {{ $this->getPricingData()['premium']['interval'] }}</p>
+                    @if($pricing['trial_days'] > 0)
+                        <p class="text-gray-500 dark:text-gray-400">{{ $pricing['trial_days'] }}-day free trial</p>
+                    @endif
+                    <div class="text-3xl font-bold text-gray-900 dark:text-white mt-2">{{ $selected['price'] }}</div>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">per {{ $selected['interval'] }}</p>
+
+                    <!-- Billing interval toggle -->
+                    <div class="mt-4 inline-flex rounded-lg border border-purple-200 dark:border-purple-700 p-1" role="group" aria-label="Billing interval">
+                        <button
+                            type="button"
+                            wire:click="$set('interval', 'month')"
+                            @class([
+                                'px-4 py-1.5 text-sm font-medium rounded-md transition',
+                                'bg-purple-600 text-white' => $this->interval === 'month',
+                                'text-gray-600 dark:text-gray-300' => $this->interval !== 'month',
+                            ])
+                            aria-pressed="{{ $this->interval === 'month' ? 'true' : 'false' }}"
+                        >
+                            Monthly · {{ $pricing['intervals']['month']['price'] }}
+                        </button>
+                        <button
+                            type="button"
+                            wire:click="$set('interval', 'year')"
+                            @class([
+                                'px-4 py-1.5 text-sm font-medium rounded-md transition',
+                                'bg-purple-600 text-white' => $this->interval === 'year',
+                                'text-gray-600 dark:text-gray-300' => $this->interval !== 'year',
+                            ])
+                            aria-pressed="{{ $this->interval === 'year' ? 'true' : 'false' }}"
+                        >
+                            Yearly · {{ $pricing['intervals']['year']['price'] }}
+                        </button>
+                    </div>
                 </div>
 
                 <ul class="space-y-3">
@@ -91,25 +127,6 @@
                         color="primary"
                         size="lg"
                         class="w-full mb-2"
-                        wire:click="startTrial"
-                        wire:target="startTrial"
-                        wire:loading.attr="disabled"
-                        aria-label="Start {{ $this->getPricingData()['premium']['trial_days'] }}-day free trial"
-                    >
-                        <span class="inline-flex items-center justify-center">
-                            <svg wire:loading wire:target="startTrial" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-                            </svg>
-                            <span wire:loading.remove wire:target="startTrial">Start Free Trial</span>
-                            <span wire:loading wire:target="startTrial">Starting…</span>
-                        </span>
-                    </x-filament::button>
-
-                    <x-filament::button
-                        color="secondary"
-                        size="lg"
-                        class="w-full"
                         wire:click="redirectToCheckout"
                         wire:target="redirectToCheckout"
                         wire:loading.attr="disabled"
@@ -120,12 +137,33 @@
                                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
                             </svg>
-                            <span wire:loading.remove wire:target="redirectToCheckout">Subscribe with Card</span>
+                            <span wire:loading.remove wire:target="redirectToCheckout">Subscribe {{ ucfirst($selected['interval']) }}ly · {{ $selected['price'] }}</span>
                             <span wire:loading wire:target="redirectToCheckout">Redirecting…</span>
                         </span>
                     </x-filament::button>
 
-                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">No credit card required for the trial</p>
+                    @if($this->showTrialButton())
+                        <x-filament::button
+                            color="secondary"
+                            size="lg"
+                            class="w-full"
+                            wire:click="startTrial"
+                            wire:target="startTrial"
+                            wire:loading.attr="disabled"
+                            aria-label="Start {{ $pricing['trial_days'] }}-day free trial"
+                        >
+                            <span class="inline-flex items-center justify-center">
+                                <svg wire:loading wire:target="startTrial" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+                                </svg>
+                                <span wire:loading.remove wire:target="startTrial">Start Free Trial</span>
+                                <span wire:loading wire:target="startTrial">Starting…</span>
+                            </span>
+                        </x-filament::button>
+
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">No credit card required for the trial</p>
+                    @endif
                 </div>
             </div>
         </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,9 +4,10 @@
     // Real values, not hardcoded. The old page claimed "£4.99" and a "7-day"
     // trial while config said $2.99 / 14 days.
     $settings = app(\App\Settings\GeneralSettings::class);
-    $price = config('subscription.premium.price', '$2.99');
-    $interval = config('subscription.premium.interval', 'month');
+    $price = app(\App\Services\SubscriptionService::class)->formatPrice('month');
+    $interval = 'month';
     $trialDays = (int) config('subscription.premium.trial_days', 14);
+    $requiresCard = (bool) config('subscription.premium.require_card', true);
 @endphp
 
 @section('content')
@@ -249,7 +250,11 @@
                 </p>
 
                 <p class="mt-3 text-label text-ink-muted">
-                    <span class="tabular-nums">{{ $trialDays }}</span>-day free trial. No card required to start.
+                    @if($trialDays > 0)
+                        <span class="tabular-nums">{{ $trialDays }}</span>-day free trial.@unless($requiresCard) No card required to start.@endunless
+                    @else
+                        Billed at checkout. Cancel anytime.
+                    @endif
                 </p>
 
                 @guest

--- a/resources/views/pages/subscription.blade.php
+++ b/resources/views/pages/subscription.blade.php
@@ -2,9 +2,10 @@
 
 @php
     $settings = app(\App\Settings\GeneralSettings::class);
-    $price = config('subscription.premium.price', '$2.99');
-    $interval = config('subscription.premium.interval', 'month');
+    $price = app(\App\Services\SubscriptionService::class)->formatPrice('month');
+    $interval = 'month';
     $trialDays = (int) config('subscription.premium.trial_days', 14);
+    $requiresCard = (bool) config('subscription.premium.require_card', true);
     $repo = 'https://github.com/liberu-genealogy/genealogy-laravel';
 
     // Every line below was checked against the code that enforces it.
@@ -41,7 +42,7 @@
     $faqs = [
         [
             'q' => 'What happens when the trial ends?',
-            'a' => "Nothing is taken from you. The DNA tools stop, and everything else — your tree, your sources, your media, your export — carries on working exactly as before. No card is required to start the trial, so nothing can be charged at the end of it.",
+            'a' => "Nothing is taken from you. The DNA tools stop, and everything else — your tree, your sources, your media, your export — carries on working exactly as before.".($requiresCard ? '' : ' No card is required to start the trial, so nothing can be charged at the end of it.'),
         ],
         [
             'q' => 'Can I cancel?',
@@ -129,7 +130,11 @@
             <div class="flex flex-col bg-surface p-8 lg:p-10">
                 <h3 class="text-title text-ink">Premium</h3>
                 <p class="mt-1 text-label text-ink-muted">
-                    <span class="tabular-nums">{{ $trialDays }}</span>-day trial. No card to start.
+                    @if($trialDays > 0)
+                        <span class="tabular-nums">{{ $trialDays }}</span>-day trial.@unless($requiresCard) No card to start.@endunless
+                    @else
+                        Billed at checkout.
+                    @endif
                 </p>
 
                 <p class="mt-6 flex items-baseline gap-2">
@@ -211,7 +216,7 @@
                 Start free. Add DNA when you need it.
             </h2>
             <p class="mt-4 max-w-[52ch] text-pretty text-body text-emerald-100">
-                The trial takes no card, and the free tier isn't a countdown. If premium turns out
+                @unless($requiresCard)The trial takes no card, and the free tier isn't a countdown.@else The free tier isn't a countdown.@endunless If premium turns out
                 not to be worth it, the tree you built is still yours and still exports.
             </p>
         </div>

--- a/resources/views/pages/termsandconditions.blade.php
+++ b/resources/views/pages/termsandconditions.blade.php
@@ -9,8 +9,8 @@
     // §6 stated "£4.99" and a "7-day" trial. Both were false — the app charges
     // $2.99 on a 14-day trial. Read from the same config as the pricing page and
     // Cashier so the terms cannot drift away from what is actually billed.
-    $price = config('subscription.premium.price', '$2.99');
-    $interval = config('subscription.premium.interval', 'month');
+    $price = app(\App\Services\SubscriptionService::class)->formatPrice('month');
+    $interval = 'month';
     $trialDays = (int) config('subscription.premium.trial_days', 14);
 @endphp
 

--- a/tests/Feature/Billing/SubscriptionServiceTest.php
+++ b/tests/Feature/Billing/SubscriptionServiceTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Billing;
+
+use App\Models\SubscriptionPrice;
+use App\Models\User;
+use App\Services\SubscriptionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * The Stripe SDK is folded into SubscriptionService behind three protected
+ * seams (createStripeProduct / createStripePrice / archiveStripePrice). This
+ * fake overrides them so the managed-price logic (create, reuse, auto-heal)
+ * can be exercised with zero Stripe HTTP. livemode is pinned to test mode.
+ */
+final class FakeStripeSubscriptionService extends SubscriptionService
+{
+    public array $created = [];
+
+    public array $archived = [];
+
+    public int $productCalls = 0;
+
+    protected function livemode(): bool
+    {
+        return false;
+    }
+
+    protected function createStripeProduct(string $name): string
+    {
+        $this->productCalls++;
+
+        return 'prod_fake_'.$this->productCalls;
+    }
+
+    protected function createStripePrice(string $productId, int $amount, string $currency, string $interval): string
+    {
+        $this->created[] = compact('productId', 'amount', 'currency', 'interval');
+
+        return 'price_fake_'.count($this->created);
+    }
+
+    protected function archiveStripePrice(string $priceId): void
+    {
+        $this->archived[] = $priceId;
+    }
+}
+
+final class SubscriptionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function service(): FakeStripeSubscriptionService
+    {
+        return new FakeStripeSubscriptionService;
+    }
+
+    public function test_resolve_managed_price_creates_product_and_price_and_records_it(): void
+    {
+        config()->set('subscription.premium.amounts.month', 299);
+        config()->set('cashier.currency', 'usd');
+
+        $service = $this->service();
+        $priceId = $service->resolveManagedPrice('month');
+
+        $this->assertSame('price_fake_1', $priceId);
+        $this->assertSame(1, $service->productCalls);
+        $this->assertCount(1, $service->created);
+
+        $this->assertDatabaseHas('subscription_prices', [
+            'interval' => 'month',
+            'livemode' => false,
+            'stripe_price_id' => 'price_fake_1',
+            'unit_amount' => 299,
+            'currency' => 'usd',
+        ]);
+    }
+
+    public function test_resolve_managed_price_reuses_existing_record_without_touching_stripe(): void
+    {
+        config()->set('subscription.premium.amounts.month', 299);
+        config()->set('cashier.currency', 'usd');
+
+        SubscriptionPrice::create([
+            'interval' => 'month',
+            'livemode' => false,
+            'stripe_product_id' => 'prod_existing',
+            'stripe_price_id' => 'price_existing',
+            'unit_amount' => 299,
+            'currency' => 'usd',
+        ]);
+
+        $service = $this->service();
+        $priceId = $service->resolveManagedPrice('month');
+
+        $this->assertSame('price_existing', $priceId);
+        $this->assertSame(0, $service->productCalls);
+        $this->assertCount(0, $service->created);
+        $this->assertCount(0, $service->archived);
+    }
+
+    public function test_resolve_managed_price_auto_heals_when_amount_changes(): void
+    {
+        config()->set('cashier.currency', 'usd');
+        SubscriptionPrice::create([
+            'interval' => 'month',
+            'livemode' => false,
+            'stripe_product_id' => 'prod_existing',
+            'stripe_price_id' => 'price_old',
+            'unit_amount' => 299,
+            'currency' => 'usd',
+        ]);
+
+        // Operator raises the price.
+        config()->set('subscription.premium.amounts.month', 399);
+
+        $service = $this->service();
+        $priceId = $service->resolveManagedPrice('month');
+
+        // New price created against the SAME product; old price archived.
+        $this->assertSame('price_fake_1', $priceId);
+        $this->assertSame(0, $service->productCalls, 'existing product should be reused');
+        $this->assertSame('prod_existing', $service->created[0]['productId']);
+        $this->assertSame(399, $service->created[0]['amount']);
+        $this->assertSame(['price_old'], $service->archived);
+
+        $this->assertDatabaseHas('subscription_prices', [
+            'interval' => 'month',
+            'stripe_price_id' => 'price_fake_1',
+            'unit_amount' => 399,
+        ]);
+        $this->assertDatabaseMissing('subscription_prices', ['stripe_price_id' => 'price_old']);
+    }
+
+    public function test_resolve_managed_price_rejects_unknown_interval(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->service()->resolveManagedPrice('weekly');
+    }
+
+    public function test_requires_card_reflects_config(): void
+    {
+        config()->set('subscription.premium.require_card', true);
+        $this->assertTrue($this->service()->requiresCard());
+
+        config()->set('subscription.premium.require_card', false);
+        $this->assertFalse($this->service()->requiresCard());
+    }
+
+    public function test_checkout_trial_days_is_null_when_zero_and_value_otherwise(): void
+    {
+        config()->set('subscription.premium.trial_days', 0);
+        $this->assertNull($this->service()->checkoutTrialDays());
+
+        config()->set('subscription.premium.trial_days', 14);
+        $this->assertSame(14, $this->service()->checkoutTrialDays());
+    }
+
+    public function test_local_trial_is_rejected_when_card_is_required(): void
+    {
+        config()->set('subscription.premium.require_card', true);
+        $user = User::factory()->create();
+
+        $this->expectException(RuntimeException::class);
+
+        try {
+            $this->service()->createPremiumSubscription($user);
+        } finally {
+            $this->assertFalse((bool) $user->fresh()->is_premium, 'no premium granted without a card');
+        }
+    }
+
+    public function test_local_trial_is_granted_when_card_not_required(): void
+    {
+        config()->set('subscription.premium.require_card', false);
+        config()->set('subscription.premium.trial_days', 14);
+        $user = User::factory()->create();
+
+        $result = $this->service()->createPremiumSubscription($user);
+
+        $this->assertNull($result);
+        $user->refresh();
+        $this->assertTrue((bool) $user->is_premium);
+        $this->assertNotNull($user->trial_ends_at);
+    }
+}

--- a/tests/Feature/Filament/SubscriptionPageTest.php
+++ b/tests/Feature/Filament/SubscriptionPageTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Filament;
 use App\Filament\App\Pages\SubscriptionPage;
 use App\Models\User;
 use App\Services\SubscriptionService;
+use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -13,8 +14,19 @@ class SubscriptionPageTest extends TestCase
 {
     use RefreshDatabase;
 
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
     public function test_start_trial_sets_user_to_premium_and_redirects(): void
     {
+        // The no-card trial only exists when the deployment doesn't require a card.
+        config()->set('subscription.premium.require_card', false);
         $user = User::factory()->withPersonalTeam()->create();
 
         Livewire::actingAs($user)
@@ -25,10 +37,39 @@ class SubscriptionPageTest extends TestCase
         $this->assertTrue($user->fresh()->is_premium);
     }
 
-    public function test_redirect_to_checkout_uses_service_and_config_price(): void
+    public function test_trial_button_hidden_when_card_required(): void
+    {
+        config()->set('subscription.premium.require_card', true);
+        $this->actingUser();
+
+        Livewire::test(SubscriptionPage::class)
+            ->assertSee('Subscribe')
+            ->assertDontSee('Start Free Trial');
+    }
+
+    public function test_start_trial_rejected_server_side_when_card_required(): void
+    {
+        config()->set('subscription.premium.require_card', true);
+        $user = $this->actingUser();
+
+        Livewire::test(SubscriptionPage::class)->call('startTrial');
+
+        $this->assertFalse((bool) $user->fresh()->is_premium, 'no premium granted without a card');
+    }
+
+    public function test_no_trial_button_when_trial_days_zero(): void
+    {
+        config()->set('subscription.premium.require_card', false);
+        config()->set('subscription.premium.trial_days', 0);
+        $this->actingUser();
+
+        Livewire::test(SubscriptionPage::class)
+            ->assertDontSee('Start Free Trial');
+    }
+
+    public function test_redirect_to_checkout_uses_service_for_selected_interval(): void
     {
         $user = User::factory()->withPersonalTeam()->create();
-        config(['subscription.premium.stripe_price_id' => 'page_price_456']);
 
         $mockCheckout = new class
         {
@@ -38,26 +79,31 @@ class SubscriptionPageTest extends TestCase
         $pricingInfo = [
             'premium' => [
                 'name' => 'Premium',
-                'price' => '$2.99',
-                'interval' => 'month',
                 'trial_days' => 14,
+                'require_card' => true,
+                'intervals' => [
+                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99'],
+                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99'],
+                ],
                 'features' => [],
-                'stripe_price_id' => 'page_price_456',
             ],
         ];
 
         $mockService = \Mockery::mock(SubscriptionService::class);
         $mockService->allows('getPricingInfo')->andReturn($pricingInfo);
+        $mockService->allows('requiresCard')->andReturnTrue();
+        $mockService->allows('trialDays')->andReturn(14);
         $mockService->allows('checkDnaUploadLimit')->andReturn(['can_upload' => false, 'remaining' => 0, 'limit' => 1]);
-        $mockService->allows('getDnaLimitData')->andReturn(['remaining' => 0, 'can_upload' => false, 'limit' => 1]);
         $mockService->shouldReceive('createCheckoutRedirect')
             ->once()
+            ->with(\Mockery::type(User::class), 'year')
             ->andReturn($mockCheckout);
 
         $this->app->instance(SubscriptionService::class, $mockService);
 
         Livewire::actingAs($user)
             ->test(SubscriptionPage::class)
+            ->set('interval', 'year')
             ->call('redirectToCheckout')
             ->assertRedirect('https://stripe-example');
     }

--- a/tests/Unit/Services/SubscriptionServiceTest.php
+++ b/tests/Unit/Services/SubscriptionServiceTest.php
@@ -21,6 +21,9 @@ class SubscriptionServiceTest extends TestCase
 
     public function test_create_premium_subscription_without_payment_method(): void
     {
+        // The no-card local trial only exists when the deployment doesn't require a card.
+        config()->set('subscription.premium.require_card', false);
+
         $user = User::factory()->create();
         $this->subscriptionService->createPremiumSubscription($user);
 


### PR DESCRIPTION
Closes #1614.

## What

Makes premium sign-up configuration-driven so a genealogy deployment can require a card, skip trials, offer yearly billing, and stand up billing with no Stripe Dashboard setup.

- **Card requirement** — `SUBSCRIPTION_REQUIRE_CARD` (default **true**). When on, the no-card local-trial path is hidden **and** rejected server-side; premium is reachable only via a card checkout.
- **No trial** — `SUBSCRIPTION_PREMIUM_TRIAL_DAYS=0` is now first-class: checkout charges immediately, no trial window.
- **Yearly** — monthly and yearly billing intervals offered via an interval toggle on the subscription page.
- **Managed prices** — the app creates and owns the Stripe Product/Price from configured cent amounts (`SUBSCRIPTION_PREMIUM_MONTHLY_AMOUNT` / `_YEARLY_AMOUNT`), records them in a global `subscription_prices` table keyed by `(interval, livemode)`, and **auto-heals** when an amount changes (creates a new Price, archives the old). No Dashboard product setup required. See ADR 0003.
- Drops the `stripe_price_id` fallback chain and the display-only `SUBSCRIPTION_PREMIUM_PRICE`/`_INTERVAL` keys; the shown price is derived from the amount so it can't drift from the charge.
- Marketing pages no longer advertise a no-card trial when a card is required.

## How it's tested

Stripe SDK calls are folded behind protected seams on `SubscriptionService` (`createStripeProduct`/`createStripePrice`/`archiveStripePrice`), overridden in tests so the create/reuse/auto-heal logic runs without live Stripe.

- `SubscriptionServiceTest` — managed-price create/reuse/auto-heal, unknown-interval rejection, `requiresCard`, `checkoutTrialDays` (null at 0), local-trial rejection when card required.
- `SubscriptionPageTest` — trial button hidden + `startTrial` rejected when card required; hidden when `trial_days=0`; interval-aware checkout.

## Verification

- `php artisan test` — **883 passed, 12 skipped, 0 failed**
- Pint clean · PHPStan level 4 clean (no baseline growth)

## Config changes

New: `SUBSCRIPTION_REQUIRE_CARD`, `SUBSCRIPTION_PREMIUM_MONTHLY_AMOUNT`, `SUBSCRIPTION_PREMIUM_YEARLY_AMOUNT`, `SUBSCRIPTION_PREMIUM_PRODUCT_NAME`.
Removed: `SUBSCRIPTION_PREMIUM_PRICE`, `SUBSCRIPTION_PREMIUM_INTERVAL`, `SUBSCRIPTION_PREMIUM_STRIPE_PRICE_ID`, `STRIPE_PREMIUM_PRICE_ID`, `STRIPE_PREMIUM_PRODUCT_ID`.