### PR TITLE
feat(affiliate): referral program — free months for paid referrals (#1621)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,13 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 # Premium Feature Configuration
 PREMIUM_ENABLED=false
 
+# Affiliate/referral program (issue #1621). Refer users who buy premium to earn
+# free months. The program is DORMANT whenever PREMIUM_ENABLED=true — a free-month
+# reward is meaningless when everyone is already premium.
+AFFILIATE_ENABLED=true
+# Qualified (paid) referrals required to earn one free month. Repeatable, no cap.
+AFFILIATE_REFERRALS_PER_FREE_MONTH=5
+
 # Require a card before granting premium access. When true (default), the no-card
 # trial is disabled and premium is only reachable via a card checkout (issue #1614).
 SUBSCRIPTION_REQUIRE_CARD=true

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -2,8 +2,11 @@
 
 namespace App\Actions\Fortify;
 
+use App\Models\Referral;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\Affiliate;
+use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -41,6 +44,7 @@ class CreateNewUser implements CreatesNewUsers
             $team = $this->createTeam($user);
             $user->switchTeam($team);
             setPermissionsTeamId($team->id);
+            $this->bindReferral($user);
             // No assignRole('panel_user'): RolesSeeder seeds only super_admin, so
             // that call threw RoleDoesNotExist and 500'd every registration that
             // reached this action. It is vestigial too — User::canAccessPanel()
@@ -48,6 +52,40 @@ class CreateNewUser implements CreatesNewUsers
             // requiring panel_user "caused 403 errors immediately after
             // login/registration for new accounts". Nothing checks for it.
         }));
+    }
+
+    /**
+     * Bind an affiliate referral captured in the cookie (CaptureReferral) to the
+     * new user: create a pending Referral for a valid, different referrer, once.
+     */
+    protected function bindReferral(User $user): void
+    {
+        if (! Affiliate::enabled()) {
+            return;
+        }
+
+        $code = request()->cookie('referral');
+
+        if (! is_string($code) || $code === '') {
+            return;
+        }
+
+        Cookie::queue(Cookie::forget('referral'));
+
+        $referrer = User::query()->where('referral_code', $code)->first();
+
+        // Unknown code, or self-referral, or already referred (unique index also
+        // backstops the last) — bind nothing.
+        if (! $referrer || $referrer->is($user)
+            || Referral::query()->where('referred_user_id', $user->id)->exists()) {
+            return;
+        }
+
+        Referral::create([
+            'referrer_id' => $referrer->id,
+            'referred_user_id' => $user->id,
+            'status' => Referral::STATUS_PENDING,
+        ]);
     }
 
     /**

--- a/app/Filament/App/Pages/ReferAndEarn.php
+++ b/app/Filament/App/Pages/ReferAndEarn.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Pages;
+
+use App\Support\Affiliate;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Where a user runs their affiliate activity: their link, referrals, rewards and
+ * progress to the next free month. User-scoped (not team-scoped) — shows the
+ * authenticated user's data regardless of active team. Hidden + inaccessible
+ * when the program is dormant.
+ */
+class ReferAndEarn extends Page
+{
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-gift';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'Refer & Earn';
+
+    #[\Override]
+    protected static string|\UnitEnum|null $navigationGroup = '👤 Account & Settings';
+
+    #[\Override]
+    protected static ?int $navigationSort = 3;
+
+    #[\Override]
+    protected string $view = 'filament.app.pages.refer-and-earn';
+
+    #[\Override]
+    protected static ?string $title = 'Refer & Earn';
+
+    #[\Override]
+    protected static ?string $slug = 'refer-and-earn';
+
+    #[\Override]
+    public static function canAccess(): bool
+    {
+        return Affiliate::enabled() && Auth::check();
+    }
+
+    #[\Override]
+    public static function shouldRegisterNavigation(): bool
+    {
+        return Affiliate::enabled() && Auth::check();
+    }
+
+    public function getReferralLink(): string
+    {
+        return Auth::user()->referralLink();
+    }
+
+    /** @return array{needed:int,toward:int,free_months:int,qualified:int,pending:int} */
+    public function getProgress(): array
+    {
+        return Auth::user()->affiliateProgress();
+    }
+
+    public function getReferrals(): Collection
+    {
+        return Auth::user()->referrals()->with('referredUser')->latest()->get();
+    }
+
+    public function getRewards(): Collection
+    {
+        return Auth::user()->affiliateRewards()->latest('granted_at')->get();
+    }
+}

--- a/app/Filament/App/Widgets/ReferralProgressWidget.php
+++ b/app/Filament/App/Widgets/ReferralProgressWidget.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Widgets;
+
+use App\Filament\App\Pages\ReferAndEarn;
+use App\Support\Affiliate;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Dashboard nudge toward the user's next free month. User-scoped; renders only
+ * while the affiliate program is live.
+ */
+class ReferralProgressWidget extends BaseWidget
+{
+    public static function canView(): bool
+    {
+        return Affiliate::enabled() && Auth::check();
+    }
+
+    #[\Override]
+    protected function getStats(): array
+    {
+        $progress = Auth::user()->affiliateProgress();
+
+        return [
+            Stat::make('Next free month', "{$progress['toward']} / {$progress['needed']}")
+                ->description('Referrals toward your next free month')
+                ->descriptionIcon('heroicon-m-gift')
+                ->color('primary')
+                ->url(ReferAndEarn::getUrl()),
+
+            Stat::make('Free months earned', $progress['free_months'])
+                ->description('From people you referred')
+                ->descriptionIcon('heroicon-m-sparkles')
+                ->color('success'),
+        ];
+    }
+}

--- a/app/Http/Middleware/CaptureReferral.php
+++ b/app/Http/Middleware/CaptureReferral.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use App\Support\Affiliate;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Stashes a valid ?ref=CODE affiliate code in a 30-day cookie for a guest, so it
+ * survives until they register (bound there by CreateNewUser). No-op when the
+ * program is dormant, the visitor is already authenticated, or the code is bogus.
+ */
+class CaptureReferral
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (Affiliate::enabled() && ! $request->user()) {
+            $code = $request->query('ref');
+
+            if (is_string($code) && $code !== ''
+                && User::query()->where('referral_code', $code)->exists()) {
+                Cookie::queue('referral', $code, 60 * 24 * 30);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Listeners/QualifyReferralOnPayment.php
+++ b/app/Listeners/QualifyReferralOnPayment.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Models\User;
+use App\Services\AffiliateRewardService;
+use App\Support\Affiliate;
+use Laravel\Cashier\Events\WebhookReceived;
+
+/**
+ * On a successful Stripe invoice, qualify the paying user's pending referral (if
+ * any) and settle the referrer's earned free months. The pending->qualified flip
+ * is idempotent, so renewals and webhook replays are no-ops.
+ */
+class QualifyReferralOnPayment
+{
+    public function __construct(private readonly AffiliateRewardService $rewards) {}
+
+    public function handle(WebhookReceived $event): void
+    {
+        if (! Affiliate::enabled()) {
+            return;
+        }
+
+        if (($event->payload['type'] ?? null) !== 'invoice.payment_succeeded') {
+            return;
+        }
+
+        $customer = $event->payload['data']['object']['customer'] ?? null;
+
+        if (! is_string($customer)) {
+            return;
+        }
+
+        $user = User::query()->where('stripe_id', $customer)->first();
+
+        if ($user === null) {
+            return;
+        }
+
+        $this->rewards->qualifyReferralFor($user);
+    }
+}

--- a/app/Models/AffiliateReward.php
+++ b/app/Models/AffiliateReward.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One granted free month (the ledger row ticket 03 writes). `referrals_consumed`
+ * summed across a user's rewards is the "already spent" side of the free-months
+ * owed calculation. Not team-scoped.
+ */
+class AffiliateReward extends Model
+{
+    use HasFactory;
+
+    public const DELIVERY_STRIPE_CREDIT = 'stripe_credit';
+
+    public const DELIVERY_ACCESS_EXTENSION = 'access_extension';
+
+    protected $fillable = [
+        'user_id',
+        'referrals_consumed',
+        'delivery',
+        'amount_cents',
+        'granted_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'referrals_consumed' => 'integer',
+            'amount_cents' => 'integer',
+            'granted_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Referral.php
+++ b/app/Models/Referral.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One referred signup. `pending` until the referred user's first premium payment
+ * succeeds, then `qualified` (ticket 03). Not team-scoped — person to person.
+ */
+class Referral extends Model
+{
+    use HasFactory;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_QUALIFIED = 'qualified';
+
+    protected $fillable = [
+        'referrer_id',
+        'referred_user_id',
+        'status',
+        'qualified_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'qualified_at' => 'datetime',
+        ];
+    }
+
+    public function referrer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'referrer_id');
+    }
+
+    public function referredUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'referred_user_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Events\UserLeveledUp;
+use App\Support\Affiliate;
 use BezhanSalleh\FilamentShield\Traits\HasPanelShield;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasDefaultTenant;
@@ -19,6 +20,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use JoelButcher\Socialstream\HasConnectedAccounts;
 use JoelButcher\Socialstream\SetsProfilePhotoFromUrl;
 // use Laravel\Jetstream\HasProfilePhoto;
@@ -431,6 +433,88 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     public function achievements(): HasMany
     {
         return $this->hasMany(UserAchievement::class);
+    }
+
+    /**
+     * Referrals where this user is the referrer (affiliate program).
+     */
+    public function referrals(): HasMany
+    {
+        return $this->hasMany(Referral::class, 'referrer_id');
+    }
+
+    /**
+     * The referral row that brought this user in, if any (referred at most once).
+     */
+    public function referredBy(): HasOne
+    {
+        return $this->hasOne(Referral::class, 'referred_user_id');
+    }
+
+    /**
+     * Free-month rewards this user has earned as a referrer.
+     */
+    public function affiliateRewards(): HasMany
+    {
+        return $this->hasMany(AffiliateReward::class);
+    }
+
+    /**
+     * This user's affiliate code, generating and persisting one on first use.
+     */
+    public function referralCode(): string
+    {
+        if (! $this->referral_code) {
+            $this->ensureReferralCode();
+        }
+
+        return (string) $this->referral_code;
+    }
+
+    /**
+     * Shareable affiliate link: site root with this user's ?ref=CODE.
+     */
+    public function referralLink(): string
+    {
+        return url('/').'?ref='.$this->referralCode();
+    }
+
+    /**
+     * Affiliate progress for the page + dashboard widget — computed one place so
+     * both read the same numbers.
+     *
+     * @return array{needed:int,toward:int,free_months:int,qualified:int,pending:int}
+     */
+    public function affiliateProgress(): array
+    {
+        $needed = Affiliate::referralsPerFreeMonth();
+        $qualified = $this->referrals()->where('status', Referral::STATUS_QUALIFIED)->count();
+        $consumed = (int) $this->affiliateRewards()->sum('referrals_consumed');
+
+        return [
+            'needed' => $needed,
+            'toward' => max(0, $qualified - $consumed) % $needed,
+            'free_months' => $this->affiliateRewards()->count(),
+            'qualified' => $qualified,
+            'pending' => $this->referrals()->where('status', Referral::STATUS_PENDING)->count(),
+        ];
+    }
+
+    /**
+     * Generate + persist a unique referral code if the user doesn't have one.
+     */
+    public function ensureReferralCode(): void
+    {
+        if ($this->referral_code) {
+            return;
+        }
+
+        // ponytail: unique index + retry, no checksum scheme.
+        do {
+            $code = Str::upper(Str::random(8));
+        } while (static::query()->where('referral_code', $code)->exists());
+
+        $this->forceFill(['referral_code' => $code])->save();
     }
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -7,6 +7,7 @@ namespace App\Providers;
 use App\Events\AchievementUnlocked;
 use App\Events\UserLeveledUp;
 use App\Listeners\AchievementUnlockedListener;
+use App\Listeners\QualifyReferralOnPayment;
 use App\Listeners\SendSubscriptionWebhookNotifications;
 use App\Listeners\SyncSubscriptionPauseState;
 use App\Listeners\UserLeveledUpListener;
@@ -32,6 +33,7 @@ class EventServiceProvider extends ServiceProvider
         WebhookReceived::class => [
             SendSubscriptionWebhookNotifications::class,
             SyncSubscriptionPauseState::class,
+            QualifyReferralOnPayment::class,
         ],
     ];
 

--- a/app/Services/AffiliateRewardService.php
+++ b/app/Services/AffiliateRewardService.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\AffiliateReward;
+use App\Models\Referral;
+use App\Models\User;
+use App\Support\Affiliate;
+use Illuminate\Support\Carbon;
+
+/**
+ * Turns a referred user's first successful premium payment into a qualified
+ * referral, and settles any free months the referrer has now earned.
+ *
+ * "Free months owed" = qualified referrals minus referrals already consumed by
+ * granted rewards (the ledger is the source of truth — no separate counter to
+ * drift). Delivery is hybrid: Stripe balance credit for a subscriber, a 30-day
+ * access extension otherwise.
+ */
+class AffiliateRewardService
+{
+    /**
+     * Qualify the referred user's pending referral (idempotent — only a pending
+     * row flips, so replays and renewals are no-ops), then settle rewards.
+     */
+    public function qualifyReferralFor(User $referred): void
+    {
+        if (! Affiliate::enabled()) {
+            return;
+        }
+
+        $referral = Referral::query()
+            ->where('referred_user_id', $referred->id)
+            ->where('status', Referral::STATUS_PENDING)
+            ->first();
+
+        if ($referral === null) {
+            return;
+        }
+
+        $referral->update([
+            'status' => Referral::STATUS_QUALIFIED,
+            'qualified_at' => now(),
+        ]);
+
+        if ($referral->referrer !== null) {
+            $this->settleRewards($referral->referrer);
+        }
+    }
+
+    /**
+     * Grant one free month per N unconsumed qualified referrals, looping so a
+     * backlog crossing several thresholds at once is fully settled.
+     */
+    public function settleRewards(User $referrer): void
+    {
+        $perMonth = Affiliate::referralsPerFreeMonth();
+
+        while ($this->unconsumedQualified($referrer) >= $perMonth) {
+            $reward = $this->deliver($referrer);
+            $reward->referrals_consumed = $perMonth;
+            $referrer->affiliateRewards()->save($reward);
+        }
+    }
+
+    /**
+     * Qualified referrals not yet paid out by a reward.
+     */
+    private function unconsumedQualified(User $referrer): int
+    {
+        $qualified = $referrer->referrals()
+            ->where('status', Referral::STATUS_QUALIFIED)
+            ->count();
+
+        $consumed = (int) $referrer->affiliateRewards()->sum('referrals_consumed');
+
+        return $qualified - $consumed;
+    }
+
+    /**
+     * Build (unsaved) the reward row and perform its side effect. A Stripe
+     * subscriber is credited one month's price (Stripe applies it to the next
+     * invoice); everyone else has premium access extended 30 days.
+     */
+    private function deliver(User $referrer): AffiliateReward
+    {
+        if ($referrer->subscribed('premium')) {
+            $amount = (int) config('subscription.premium.amounts.month');
+            $this->creditReferrer($referrer, $amount);
+
+            return new AffiliateReward([
+                'delivery' => AffiliateReward::DELIVERY_STRIPE_CREDIT,
+                'amount_cents' => $amount,
+                'granted_at' => now(),
+            ]);
+        }
+
+        // Non-subscriber: extend the local access window, keeping any unused
+        // future time (stack, don't shrink) and ensuring isPremium() is true.
+        $current = $referrer->trial_ends_at !== null ? Carbon::parse($referrer->trial_ends_at) : null;
+        $from = ($current !== null && $current->isFuture()) ? $current : now();
+
+        $referrer->forceFill([
+            'trial_ends_at' => $from->copy()->addDays(30),
+            'is_premium' => true,
+        ])->save();
+
+        return new AffiliateReward([
+            'delivery' => AffiliateReward::DELIVERY_ACCESS_EXTENSION,
+            'amount_cents' => null,
+            'granted_at' => now(),
+        ]);
+    }
+
+    /**
+     * The single Stripe-touching call, isolated so tests can override it without
+     * hitting the API. creditBalance records a customer balance credit that
+     * Stripe auto-applies to the next invoice.
+     */
+    protected function creditReferrer(User $referrer, int $amountCents): void
+    {
+        $referrer->creditBalance($amountCents, 'Affiliate reward: 1 free month (#1621)');
+    }
+}

--- a/app/Support/Affiliate.php
+++ b/app/Support/Affiliate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Single source of truth for whether the affiliate program is live and how many
+ * referrals buy a free month. Everything downstream (middleware, registration
+ * hook, webhook listener, Filament page/widget) gates on Affiliate::enabled().
+ */
+class Affiliate
+{
+    /**
+     * The program runs only when its own switch is on AND premium is a paid
+     * product. When premium.enabled is true everyone is premium, so a free-month
+     * reward has nothing to give — the whole program goes dormant.
+     */
+    public static function enabled(): bool
+    {
+        return (bool) config('affiliate.enabled') && ! (bool) config('premium.enabled');
+    }
+
+    /**
+     * Qualified referrals required per free month, floored to 1 so the reward
+     * maths can never divide by zero.
+     */
+    public static function referralsPerFreeMonth(): int
+    {
+        return max(1, (int) config('affiliate.referrals_per_free_month'));
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\CaptureReferral;
 use App\Http\Middleware\SecurityHeaders;
 use Filament\Forms\Form;
 use Filament\Schemas\Schema;
@@ -25,6 +26,8 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withBroadcasting(__DIR__.'/../routes/channels.php')
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(SecurityHeaders::class);
+        // Capture ?ref=CODE affiliate links into a cookie for guests (issue #1621).
+        $middleware->web(append: CaptureReferral::class);
         $middleware->validateCsrfTokens(except: [
             'stripe/*',
         ]);

--- a/config/affiliate.php
+++ b/config/affiliate.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Master switch for the referral/affiliate program. NOTE: the program is
+    // ALSO dormant whenever premium.enabled is true — when everyone is premium a
+    // free-month reward is meaningless. Both conditions are ANDed in the single
+    // gate App\Support\Affiliate::enabled(); always check that, never this raw
+    // flag, so nav, routes, qualification and grants stay in lockstep.
+    'enabled' => env('AFFILIATE_ENABLED', true),
+
+    // Number of qualified (paid) referrals that earn one free month. Repeatable
+    // with no cap. Floored to 1 by Affiliate::referralsPerFreeMonth().
+    'referrals_per_free_month' => (int) env('AFFILIATE_REFERRALS_PER_FREE_MONTH', 5),
+];

--- a/database/migrations/2026_07_24_140000_add_referral_code_to_users_table.php
+++ b/database/migrations/2026_07_24_140000_add_referral_code_to_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            // Short, unique, URL-safe affiliate code. Generated lazily on first
+            // access (User::ensureReferralCode()), not backfilled.
+            $table->string('referral_code', 16)->nullable()->unique()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropUnique(['referral_code']);
+            $table->dropColumn('referral_code');
+        });
+    }
+};

--- a/database/migrations/2026_07_24_140001_create_referrals_table.php
+++ b/database/migrations/2026_07_24_140001_create_referrals_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('referrals', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('referrer_id')->constrained('users')->cascadeOnDelete();
+            // Unique: a user is referred at most once (backstops self/double-referral).
+            $table->foreignId('referred_user_id')->unique()->constrained('users')->cascadeOnDelete();
+            $table->string('status')->default('pending')->index();
+            $table->timestamp('qualified_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('referrals');
+    }
+};

--- a/database/migrations/2026_07_24_140002_create_affiliate_rewards_table.php
+++ b/database/migrations/2026_07_24_140002_create_affiliate_rewards_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('affiliate_rewards', function (Blueprint $table): void {
+            $table->id();
+            // The referrer being rewarded.
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            // How many qualified referrals this reward consumed (= N at grant time).
+            $table->unsignedInteger('referrals_consumed');
+            // 'stripe_credit' | 'access_extension' — see AffiliateReward consts.
+            $table->string('delivery');
+            // One month's price in cents, for the stripe_credit case; null otherwise.
+            $table->unsignedInteger('amount_cents')->nullable();
+            $table->timestamp('granted_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('affiliate_rewards');
+    }
+};

--- a/resources/views/filament/app/pages/refer-and-earn.blade.php
+++ b/resources/views/filament/app/pages/refer-and-earn.blade.php
@@ -1,0 +1,105 @@
+<x-filament-panels::page>
+    @php($progress = $this->getProgress())
+
+    <div class="space-y-6">
+        {{-- Referral link --}}
+        <x-filament::section>
+            <x-slot name="heading">Your referral link</x-slot>
+            <x-slot name="description">Share this link. When someone you refer buys Premium, it counts toward a free month.</x-slot>
+
+            <div x-data="{ copied: false }" class="flex items-center gap-2">
+                <input
+                    type="text"
+                    readonly
+                    value="{{ $this->getReferralLink() }}"
+                    class="flex-1 rounded-lg border-gray-300 bg-gray-50 text-sm dark:border-gray-700 dark:bg-gray-900"
+                    x-on:focus="$el.select()"
+                />
+                <x-filament::button
+                    x-on:click="navigator.clipboard.writeText('{{ $this->getReferralLink() }}'); copied = true; setTimeout(() => copied = false, 2000)"
+                    icon="heroicon-o-clipboard"
+                >
+                    <span x-show="! copied">Copy</span>
+                    <span x-show="copied" x-cloak>Copied!</span>
+                </x-filament::button>
+            </div>
+        </x-filament::section>
+
+        {{-- Progress --}}
+        <x-filament::section>
+            <x-slot name="heading">Progress to your next free month</x-slot>
+
+            <div class="space-y-3">
+                <div class="flex items-baseline justify-between">
+                    <span class="text-2xl font-bold text-primary-600 dark:text-primary-400">
+                        {{ $progress['toward'] }} / {{ $progress['needed'] }}
+                    </span>
+                    <span class="text-sm text-gray-500">
+                        {{ $progress['free_months'] }} free {{ \Illuminate\Support\Str::plural('month', $progress['free_months']) }} earned
+                    </span>
+                </div>
+
+                <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                    <div
+                        class="h-full rounded-full bg-primary-500 transition-all"
+                        style="width: {{ $progress['needed'] > 0 ? min(100, round($progress['toward'] / $progress['needed'] * 100)) : 0 }}%"
+                    ></div>
+                </div>
+
+                <p class="text-sm text-gray-500">
+                    {{ $progress['qualified'] }} qualified &middot; {{ $progress['pending'] }} pending
+                </p>
+            </div>
+        </x-filament::section>
+
+        {{-- Referrals --}}
+        <x-filament::section>
+            <x-slot name="heading">Your referrals</x-slot>
+
+            @if ($this->getReferrals()->isEmpty())
+                <p class="text-sm text-gray-500">No referrals yet. Share your link to get started.</p>
+            @else
+                <table class="w-full text-sm">
+                    <thead class="text-left text-gray-500">
+                        <tr>
+                            <th class="pb-2">Person</th>
+                            <th class="pb-2">Joined</th>
+                            <th class="pb-2">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+                        @foreach ($this->getReferrals() as $referral)
+                            <tr>
+                                <td class="py-2">{{ $referral->referredUser?->name ?? 'Unknown' }}</td>
+                                <td class="py-2">{{ $referral->created_at?->toFormattedDateString() }}</td>
+                                <td class="py-2">
+                                    <x-filament::badge :color="$referral->status === \App\Models\Referral::STATUS_QUALIFIED ? 'success' : 'gray'">
+                                        {{ ucfirst($referral->status) }}
+                                    </x-filament::badge>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            @endif
+        </x-filament::section>
+
+        {{-- Rewards --}}
+        @if ($this->getRewards()->isNotEmpty())
+            <x-filament::section>
+                <x-slot name="heading">Free months earned</x-slot>
+
+                <ul class="divide-y divide-gray-100 text-sm dark:divide-gray-800">
+                    @foreach ($this->getRewards() as $reward)
+                        <li class="flex justify-between py-2">
+                            <span>1 free month &middot; {{ $reward->granted_at?->toFormattedDateString() }}</span>
+                            <span class="text-gray-500">
+                                {{ $reward->delivery === \App\Models\AffiliateReward::DELIVERY_STRIPE_CREDIT ? 'Applied as billing credit' : 'Added to your access' }}
+                            </span>
+                        </li>
+                    @endforeach
+                </ul>
+            </x-filament::section>
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/AffiliateAttributionTest.php
+++ b/tests/Feature/AffiliateAttributionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Http\Middleware\CaptureReferral;
+use App\Models\Referral;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Tests\TestCase;
+
+class AffiliateAttributionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['affiliate.enabled' => true, 'premium.enabled' => false]);
+    }
+
+    /** @param array<string,string> $cookies */
+    private function register(string $email, array $cookies = []): User
+    {
+        $request = Request::create('/register', 'POST', [], $cookies);
+        $this->app->instance('request', $request);
+
+        return app(CreateNewUser::class)->create([
+            'name' => 'New Person',
+            'email' => $email,
+            'password' => 'password1234',
+            'password_confirmation' => 'password1234',
+        ]);
+    }
+
+    public function test_middleware_stashes_valid_ref_code_for_guest(): void
+    {
+        $referrer = User::factory()->create();
+        $referrer->referralCode();
+
+        $req = Request::create('/?ref='.$referrer->referral_code);
+        (new CaptureReferral)->handle($req, fn () => response('ok'));
+
+        $this->assertTrue(Cookie::hasQueued('referral'));
+        $this->assertSame($referrer->referral_code, Cookie::queued('referral')->getValue());
+    }
+
+    public function test_middleware_ignores_unknown_code(): void
+    {
+        $req = Request::create('/?ref=NOPENOPE');
+        (new CaptureReferral)->handle($req, fn () => response('ok'));
+
+        $this->assertFalse(Cookie::hasQueued('referral'));
+    }
+
+    public function test_middleware_no_op_when_dormant(): void
+    {
+        config(['premium.enabled' => true]); // everyone premium => program dormant
+        $referrer = User::factory()->create();
+        $referrer->referralCode();
+
+        $req = Request::create('/?ref='.$referrer->referral_code);
+        (new CaptureReferral)->handle($req, fn () => response('ok'));
+
+        $this->assertFalse(Cookie::hasQueued('referral'));
+    }
+
+    public function test_registration_binds_pending_referral_and_clears_cookie(): void
+    {
+        $referrer = User::factory()->create();
+        $referrer->referralCode();
+
+        $referred = $this->register('referred@example.test', ['referral' => $referrer->referral_code]);
+
+        $this->assertDatabaseHas('referrals', [
+            'referrer_id' => $referrer->id,
+            'referred_user_id' => $referred->id,
+            'status' => Referral::STATUS_PENDING,
+        ]);
+        $this->assertTrue(Cookie::hasQueued('referral')); // forget() is a queued cookie
+        $this->assertTrue(Cookie::queued('referral')->isCleared());
+    }
+
+    public function test_unknown_cookie_code_binds_nothing(): void
+    {
+        $referred = $this->register('nobody@example.test', ['referral' => 'GHOSTNONE']);
+
+        $this->assertDatabaseMissing('referrals', ['referred_user_id' => $referred->id]);
+    }
+
+    public function test_no_cookie_binds_nothing(): void
+    {
+        $referred = $this->register('plain@example.test');
+
+        $this->assertDatabaseMissing('referrals', ['referred_user_id' => $referred->id]);
+    }
+
+    public function test_referral_link_points_at_root_with_ref(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertSame(url('/').'?ref='.$user->referralCode(), $user->referralLink());
+    }
+}

--- a/tests/Feature/AffiliateFoundationsTest.php
+++ b/tests/Feature/AffiliateFoundationsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\AffiliateReward;
+use App\Models\Referral;
+use App\Models\User;
+use App\Support\Affiliate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AffiliateFoundationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_gate_is_on_only_when_affiliate_on_and_premium_paid(): void
+    {
+        config(['affiliate.enabled' => true, 'premium.enabled' => false]);
+        $this->assertTrue(Affiliate::enabled());
+
+        // Everyone premium => nothing to reward => dormant.
+        config(['affiliate.enabled' => true, 'premium.enabled' => true]);
+        $this->assertFalse(Affiliate::enabled());
+
+        // Switched off explicitly.
+        config(['affiliate.enabled' => false, 'premium.enabled' => false]);
+        $this->assertFalse(Affiliate::enabled());
+    }
+
+    public function test_referrals_per_free_month_reads_config_and_floors_to_one(): void
+    {
+        config(['affiliate.referrals_per_free_month' => 5]);
+        $this->assertSame(5, Affiliate::referralsPerFreeMonth());
+
+        config(['affiliate.referrals_per_free_month' => 0]);
+        $this->assertSame(1, Affiliate::referralsPerFreeMonth());
+    }
+
+    public function test_referral_code_is_generated_stable_and_unique(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertNull($user->referral_code);
+        $code = $user->referralCode();
+
+        $this->assertNotEmpty($code);
+        $this->assertSame($code, $user->fresh()->referralCode(), 'code must persist and be stable');
+
+        $other = User::factory()->create();
+        $this->assertNotSame($code, $other->referralCode());
+    }
+
+    public function test_relations_resolve(): void
+    {
+        $referrer = User::factory()->create();
+        $referred = User::factory()->create();
+
+        $referral = Referral::create([
+            'referrer_id' => $referrer->id,
+            'referred_user_id' => $referred->id,
+            'status' => Referral::STATUS_PENDING,
+        ]);
+
+        $reward = AffiliateReward::create([
+            'user_id' => $referrer->id,
+            'referrals_consumed' => 5,
+            'delivery' => AffiliateReward::DELIVERY_ACCESS_EXTENSION,
+            'granted_at' => now(),
+        ]);
+
+        $this->assertTrue($referrer->referrals->contains($referral));
+        $this->assertTrue($referrer->affiliateRewards->contains($reward));
+        $this->assertSame($referral->id, $referred->referredBy?->id);
+        $this->assertSame($referrer->id, $referral->referrer->id);
+        $this->assertSame($referred->id, $referral->referredUser->id);
+    }
+}

--- a/tests/Feature/AffiliateRewardTest.php
+++ b/tests/Feature/AffiliateRewardTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Listeners\QualifyReferralOnPayment;
+use App\Models\AffiliateReward;
+use App\Models\Referral;
+use App\Models\User;
+use App\Services\AffiliateRewardService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Events\WebhookReceived;
+use Tests\TestCase;
+
+class AffiliateRewardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['affiliate.enabled' => true, 'premium.enabled' => false]);
+    }
+
+    /** A service whose only Stripe call is recorded instead of sent. */
+    private function fakeCreditService(): AffiliateRewardService
+    {
+        return new class extends AffiliateRewardService
+        {
+            /** @var array<int,array{user:int,amount:int}> */
+            public array $credited = [];
+
+            protected function creditReferrer(User $referrer, int $amountCents): void
+            {
+                $this->credited[] = ['user' => $referrer->id, 'amount' => $amountCents];
+            }
+        };
+    }
+
+    private function pendingReferral(User $referrer, User $referred): Referral
+    {
+        return Referral::create([
+            'referrer_id' => $referrer->id,
+            'referred_user_id' => $referred->id,
+            'status' => Referral::STATUS_PENDING,
+        ]);
+    }
+
+    private function seedQualified(User $referrer, int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            Referral::create([
+                'referrer_id' => $referrer->id,
+                'referred_user_id' => User::factory()->create()->id,
+                'status' => Referral::STATUS_QUALIFIED,
+                'qualified_at' => now(),
+            ]);
+        }
+    }
+
+    public function test_dormant_program_does_not_qualify(): void
+    {
+        config(['premium.enabled' => true]); // everyone premium => dormant
+        $referral = $this->pendingReferral(User::factory()->create(), $referred = User::factory()->create());
+
+        $this->fakeCreditService()->qualifyReferralFor($referred);
+
+        $this->assertSame(Referral::STATUS_PENDING, $referral->fresh()->status);
+    }
+
+    public function test_qualify_flips_pending_and_is_idempotent(): void
+    {
+        config(['affiliate.referrals_per_free_month' => 5]);
+        $referrer = User::factory()->create();
+        $referred = User::factory()->create();
+        $this->pendingReferral($referrer, $referred);
+
+        $service = $this->fakeCreditService();
+        $service->qualifyReferralFor($referred);
+        $service->qualifyReferralFor($referred); // replay / renewal
+
+        $this->assertDatabaseCount('referrals', 1);
+        $this->assertSame(Referral::STATUS_QUALIFIED, Referral::first()->status);
+        $this->assertNotNull(Referral::first()->qualified_at);
+        $this->assertDatabaseCount('affiliate_rewards', 0); // 1 qualified < 5
+    }
+
+    public function test_threshold_grants_one_free_month_via_access_extension(): void
+    {
+        config(['affiliate.referrals_per_free_month' => 2]);
+        $referrer = User::factory()->create(['trial_ends_at' => null, 'is_premium' => false]);
+        $this->seedQualified($referrer, 1); // one already qualified
+
+        $referred = User::factory()->create();
+        $this->pendingReferral($referrer, $referred);
+        $this->fakeCreditService()->qualifyReferralFor($referred); // now 2 unconsumed
+
+        $this->assertDatabaseCount('affiliate_rewards', 1);
+        $reward = AffiliateReward::first();
+        $this->assertSame(AffiliateReward::DELIVERY_ACCESS_EXTENSION, $reward->delivery);
+        $this->assertSame(2, $reward->referrals_consumed);
+        $this->assertNull($reward->amount_cents);
+
+        $referrer->refresh();
+        $this->assertTrue($referrer->trial_ends_at?->greaterThan(now()->addDays(29)));
+        $this->assertTrue($referrer->isPremium());
+    }
+
+    public function test_backlog_crossing_two_thresholds_grants_two(): void
+    {
+        config(['affiliate.referrals_per_free_month' => 2]);
+        $referrer = User::factory()->create(['trial_ends_at' => null, 'is_premium' => false]);
+        $this->seedQualified($referrer, 4);
+
+        $this->fakeCreditService()->settleRewards($referrer);
+
+        $this->assertDatabaseCount('affiliate_rewards', 2);
+        $this->assertSame(4, (int) $referrer->affiliateRewards()->sum('referrals_consumed'));
+        // Two 30-day extensions stack from now.
+        $this->assertTrue($referrer->fresh()->trial_ends_at?->greaterThan(now()->addDays(59)));
+    }
+
+    public function test_subscriber_referrer_gets_stripe_credit(): void
+    {
+        config(['affiliate.referrals_per_free_month' => 1]);
+        $referrer = User::factory()->create(['trial_ends_at' => null]);
+        $referrer->subscriptions()->create([
+            'type' => 'premium',
+            'stripe_id' => 'sub_test123',
+            'stripe_status' => 'active',
+            'stripe_price' => 'price_test',
+            'quantity' => 1,
+        ]);
+        $this->assertTrue($referrer->fresh()->subscribed('premium'));
+
+        $service = $this->fakeCreditService();
+        $this->seedQualified($referrer, 1);
+        $service->settleRewards($referrer);
+
+        $month = (int) config('subscription.premium.amounts.month');
+        $this->assertSame([['user' => $referrer->id, 'amount' => $month]], $service->credited);
+
+        $reward = AffiliateReward::first();
+        $this->assertSame(AffiliateReward::DELIVERY_STRIPE_CREDIT, $reward->delivery);
+        $this->assertSame($month, $reward->amount_cents);
+        $this->assertSame(1, $reward->referrals_consumed);
+        $this->assertNull($referrer->fresh()->trial_ends_at); // access window untouched
+    }
+
+    public function test_listener_qualifies_on_invoice_paid_webhook(): void
+    {
+        config(['affiliate.referrals_per_free_month' => 5]);
+        $referrer = User::factory()->create();
+        $referred = User::factory()->create();
+        $referred->forceFill(['stripe_id' => 'cus_ref'])->save();
+        $referral = $this->pendingReferral($referrer, $referred);
+
+        $payload = ['type' => 'invoice.payment_succeeded', 'data' => ['object' => ['customer' => 'cus_ref']]];
+        (new QualifyReferralOnPayment(app(AffiliateRewardService::class)))->handle(new WebhookReceived($payload));
+
+        $this->assertSame(Referral::STATUS_QUALIFIED, $referral->fresh()->status);
+    }
+}

--- a/tests/Filament/ReferAndEarnPageTest.php
+++ b/tests/Filament/ReferAndEarnPageTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament;
+
+use App\Filament\App\Pages\ReferAndEarn;
+use App\Models\Referral;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ReferAndEarnPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        config(['affiliate.enabled' => true, 'premium.enabled' => false, 'affiliate.referrals_per_free_month' => 5]);
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    public function test_gated_off_when_dormant(): void
+    {
+        $this->actingUser();
+        config(['premium.enabled' => true]); // everyone premium => dormant
+
+        $this->assertFalse(ReferAndEarn::canAccess());
+        $this->assertFalse(ReferAndEarn::shouldRegisterNavigation());
+    }
+
+    public function test_visible_when_program_live(): void
+    {
+        $this->actingUser();
+
+        $this->assertTrue(ReferAndEarn::canAccess());
+        $this->assertTrue(ReferAndEarn::shouldRegisterNavigation());
+    }
+
+    public function test_renders_link_and_progress(): void
+    {
+        $user = $this->actingUser();
+
+        Livewire::test(ReferAndEarn::class)
+            ->assertOk()
+            ->assertSee($user->referralCode())
+            ->assertSee('0 / 5');
+    }
+
+    public function test_renders_referrals_with_status_and_progress(): void
+    {
+        $user = $this->actingUser();
+
+        $qualified = User::factory()->create(['name' => 'Paid Pat']);
+        Referral::create([
+            'referrer_id' => $user->id, 'referred_user_id' => $qualified->id,
+            'status' => Referral::STATUS_QUALIFIED, 'qualified_at' => now(),
+        ]);
+        $pending = User::factory()->create(['name' => 'Maybe Max']);
+        Referral::create([
+            'referrer_id' => $user->id, 'referred_user_id' => $pending->id,
+            'status' => Referral::STATUS_PENDING,
+        ]);
+
+        Livewire::test(ReferAndEarn::class)
+            ->assertOk()
+            ->assertSee('Paid Pat')
+            ->assertSee('Maybe Max')
+            ->assertSee('Qualified')
+            ->assertSee('Pending')
+            ->assertSee('1 / 5'); // one unconsumed qualified toward 5
+    }
+}

--- a/tests/Filament/Widgets/ReferralProgressWidgetTest.php
+++ b/tests/Filament/Widgets/ReferralProgressWidgetTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Widgets;
+
+use App\Filament\App\Widgets\ReferralProgressWidget;
+use App\Models\Referral;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class ReferralProgressWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        config(['affiliate.enabled' => true, 'premium.enabled' => false, 'affiliate.referrals_per_free_month' => 5]);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    /** @return array<string, Stat> label => stat */
+    private function stats(): array
+    {
+        $method = new ReflectionMethod(ReferralProgressWidget::class, 'getStats');
+        $method->setAccessible(true);
+
+        return collect($method->invoke(new ReferralProgressWidget))
+            ->keyBy(fn (Stat $s): string => $s->getLabel())
+            ->all();
+    }
+
+    public function test_hidden_when_dormant(): void
+    {
+        $this->actingUser();
+        config(['premium.enabled' => true]); // everyone premium => dormant
+
+        $this->assertFalse(ReferralProgressWidget::canView());
+    }
+
+    public function test_visible_when_live(): void
+    {
+        $this->actingUser();
+
+        $this->assertTrue(ReferralProgressWidget::canView());
+    }
+
+    public function test_stats_reflect_progress(): void
+    {
+        $user = $this->actingUser();
+
+        $stats = $this->stats();
+        $this->assertSame('0 / 5', $stats['Next free month']->getValue());
+        $this->assertSame(0, $stats['Free months earned']->getValue());
+
+        $referred = User::factory()->create();
+        Referral::create([
+            'referrer_id' => $user->id, 'referred_user_id' => $referred->id,
+            'status' => Referral::STATUS_QUALIFIED, 'qualified_at' => now(),
+        ]);
+
+        $this->assertSame('1 / 5', $this->stats()['Next free month']->getValue());
+    }
+}

--- a/tests/Unit/FabricationGateTest.php
+++ b/tests/Unit/FabricationGateTest.php
@@ -41,6 +41,11 @@ final class FabricationGateTest extends TestCase
                 'Kit variable_name identifier, generated inside a collision-retry loop that re-rolls until unique.',
             ),
             new AllowlistEntry(
+                'Models/User.php', 'Str::random', 'identifier',
+                'Affiliate referral_code — a unique share identifier generated in a collision-retry loop '
+                .'(ensureReferralCode), not an invented domain value.',
+            ),
+            new AllowlistEntry(
                 'Services/VideoConferencing/GoogleMeetService.php', 'uniqid', 'api-request-id',
                 'requestId for the Google Meet createRequest call — an external API request identifier.',
             ),


### PR DESCRIPTION
Closes #1621.

Refer users who buy Premium to earn free months. The program is **active only when premium is a paid product** and **dormant when `PREMIUM_ENABLED=true`** (everyone is premium, so a free-month reward is meaningless). One gate: `App\Support\Affiliate::enabled()`.

## Flow
Unique referral link → cookie captures `?ref=CODE` for guests → bound to a **pending** referral at signup → the referred user's **first premium payment** flips it to **qualified** → every **N** (env, default 5) unconsumed qualified referrals grants **one free month**.

## What's included
- **Foundations** — `config/affiliate.php` (`AFFILIATE_ENABLED`, `AFFILIATE_REFERRALS_PER_FREE_MONTH=5`), `users.referral_code` (lazy, unique), `referrals` + `affiliate_rewards` tables/models. Not team-scoped (person-to-person).
- **Attribution** — `CaptureReferral` middleware (guests only, dormant-safe); `CreateNewUser` binds one pending referral at signup; `User::referralLink()`.
- **Reward engine** — `QualifyReferralOnPayment` listener on Cashier `invoice.payment_succeeded` + `AffiliateRewardService`. Idempotent qualify (renewals/replays are no-ops); threshold loop settles backlogs; **hybrid delivery** — Stripe balance credit for subscribers, 30-day `trial_ends_at` extension otherwise. Credits **one month's price** (not the interval amount — that would over-credit yearly subscribers).
- **UI** — user-scoped **Refer & Earn** app page (copyable link, progress bar, referral list, rewards) + a dashboard **ReferralProgressWidget**; both hidden/blocked when dormant.

## Out of scope (deliberate)
Cash payouts, yearly milestone awards, refund/chargeback clawback, admin oversight view.

## Verification
- **24 new tests**; full suite **982 passed, 12 skipped, 0 failed**.
- **PHPStan level 4** clean (`paths: app`), **Pint `--test`** clean.
- One `users` column + two tables; **no new dependency**.