### PR TITLE
Families table: names, children, single-parent, same-sex, dedup (#1617)

### DIFF
--- a/app/Filament/App/Resources/FamilyResource.php
+++ b/app/Filament/App/Resources/FamilyResource.php
@@ -7,10 +7,13 @@ namespace App\Filament\App\Resources;
 use App\Filament\App\Resources\FamilyResource\Pages\CreateFamily;
 use App\Filament\App\Resources\FamilyResource\Pages\EditFamily;
 use App\Filament\App\Resources\FamilyResource\Pages\ListFamilies;
+use App\Filament\App\Resources\FamilyResource\RelationManagers\ChildrenRelationManager;
 use App\Models\Family;
+use App\Models\Person;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -20,6 +23,7 @@ use Filament\Tables;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Override;
 
 class FamilyResource extends AppResource
@@ -39,25 +43,55 @@ class FamilyResource extends AppResource
     #[Override]
     protected static ?int $navigationSort = 2;
 
+    /** "Givn Surn" for a person, or '' when the person is null/unnamed (so a column placeholder shows). */
+    protected static function personName(?Person $person): string
+    {
+        return $person ? trim("{$person->givn} {$person->surn}") : '';
+    }
+
+    /** Eager-load the parents and children the table/name columns read, so the list isn't N+1. */
+    #[Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->with(['husband', 'wife', 'children']);
+    }
+
+    /**
+     * A searchable person-picker for one parent slot. No sex filter (same-sex
+     * families allowed) and not required (single-parent families allowed).
+     * Writes the person id straight to the husband_id/wife_id column. The
+     * Person query is team-scoped by BelongsToTenant, so it only offers the
+     * current team's people.
+     */
+    protected static function parentSelect(string $field, string $label): Select
+    {
+        $optionLabel = static fn (Person $p): string => trim("{$p->givn} {$p->surn}")." (#{$p->id})";
+
+        return Select::make($field)
+            ->label($label)
+            ->searchable()
+            ->getSearchResultsUsing(static fn (string $search): array => Person::query()
+                ->where(fn ($q) => $q->where('givn', 'like', "%{$search}%")
+                    ->orWhere('surn', 'like', "%{$search}%"))
+                ->limit(50)
+                ->get()
+                ->mapWithKeys(static fn (Person $p): array => [$p->id => $optionLabel($p)])
+                ->all())
+            ->getOptionLabelUsing(static fn ($value): ?string => ($p = Person::find($value)) ? $optionLabel($p) : null);
+    }
+
     #[Override]
     public static function form(Schema $schema): Schema
     {
         return $schema
             ->components([
-                Section::make('Family Members')
-                    ->description('Identify the husband and wife in this family unit')
+                Section::make('Parents')
+                    ->description('Either or both parents, any sex — single-parent and same-sex families are allowed. Leave one blank for a single parent.')
                     ->icon('heroicon-o-users')
                     ->columns(2)
                     ->schema([
-                        TextInput::make('husband_id')
-                            ->label('Husband ID')
-                            ->numeric(),
-                        TextInput::make('wife_id')
-                            ->label('Wife ID')
-                            ->numeric(),
-                        TextInput::make('nchi')
-                            ->label('Number of Children')
-                            ->maxLength(255),
+                        self::parentSelect('husband_id', 'Parent 1'),
+                        self::parentSelect('wife_id', 'Parent 2'),
                         TextInput::make('type_id')
                             ->label('Family Type')
                             ->numeric(),
@@ -97,17 +131,24 @@ class FamilyResource extends AppResource
                 TextColumn::make('id')
                     ->label('ID')
                     ->sortable(),
-                TextColumn::make('husband_id')
-                    ->label('Husband ID')
-                    ->numeric()
-                    ->sortable(),
-                TextColumn::make('wife_id')
-                    ->label('Wife ID')
-                    ->numeric()
-                    ->sortable(),
-                TextColumn::make('nchi')
+                TextColumn::make('parent1')
+                    ->label('Parent 1')
+                    ->state(fn (Family $record): string => self::personName($record->husband))
+                    ->placeholder('—'),
+                TextColumn::make('parent2')
+                    ->label('Parent 2')
+                    ->state(fn (Family $record): string => self::personName($record->wife))
+                    ->placeholder('—'),
+                TextColumn::make('children')
                     ->label('Children')
-                    ->searchable(),
+                    ->state(fn (Family $record): array => $record->children
+                        ->map(fn (Person $child): string => self::personName($child))
+                        ->all())
+                    ->badge()
+                    ->listWithLineBreaks()
+                    ->limitList(3)
+                    ->expandableLimitedList()
+                    ->placeholder('—'),
                 IconColumn::make('is_active')
                     ->label('Active')
                     ->boolean(),
@@ -140,7 +181,7 @@ class FamilyResource extends AppResource
     public static function getRelations(): array
     {
         return [
-            //
+            ChildrenRelationManager::class,
         ];
     }
 

--- a/app/Filament/App/Resources/FamilyResource/RelationManagers/ChildrenRelationManager.php
+++ b/app/Filament/App/Resources/FamilyResource/RelationManagers/ChildrenRelationManager.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\FamilyResource\RelationManagers;
+
+use App\Enums\PedigreeType;
+use App\Filament\App\Resources\AppRelationManager;
+use App\Models\Person;
+use Filament\Actions\AssociateAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DissociateAction;
+use Filament\Actions\DissociateBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * The children of a family. Children link upward via people.child_in_family_id
+ * (Family::children() is a plain hasMany), so associate/dissociate just set/null
+ * that FK — no pivot. Each child's link type (biological / adopted / foster /
+ * sealing) is its people.pedigree (GEDCOM FAMC.PEDI); null reads as biological.
+ *
+ * AssociateAction attaches an existing person with the default (biological)
+ * pedigree; set a non-default pedigree via the row Edit or when creating a new
+ * child. A person has one child_in_family_id, so associating a child here moves
+ * them out of any prior family — expected for this GEDCOM-shaped schema.
+ */
+class ChildrenRelationManager extends AppRelationManager
+{
+    #[\Override]
+    protected static string $relationship = 'children';
+
+    // Person's belongsTo back to the family is childInFamily(), not the family() that
+    // Filament would guess — associate/dissociate need it to set/null child_in_family_id.
+    #[\Override]
+    protected static ?string $inverseRelationship = 'childInFamily';
+
+    #[\Override]
+    protected static ?string $title = 'Children';
+
+    #[\Override]
+    protected static ?string $recordTitleAttribute = 'givn';
+
+    #[\Override]
+    public function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('givn')
+                ->label('Given name')
+                ->maxLength(255),
+            TextInput::make('surn')
+                ->label('Surname')
+                ->maxLength(255),
+            Select::make('pedigree')
+                ->label('Relationship to this family')
+                ->options(PedigreeType::options())
+                ->placeholder('Biological'),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Name')
+                    ->state(fn (Person $record): string => $record->fullname())
+                    ->searchable(['givn', 'surn']),
+                TextColumn::make('pedigree')
+                    ->label('Relationship')
+                    ->state(fn (Person $record): string => $record->pedigreeLabel())
+                    ->badge(),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+                AssociateAction::make()
+                    ->recordSelect(fn (Select $select): Select => $select
+                        ->label('Child')
+                        ->getSearchResultsUsing(fn (string $search): array => Person::query()
+                            ->where(fn ($query) => $query
+                                ->where('givn', 'like', "%{$search}%")
+                                ->orWhere('surn', 'like', "%{$search}%"))
+                            ->limit(50)
+                            ->get()
+                            ->mapWithKeys(fn (Person $person): array => [$person->getKey() => $person->fullname()])
+                            ->all())
+                        ->getOptionLabelUsing(fn ($value): ?string => Person::find($value)?->fullname())),
+            ])
+            ->actions([
+                EditAction::make(),
+                DissociateAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DissociateBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/database/migrations/2026_07_24_000001_deduplicate_families.php
+++ b/database/migrations/2026_07_24_000001_deduplicate_families.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * De-duplicate the families table. The GEDCOM importer's
+ * updateOrCreate($value, $value) keys on the whole row, so re-importing a tree
+ * never matches and re-inserts every couple — the dev DB held each couple 2-6×.
+ *
+ * Collapse each duplicate (husband_id, wife_id, team_id) group with BOTH parents
+ * set to its lowest id, repointing the child / event / sealing FKs, then add a
+ * unique index so a future re-import fails loud instead of silently duplicating.
+ *
+ * Single-parent rows (a null husband or wife) are intentionally left alone: a
+ * unique index treats NULLs as distinct, which is exactly the "both parents
+ * present" scope we want — MySQL/MariaDB has no partial-index WHERE clause, and
+ * this null behaviour gives it for free. Two distinct marriages of the same pair
+ * would now collide; that rare case is the accepted cost (see ticket 05).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $groups = DB::table('families')
+            ->select('husband_id', 'wife_id', 'team_id', DB::raw('MIN(id) as canonical_id'))
+            ->whereNotNull('husband_id')
+            ->whereNotNull('wife_id')
+            ->groupBy('husband_id', 'wife_id', 'team_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        foreach ($groups as $group) {
+            $extraIds = DB::table('families')
+                ->where('husband_id', $group->husband_id)
+                ->where('wife_id', $group->wife_id)
+                ->where('team_id', $group->team_id)
+                ->where('id', '!=', $group->canonical_id)
+                ->pluck('id');
+
+            if ($extraIds->isEmpty()) {
+                continue;
+            }
+
+            DB::table('people')->whereIn('child_in_family_id', $extraIds)
+                ->update(['child_in_family_id' => $group->canonical_id]);
+
+            if (Schema::hasTable('family_events')) {
+                DB::table('family_events')->whereIn('family_id', $extraIds)
+                    ->update(['family_id' => $group->canonical_id]);
+            }
+
+            if (Schema::hasTable('family_slgs')) {
+                DB::table('family_slgs')->whereIn('family_id', $extraIds)
+                    ->update(['family_id' => $group->canonical_id]);
+            }
+
+            DB::table('families')->whereIn('id', $extraIds)->delete();
+        }
+
+        Schema::table('families', function (Blueprint $table): void {
+            $table->unique(['husband_id', 'wife_id', 'team_id'], 'families_husband_wife_team_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('families', function (Blueprint $table): void {
+            $table->dropUnique('families_husband_wife_team_unique');
+        });
+        // Collapsed rows are not restored — the merge is irreversible.
+    }
+};

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -2,3 +2,15 @@
 
 @source '../../../../app/Filament/App/**/*';
 @source '../../../../resources/views/filament/app/**/*';
+
+/*
+ * The Profile page (EditProfile -> filament.pages.edit-profile) embeds Jetstream
+ * Livewire forms, whose Blade lives outside app/Filament/App. Filament's panel
+ * stylesheet only compiles utilities it finds in the sources above, so those
+ * forms' classes (md:grid-cols-3, col-span-6, bg-white, shadow...) were never
+ * generated and the profile layout collapsed. Scan the page views and the
+ * shared Jetstream components they render so the panel CSS carries them.
+ */
+@source '../../../../resources/views/filament/pages/**/*';
+@source '../../../../resources/views/profile/**/*';
+@source '../../../../resources/views/components/**/*';

--- a/tests/Feature/FamilyDeduplicationTest.php
+++ b/tests/Feature/FamilyDeduplicationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Family;
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The deduplicate_families migration adds a unique index on
+ * (husband_id, wife_id, team_id) so a re-import can't silently re-duplicate a
+ * couple. Single-parent families (a null slot) are exempt — NULLs compare
+ * distinct in a unique index.
+ */
+class FamilyDeduplicationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+
+        return $user;
+    }
+
+    public function test_a_second_family_for_the_same_couple_is_rejected(): void
+    {
+        $this->actingUser();
+        $husband = Person::factory()->create();
+        $wife = Person::factory()->create();
+
+        Family::factory()->create(['husband_id' => $husband->id, 'wife_id' => $wife->id]);
+
+        $this->expectException(QueryException::class);
+        Family::factory()->create(['husband_id' => $husband->id, 'wife_id' => $wife->id]);
+    }
+
+    public function test_multiple_single_parent_families_with_the_same_parent_are_allowed(): void
+    {
+        $this->actingUser();
+        $mother = Person::factory()->create();
+
+        // Two mother-only families (null husband) must coexist — NULLs are distinct.
+        Family::factory()->create(['husband_id' => null, 'wife_id' => $mother->id]);
+        $second = Family::factory()->create(['husband_id' => null, 'wife_id' => $mother->id]);
+
+        $this->assertDatabaseHas('families', ['id' => $second->id]);
+    }
+}

--- a/tests/Feature/Filament/Resources/ChildrenRelationManagerTest.php
+++ b/tests/Feature/Filament/Resources/ChildrenRelationManagerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources;
+
+use App\Filament\App\Resources\FamilyResource\Pages\EditFamily;
+use App\Filament\App\Resources\FamilyResource\RelationManagers\ChildrenRelationManager;
+use App\Models\Family;
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * ChildrenRelationManager: children link upward via child_in_family_id, so
+ * associate/dissociate set/null the FK and create makes a person straight into
+ * the family. Each child's pedigree records its link type.
+ */
+class ChildrenRelationManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam);
+
+        // Relation-manager actions gate on the related model's policy (PersonPolicy),
+        // which Filament hides/aborts without the Shield permission. Shield grants
+        // super_admin a Gate::before short-circuit in production that the harness
+        // lacks; replicate it so these tests cover the children wiring, not Shield.
+        Gate::before(fn () => true);
+
+        return $user;
+    }
+
+    private function livewire(Family $family): Testable
+    {
+        return Livewire::test(ChildrenRelationManager::class, [
+            'ownerRecord' => $family,
+            'pageClass' => EditFamily::class,
+        ]);
+    }
+
+    public function test_relation_manager_lists_the_family_children(): void
+    {
+        $this->actingUser();
+        $family = Family::factory()->create();
+        $child = Person::factory()->create(['child_in_family_id' => $family->id]);
+
+        $this->livewire($family)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$child]);
+    }
+
+    public function test_existing_person_can_be_associated_as_a_child(): void
+    {
+        $this->actingUser();
+        $family = Family::factory()->create();
+        $person = Person::factory()->create(['child_in_family_id' => null]);
+
+        $this->livewire($family)
+            ->callTableAction('associate', data: ['recordId' => $person->id])
+            ->assertHasNoActionErrors();
+
+        $this->assertSame($family->id, $person->fresh()->child_in_family_id);
+    }
+
+    public function test_dissociate_removes_the_child_but_keeps_the_person(): void
+    {
+        $this->actingUser();
+        $family = Family::factory()->create();
+        $child = Person::factory()->create(['child_in_family_id' => $family->id]);
+
+        $this->livewire($family)
+            ->callTableAction('dissociate', $child)
+            ->assertHasNoActionErrors();
+
+        $this->assertNull($child->fresh()->child_in_family_id);
+        $this->assertDatabaseHas('people', ['id' => $child->id]);
+    }
+
+    public function test_new_child_can_be_created_with_a_pedigree(): void
+    {
+        $this->actingUser();
+        $family = Family::factory()->create();
+
+        $this->livewire($family)
+            ->callTableAction('create', data: ['givn' => 'New', 'surn' => 'Kid', 'pedigree' => 'adopted'])
+            ->assertHasNoActionErrors();
+
+        $this->assertDatabaseHas('people', [
+            'givn' => 'New',
+            'surn' => 'Kid',
+            'child_in_family_id' => $family->id,
+            'pedigree' => 'adopted',
+        ]);
+    }
+}

--- a/tests/Feature/Filament/Resources/FamilyResourceTest.php
+++ b/tests/Feature/Filament/Resources/FamilyResourceTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Tests\Feature\Filament\Resources;
 
 use App\Filament\App\Resources\FamilyResource;
+use App\Filament\App\Resources\FamilyResource\Pages\CreateFamily;
+use App\Filament\App\Resources\FamilyResource\Pages\ListFamilies;
 use App\Models\Family;
+use App\Models\Person;
 use App\Models\User;
+use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class FamilyResourceTest extends TestCase
@@ -45,5 +50,65 @@ class FamilyResourceTest extends TestCase
         $family = Family::factory()->create();
 
         $this->assertDatabaseHas('families', ['id' => $family->id]);
+    }
+
+    /** The form's parent Selects are optional: a single-parent family saves with one slot blank. */
+    public function test_single_parent_family_can_be_created_via_form(): void
+    {
+        $this->actingAs($this->user);
+        Filament::setTenant($this->user->currentTeam, isQuiet: true);
+        $parent = Person::factory()->create();
+
+        Livewire::test(CreateFamily::class)
+            ->fillForm(['husband_id' => $parent->id, 'wife_id' => null])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('families', ['husband_id' => $parent->id, 'wife_id' => null]);
+    }
+
+    /** The parent Selects apply no sex filter: a same-sex couple (two males) saves. */
+    public function test_same_sex_family_can_be_created_via_form(): void
+    {
+        $this->actingAs($this->user);
+        Filament::setTenant($this->user->currentTeam, isQuiet: true);
+        $one = Person::factory()->create(['sex' => 'M']);
+        $two = Person::factory()->create(['sex' => 'M']);
+
+        Livewire::test(CreateFamily::class)
+            ->fillForm(['husband_id' => $one->id, 'wife_id' => $two->id])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('families', ['husband_id' => $one->id, 'wife_id' => $two->id]);
+    }
+
+    /** The list shows parent names (not ids) and each family's children. */
+    public function test_table_shows_parent_names_and_children(): void
+    {
+        $this->actingAs($this->user);
+        Filament::setTenant($this->user->currentTeam, isQuiet: true);
+        $husband = Person::factory()->create(['givn' => 'John', 'surn' => 'Doe']);
+        $wife = Person::factory()->create(['givn' => 'Jane', 'surn' => 'Doe']);
+        $family = Family::factory()->create(['husband_id' => $husband->id, 'wife_id' => $wife->id]);
+        Person::factory()->create(['givn' => 'Kid', 'surn' => 'Doe', 'child_in_family_id' => $family->id]);
+
+        Livewire::test(ListFamilies::class)
+            ->assertTableColumnStateSet('parent1', 'John Doe', record: $family)
+            ->assertTableColumnStateSet('parent2', 'Jane Doe', record: $family)
+            ->assertTableColumnStateSet('children', ['Kid Doe'], record: $family);
+    }
+
+    /** A single-parent family renders the empty slot as a placeholder, not "0" or a crash. */
+    public function test_table_renders_single_parent_family_cleanly(): void
+    {
+        $this->actingAs($this->user);
+        Filament::setTenant($this->user->currentTeam, isQuiet: true);
+        $husband = Person::factory()->create(['givn' => 'Solo', 'surn' => 'Parent']);
+        $family = Family::factory()->create(['husband_id' => $husband->id, 'wife_id' => null]);
+
+        Livewire::test(ListFamilies::class)
+            ->assertTableColumnStateSet('parent1', 'Solo Parent', record: $family)
+            ->assertTableColumnStateSet('parent2', '', record: $family);
     }
 }


### PR DESCRIPTION
Addresses liberu-genealogy/genealogy-laravel#1617 ("families table").

## What changed

The Families resource now works with people **by name** instead of raw id numbers, and supports the family shapes GEDCOM allows.

- **Form** (`FamilyResource`): the two parent slots are searchable person-pickers labelled **Parent 1 / Parent 2**, both optional (**single-parent** families) with no sex filter (**same-sex** couples). The hand-typed `nchi` "number of children" input is gone — the count is derived.
- **Table**: shows parent **names** (with a `—` placeholder for an empty slot) and each family's **children** as a badge list; eager-loads `husband`/`wife`/`children` to avoid N+1.
- **ChildrenRelationManager**: add an existing person (associate) or a new one (create), remove one (dissociate) or several / all (bulk), each recording its **pedigree** link type (biological / adopted / foster / sealing). Declares the `childInFamily` inverse so associate/dissociate set/null `child_in_family_id`.

## De-duplication

Investigation showed children were already grouped one-row-per-couple; the visible "duplicate families" were **duplicate `families` rows from re-import** — the vendor importer keyed `updateOrCreate` on the whole row, so re-imports never matched.

- A migration collapses duplicate `(husband_id, wife_id, team_id)` rows to the lowest id, repoints the child / event / sealing FKs, and adds a unique index so re-imports **fail loud** instead of silently duplicating. Single-parent rows are exempt via null-distinct index semantics (no partial-`WHERE` needed on MariaDB).
- On the dev DB this collapsed **4266 → 1990** rows (1138 duplicate groups → 0), with no orphaned FKs.

## Scope notes

- Same-sex uses the existing two spouse slots (no schema redesign). Step relationships are unchanged — already handled via person associations (`PersonAssoResource`).
- Not fixed here (deliberate): the vendor import idempotency itself (an upstream PR to `liberu-genealogy/laravel-gedcom` is the clean path), a friendly form message for the new duplicate-couple constraint, and collapsing duplicate *single-parent* rows.

## Tests

New coverage: single-parent + same-sex create, table name/children rendering, the children add/remove/pedigree flows, and the dedup constraint. Full suite green (910 passed). Pint + PHPStan clean.