### PR TITLE
fix(people): correct create/edit form + represent people on dashboard (#1618)

### DIFF
--- a/app/Filament/App/Pages/Dashboard.php
+++ b/app/Filament/App/Pages/Dashboard.php
@@ -6,6 +6,7 @@ namespace App\Filament\App\Pages;
 
 use App\Filament\App\Widgets\FamilyStatsWidget;
 use App\Filament\App\Widgets\FamilyTreeOverviewWidget;
+use App\Filament\App\Widgets\PeopleWidget;
 use App\Filament\App\Widgets\QuickActionsWidget;
 use App\Filament\App\Widgets\RecentActivityWidget;
 use Filament\Pages\Dashboard as BaseDashboard;
@@ -29,6 +30,7 @@ class Dashboard extends BaseDashboard
     {
         return [
             FamilyStatsWidget::class,
+            PeopleWidget::class,
             RecentActivityWidget::class,
             QuickActionsWidget::class,
             FamilyTreeOverviewWidget::class,

--- a/app/Filament/App/Resources/PersonResource.php
+++ b/app/Filament/App/Resources/PersonResource.php
@@ -13,6 +13,7 @@ use App\Filament\App\Resources\PersonResource\Pages\ListPeople;
 // a directory that does not exist. ::class does not autoload, so the bad name was
 // only discovered when Filament tried to instantiate it.
 use App\Filament\App\Resources\PersonResource\RelationManagers;
+use App\Models\Family;
 use App\Models\Person;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
@@ -48,6 +49,47 @@ class PersonResource extends AppResource
 
     // protected static ?string $tenantRelationshipName = 'People';
 
+    /** "Parent1 & Parent2 (#id)" for a family option, mirroring FamilyResource's parent labels. */
+    protected static function familyOptionLabel(Family $f): string
+    {
+        $names = array_filter([
+            $f->husband ? trim("{$f->husband->givn} {$f->husband->surn}") : null,
+            $f->wife ? trim("{$f->wife->givn} {$f->wife->surn}") : null,
+        ]);
+
+        return ($names === [] ? 'Unknown parents' : implode(' & ', $names))." (#{$f->id})";
+    }
+
+    /**
+     * Searchable picker for the child-in-family link, labelled by parent names (not a raw id).
+     * Optional — a person need not be a child in any family. Writes families.id to the
+     * people.child_in_family_id FK. Search matches either parent's name, or a bare family id.
+     */
+    protected static function childInFamilySelect(): Select
+    {
+        return Select::make('child_in_family_id')
+            ->label('Child in Family')
+            ->helperText('The family this person is a child of. Search by a parent\'s name.')
+            ->searchable()
+            ->getSearchResultsUsing(static fn (string $search): array => Family::query()
+                ->with(['husband', 'wife'])
+                ->where(function ($q) use ($search): void {
+                    $name = static fn ($sub) => $sub->where('givn', 'like', "%{$search}%")
+                        ->orWhere('surn', 'like', "%{$search}%");
+                    $q->whereHas('husband', $name)->orWhereHas('wife', $name);
+                    if (ctype_digit($search)) {
+                        $q->orWhere('id', (int) $search);
+                    }
+                })
+                ->limit(50)
+                ->get()
+                ->mapWithKeys(static fn (Family $f): array => [$f->id => self::familyOptionLabel($f)])
+                ->all())
+            ->getOptionLabelUsing(static fn ($value): ?string => ($f = Family::with(['husband', 'wife'])->find($value))
+                ? self::familyOptionLabel($f)
+                : null);
+    }
+
     #[Override]
     public static function form(Schema $schema): Schema
     {
@@ -64,7 +106,13 @@ class PersonResource extends AppResource
                             ->directory('persons')
                             ->disk('public')
                             ->columnSpanFull(),
-                        TextInput::make('givn')->label('First Name'),
+                        // A person must have at least one name. Enforced once, on givn: it is
+                        // required only when both surn and the legacy `name` are empty, so any
+                        // single populated name field satisfies the rule.
+                        TextInput::make('givn')
+                            ->label('First Name')
+                            ->requiredWithoutAll('surn,name')
+                            ->validationMessages(['required_without_all' => 'Enter at least a first name, last name, or full name.']),
                         TextInput::make('surn')->label('Last Name'),
                         TextInput::make('titl')->label('Title'),
                         TextInput::make('appellative')->label('Appellative'),
@@ -83,7 +131,7 @@ class PersonResource extends AppResource
                         DateTimePicker::make('birthday')->label('Date of Birth'),
                         DateTimePicker::make('deathday')->label('Date of Death'),
                         DateTimePicker::make('burial_day')->label('Burial Date'),
-                        TextInput::make('child_in_family_id')->label('Child in Family ID'),
+                        self::childInFamilySelect(),
                         Select::make('pedigree')
                             ->options(PedigreeType::options())
                             ->label('Pedigree')

--- a/app/Filament/App/Widgets/FamilyStatsWidget.php
+++ b/app/Filament/App/Widgets/FamilyStatsWidget.php
@@ -18,29 +18,27 @@ class FamilyStatsWidget extends BaseWidget
         $recentlyAdded = Person::where('created_at', '>=', now()->subDays(30))->count();
 
         return [
+            // No ->chart(): the previous sparklines were hardcoded fabricated arrays. Real
+            // per-period trend is an optional follow-up (see people-1618 map "Not yet specified").
             Stat::make('Total People', $totalPeople)
                 ->description('Individuals in your family tree')
                 ->descriptionIcon('heroicon-m-users')
-                ->color('success')
-                ->chart([7, 2, 10, 3, 15, 4, 17]),
+                ->color('success'),
 
             Stat::make('Families', $totalFamilies)
                 ->description('Family units recorded')
                 ->descriptionIcon('heroicon-m-home')
-                ->color('info')
-                ->chart([15, 4, 10, 2, 12, 4, 12]),
+                ->color('info'),
 
             Stat::make('Living People', $livingPeople)
                 ->description('Currently living family members')
                 ->descriptionIcon('heroicon-m-heart')
-                ->color('warning')
-                ->chart([2, 10, 1, 22, 15, 4, 17]),
+                ->color('warning'),
 
             Stat::make('Recently Added', $recentlyAdded)
                 ->description('New entries this month')
                 ->descriptionIcon('heroicon-m-plus-circle')
-                ->color('primary')
-                ->chart([7, 3, 4, 5, 6, 3, 5, 3]),
+                ->color('primary'),
         ];
     }
 }

--- a/app/Filament/App/Widgets/PeopleWidget.php
+++ b/app/Filament/App/Widgets/PeopleWidget.php
@@ -2,38 +2,41 @@
 
 namespace App\Filament\App\Widgets;
 
+use App\Filament\App\Resources\PersonResource;
 use App\Models\Person;
-use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
-use Illuminate\Database\Eloquent\Builder;
 
 class PeopleWidget extends BaseWidget
 {
-    protected function getTableQuery(): Builder
-    {
-        return Person::query()->latest();
-    }
+    protected int|string|array $columnSpan = 'full';
 
-    protected function getTableColumns(): array
+    public function table(Table $table): Table
     {
-        return [
-            TextColumn::make('fullname')
-                ->label('Name')
-                ->searchable(['givn', 'surn'])
-                ->sortable(),
-            TextColumn::make('sex')
-                ->label('Gender'),
-            TextColumn::make('birthday')
-                ->date()
-                ->sortable(),
-        ];
-    }
-
-    protected function getTableActions(): array
-    {
-        return [
-            // Tables\Actions\ViewAction::make(),
-        ];
+        return $table
+            ->heading('Recent People')
+            ->query(Person::query()->latest())
+            ->recordUrl(fn (Person $record): string => PersonResource::getUrl('edit', ['record' => $record]))
+            ->columns([
+                // 'fullname' resolves via Person::getFullnameAttribute (givn+surn, name fallback);
+                // not sortable — it is a computed accessor, not a DB column.
+                TextColumn::make('fullname')
+                    ->label('Name')
+                    ->searchable(['givn', 'surn']),
+                TextColumn::make('sex')
+                    ->label('Gender')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'M' => 'info',
+                        'F' => 'danger',
+                        default => 'gray',
+                    }),
+                TextColumn::make('birthday')
+                    ->label('Born')
+                    ->date()
+                    ->sortable(),
+            ])
+            ->paginated([5, 10, 25]);
     }
 }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -239,7 +239,18 @@ class Person extends Model
 
     public function fullname(): string
     {
-        return $this->givn.' '.$this->surn;
+        // Falls back to the legacy `name` column when both GEDCOM name parts are empty.
+        return trim($this->givn.' '.$this->surn) ?: (string) ($this->name ?? '');
+    }
+
+    /**
+     * Attribute-style access so `$person->fullname` (Filament TextColumn::make('fullname'),
+     * Blade property access) resolves — otherwise Eloquent treats the bare property as a
+     * relationship and throws. The 60+ existing `->fullname()` method callers are unaffected.
+     */
+    public function getFullnameAttribute(): string
+    {
+        return $this->fullname();
     }
 
     public function getSex(): string

--- a/tests/Filament/Resources/PersonResourceTest.php
+++ b/tests/Filament/Resources/PersonResourceTest.php
@@ -3,8 +3,13 @@
 namespace Tests\Filament\Resources;
 
 use App\Filament\App\Resources\PersonResource;
+use App\Filament\App\Resources\PersonResource\Pages\CreatePerson;
+use App\Models\Family;
 use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class PersonResourceTest extends TestCase
@@ -42,5 +47,50 @@ class PersonResourceTest extends TestCase
 
         $person->delete();
         $this->assertSoftDeleted('people', ['id' => $person->id]);
+    }
+
+    private function actingAsTenantUser(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+    }
+
+    /** child_in_family_id is a Family picker: a person saves linked to a chosen family. */
+    public function test_person_form_saves_with_family_picker(): void
+    {
+        $this->actingAsTenantUser();
+        $family = Family::factory()->create();
+
+        Livewire::test(CreatePerson::class)
+            ->fillForm(['givn' => 'Kid', 'surn' => 'Doe', 'child_in_family_id' => $family->id])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('people', ['givn' => 'Kid', 'child_in_family_id' => $family->id]);
+    }
+
+    /** A person with every name field empty is rejected, not silently saved blank. */
+    public function test_person_form_rejects_blank_name(): void
+    {
+        $this->actingAsTenantUser();
+
+        Livewire::test(CreatePerson::class)
+            ->fillForm(['givn' => '', 'surn' => '', 'name' => ''])
+            ->call('create')
+            ->assertHasFormErrors(['givn']);
+    }
+
+    /** Any single name field satisfies the "must have a name" rule — here, only surn. */
+    public function test_person_form_saves_with_only_one_name(): void
+    {
+        $this->actingAsTenantUser();
+
+        Livewire::test(CreatePerson::class)
+            ->fillForm(['givn' => '', 'surn' => 'Solo', 'name' => ''])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('people', ['surn' => 'Solo']);
     }
 }

--- a/tests/Filament/Widgets/FamilyStatsWidgetTest.php
+++ b/tests/Filament/Widgets/FamilyStatsWidgetTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Widgets;
+
+use App\Filament\App\Widgets\FamilyStatsWidget;
+use App\Models\Family;
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class FamilyStatsWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Auth + tenant first, so rows created in a test are stamped with this team and the
+        // widget's team-scoped counts see them.
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+    }
+
+    /** @return array<string, Stat> label => stat */
+    private function stats(): array
+    {
+        $method = new ReflectionMethod(FamilyStatsWidget::class, 'getStats');
+        $method->setAccessible(true);
+
+        return collect($method->invoke(new FamilyStatsWidget))
+            ->keyBy(fn (Stat $s): string => $s->getLabel())
+            ->all();
+    }
+
+    public function test_stats_reflect_real_rows(): void
+    {
+        Person::factory()->count(2)->create(['deathday' => null]);
+        Person::factory()->create(['deathday' => now()]);
+        // Null parents: the Family factory otherwise auto-creates a husband + wife Person,
+        // which would inflate the people counts.
+        Family::factory()->create(['husband_id' => null, 'wife_id' => null]);
+
+        $stats = $this->stats();
+
+        $this->assertSame(3, $stats['Total People']->getValue());
+        $this->assertSame(2, $stats['Living People']->getValue());
+        $this->assertSame(1, $stats['Families']->getValue());
+    }
+
+    /** The fabricated sparkline arrays are gone — no stat carries a chart. */
+    public function test_no_fabricated_sparklines(): void
+    {
+        foreach ($this->stats() as $stat) {
+            $this->assertNull($stat->getChart());
+        }
+    }
+}

--- a/tests/Filament/Widgets/PeopleWidgetTest.php
+++ b/tests/Filament/Widgets/PeopleWidgetTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Widgets;
+
+use App\Filament\App\Pages\Dashboard;
+use App\Filament\App\Widgets\PeopleWidget;
+use App\Models\Person;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PeopleWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($this->user);
+        Filament::setTenant($this->user->currentTeam, isQuiet: true);
+    }
+
+    public function test_widget_renders_and_lists_people(): void
+    {
+        $person = Person::factory()->create(['givn' => 'Ada', 'surn' => 'Lovelace']);
+
+        Livewire::test(PeopleWidget::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$person]);
+    }
+
+    public function test_widget_is_registered_on_the_dashboard(): void
+    {
+        $this->assertContains(PeopleWidget::class, (new Dashboard)->getWidgets());
+    }
+}

--- a/tests/Unit/PersonFullnameTest.php
+++ b/tests/Unit/PersonFullnameTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\Person;
+use PHPUnit\Framework\TestCase;
+
+class PersonFullnameTest extends TestCase
+{
+    public function test_fullname_joins_givn_and_surn(): void
+    {
+        $person = new Person(['givn' => 'John', 'surn' => 'Doe']);
+
+        $this->assertSame('John Doe', $person->fullname());
+    }
+
+    /** When both GEDCOM name parts are empty, it falls back to the legacy `name` column. */
+    public function test_fullname_falls_back_to_legacy_name(): void
+    {
+        $person = new Person(['givn' => null, 'surn' => null, 'name' => 'Legacy Fullname']);
+
+        $this->assertSame('Legacy Fullname', $person->fullname());
+    }
+
+    /** Property access ($person->fullname) must work too — Filament TextColumn::make('fullname'). */
+    public function test_fullname_is_accessible_as_an_attribute(): void
+    {
+        $person = new Person(['givn' => 'Jane', 'surn' => 'Roe']);
+
+        $this->assertSame('Jane Roe', $person->fullname);
+    }
+}


### PR DESCRIPTION
Closes #1618.

## What

Make person **create/edit work correctly** and make people **well represented on the dashboard**, keeping the families count intact.

### Person create/edit form
- `child_in_family_id` was a raw numeric text input (type an id) → now a **searchable Family picker** labelled by parent names, optional, writing the FK directly (mirrors the #1617 parent-picker pattern).
- No field was required, so a **fully blank person could be saved** → added a single `requiredWithoutAll('surn,name')` rule on `givn`: any one of first/last/full name satisfies it.

### Person model
- `fullname()` now **falls back to the legacy `name` column** when both GEDCOM parts (`givn`/`surn`) are empty — benefits all ~60 existing callers.
- Added a `getFullnameAttribute` accessor so **`$person->fullname` property access resolves** (needed by Filament `TextColumn::make('fullname')` and Blade). Method-style `->fullname()` callers are unchanged.

### Dashboard
- `PeopleWidget` was written in **dead Filament-3 style** (`getTableQuery`/`getTableColumns`) on a Filament 5 stack and **wasn't registered** → rewritten to a Filament-5 `table()` (recent people; name/sex/born; rows link to edit) and **registered** on the dashboard.
- Removed the **hardcoded fabricated sparkline arrays** (`->chart([7,2,10,...])`) from `FamilyStatsWidget`. People + Families counts are unchanged and verified.

## Tests
New coverage (all green): person form (family picker create, blank-name rejection, single-name pass), `fullname` accessor + `name` fallback + property access, `PeopleWidget` renders/lists/registered, `FamilyStatsWidget` counts reflect real rows + no chart.

Pint `--test` and PHPStan level 4 clean on all changed files. No migration, no new dependency.

## Out of scope
Rationalizing the redundant name fields (`givn`/`surn` vs legacy `name` vs `titl`/`appellative`); real computed trend sparklines (fabricated ones just dropped).