### PR TITLE
feat: redirect non-premium users to sign-up instead of 403 (#1630)

### DIFF
--- a/app/Exceptions/PremiumRequiredException.php
+++ b/app/Exceptions/PremiumRequiredException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+/**
+ * Thrown by a premium Filament surface's canAccess() when the current user may
+ * not use premium features. A single handler in bootstrap/app.php renders it as
+ * a redirect to the sign-up path (upstream #1630) instead of a bare 403 — so a
+ * non-premium user who reaches a gated URL is sent to buy, not stonewalled.
+ *
+ * It is a *distinct* exception on purpose: plain HttpException 403s (tenant/team
+ * boundaries like TeamMembers / TreePrivacy) must keep 403ing, so the handler
+ * keys on this type, not on the 403 status. See the payment-gate map decision.
+ *
+ * canAccess() stays a bool for premium users (returns true) — the throw only
+ * replaces the false branch, and nav never reaches it because
+ * shouldRegisterNavigation() already hides the item from non-premium users.
+ */
+class PremiumRequiredException extends Exception
+{
+    /**
+     * Throw unless the current user may use premium features. Mirrors the
+     * canonical gate: the global switch, or the user's own premium status.
+     */
+    public static function unlessPremium(): void
+    {
+        if (config('premium.enabled')) {
+            return;
+        }
+
+        if (auth()->user()?->isPremium() ?? false) {
+            return;
+        }
+
+        throw new self;
+    }
+}

--- a/app/Filament/App/Pages/DnaTriangulationPage.php
+++ b/app/Filament/App/Pages/DnaTriangulationPage.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Pages;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Models\Dna;
 use App\Services\Dna\SegmentMatcher;
 use App\Services\DnaTriangulationService;
@@ -51,12 +52,11 @@ class DnaTriangulationPage extends Page implements HasForms
     public static function canAccess(): bool
     {
         // Server-side premium gate: hiding the nav item is not enough, the
-        // page URL must reject non-premium users directly.
-        if (config('premium.enabled')) {
-            return true;
-        }
+        // page URL must reject non-premium users directly. Throws (rather than
+        // returning false) so the handler redirects to sign-up (#1630).
+        PremiumRequiredException::unlessPremium();
 
-        return auth()->user()?->isPremium() ?? false;
+        return true;
     }
 
     public function mount(): void

--- a/app/Filament/App/Resources/DnaMatchingResource.php
+++ b/app/Filament/App/Resources/DnaMatchingResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Filament\App\Resources\DnaMatchingResource\Pages\CreateDnaMatching;
 use App\Filament\App\Resources\DnaMatchingResource\Pages\EditDnaMatching;
 use App\Filament\App\Resources\DnaMatchingResource\Pages\ListDnaMatchings;
@@ -59,12 +60,11 @@ class DnaMatchingResource extends AppResource
     public static function canAccess(): bool
     {
         // Server-side premium gate: hiding the nav item is not enough, the
-        // resource URL must reject non-premium users directly.
-        if (config('premium.enabled')) {
-            return true;
-        }
+        // resource URL must reject non-premium users directly. Throws (rather
+        // than returning false) so the handler redirects to sign-up (#1630).
+        PremiumRequiredException::unlessPremium();
 
-        return auth()->user()?->isPremium() ?? false;
+        return true;
     }
 
     #[\Override]

--- a/app/Filament/App/Resources/DnaResource.php
+++ b/app/Filament/App/Resources/DnaResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Filament\App\Resources\DnaResource\Pages\CreateDna;
 use App\Filament\App\Resources\DnaResource\Pages\EditDna;
 use App\Filament\App\Resources\DnaResource\Pages\ListDnas;
@@ -52,12 +53,11 @@ class DnaResource extends AppResource
     public static function canAccess(): bool
     {
         // Server-side premium gate: hiding the nav item is not enough, the
-        // resource URL must reject non-premium users directly.
-        if (config('premium.enabled')) {
-            return true;
-        }
+        // resource URL must reject non-premium users directly. Throws (rather
+        // than returning false) so the handler redirects to sign-up (#1630).
+        PremiumRequiredException::unlessPremium();
 
-        return auth()->user()?->isPremium() ?? false;
+        return true;
     }
 
     #[Override]

--- a/app/Filament/App/Resources/DuplicateCheckResource.php
+++ b/app/Filament/App/Resources/DuplicateCheckResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Filament\App\Resources\DuplicateCheckResource\Pages\ListDuplicateChecks;
 use App\Filament\App\Resources\DuplicateCheckResource\Pages\ViewDuplicateCheck;
 use App\Models\DuplicateCheck;
@@ -44,11 +45,11 @@ class DuplicateCheckResource extends AppResource
     #[\Override]
     public static function canAccess(): bool
     {
-        if (config('premium.enabled')) {
-            return true;
-        }
+        // Throws (rather than returning false) so the handler redirects a
+        // non-premium user to sign-up instead of showing a bare 403 (#1630).
+        PremiumRequiredException::unlessPremium();
 
-        return Auth::user()?->isPremium() ?? false;
+        return true;
     }
 
     #[\Override]

--- a/app/Filament/App/Resources/SmartMatchResource.php
+++ b/app/Filament/App/Resources/SmartMatchResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Filament\App\Resources\SmartMatchResource\Pages\ListSmartMatches;
 use App\Filament\App\Resources\SmartMatchResource\Pages\ViewSmartMatch;
 use App\Models\SmartMatch;
@@ -47,11 +48,11 @@ class SmartMatchResource extends AppResource
     #[\Override]
     public static function canAccess(): bool
     {
-        if (config('premium.enabled')) {
-            return true;
-        }
+        // Throws (rather than returning false) so the handler redirects a
+        // non-premium user to sign-up instead of showing a bare 403 (#1630).
+        PremiumRequiredException::unlessPremium();
 
-        return Auth::user()?->isPremium() ?? false;
+        return true;
     }
 
     #[\Override]

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\PremiumRequiredException;
 use App\Http\Middleware\CaptureReferral;
 use App\Http\Middleware\SecurityHeaders;
 use Filament\Forms\Form;
@@ -7,6 +8,8 @@ use Filament\Schemas\Schema;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
 
 if (! class_exists(Form::class) && class_exists(Schema::class)) {
     class_alias(Schema::class, Form::class);
@@ -37,5 +40,24 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->throttleApi('60,1');
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        // A non-premium user who reaches a gated premium surface is redirected
+        // to sign-up rather than shown a bare 403 (upstream #1630). Keyed on the
+        // exception type, so tenant/team 403s (TeamMembers, TreePrivacy) fall
+        // through untouched. Target mirrors PremiumDashboardPage::mount().
+        $exceptions->render(function (PremiumRequiredException $e) {
+            $user = auth()->user();
+
+            if (! $user) {
+                return new Response('Forbidden', 403);
+            }
+
+            $route = $user->hasExpiredTrial()
+                ? 'filament.app.pages.trial-expired'
+                : 'filament.app.pages.subscription';
+
+            // Build the RedirectResponse directly: the redirect() helper resolves
+            // Livewire's Redirector inside a Livewire request, which is not a
+            // Symfony Response and breaks the panel's typed middleware.
+            return new RedirectResponse(route($route, ['tenant' => $user->currentTeam]));
+        });
     })->create();

--- a/tests/Feature/Dna/DnaTriangulationPageAccessTest.php
+++ b/tests/Feature/Dna/DnaTriangulationPageAccessTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Dna;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Filament\App\Pages\DnaTriangulationPage;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,13 +13,14 @@ class DnaTriangulationPageAccessTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_can_access_denied_for_non_premium_user(): void
+    public function test_can_access_throws_for_non_premium_user(): void
     {
         config(['premium.enabled' => false]);
         $user = User::factory()->create(['is_premium' => false, 'trial_ends_at' => null]);
         Auth::login($user);
 
-        $this->assertFalse(DnaTriangulationPage::canAccess());
+        $this->expectException(PremiumRequiredException::class);
+        DnaTriangulationPage::canAccess();
     }
 
     public function test_can_access_allowed_for_trialing_premium_user(): void

--- a/tests/Feature/Filament/PremiumGateRedirectTest.php
+++ b/tests/Feature/Filament/PremiumGateRedirectTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Pages\DnaTriangulationPage;
+use App\Filament\App\Pages\TeamMembers;
+use App\Filament\App\Resources\DnaMatchingResource;
+use App\Filament\App\Resources\DnaResource;
+use App\Filament\App\Resources\DuplicateCheckResource;
+use App\Filament\App\Resources\SmartMatchResource;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * #1630: a non-premium user who reaches a gated premium surface by direct URL
+ * is redirected to sign-up, not shown a bare 403. The gate throws
+ * PremiumRequiredException; the handler in bootstrap/app.php converts it to a
+ * redirect. Revert-sensitive: before #1630 the gate returned false → 403, so the
+ * assertRedirect assertions fail on the old code.
+ */
+class PremiumGateRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAsUser(array $attributes): User
+    {
+        $user = User::factory()->withPersonalTeam()->create($attributes);
+        $this->actingAs($user);
+        Filament::setTenant($user->currentTeam, isQuiet: true);
+
+        return $user;
+    }
+
+    /** @return array<string,string> Every gated premium surface's URL. */
+    private function premiumUrls(): array
+    {
+        return [
+            'dna' => DnaResource::getUrl('index'),
+            'dna-matching' => DnaMatchingResource::getUrl('index'),
+            'smart-match' => SmartMatchResource::getUrl('index'),
+            'duplicate-check' => DuplicateCheckResource::getUrl('index'),
+            'triangulation' => DnaTriangulationPage::getUrl(),
+        ];
+    }
+
+    public function test_non_premium_user_is_redirected_to_subscription_on_every_gated_surface(): void
+    {
+        config(['premium.enabled' => false]);
+        $user = $this->actingAsUser(['is_premium' => false, 'trial_ends_at' => null]);
+        $target = route('filament.app.pages.subscription', ['tenant' => $user->currentTeam]);
+
+        foreach ($this->premiumUrls() as $label => $url) {
+            $this->get($url)->assertRedirect($target);
+        }
+    }
+
+    public function test_expired_trial_user_is_redirected_to_trial_expired(): void
+    {
+        config(['premium.enabled' => false]);
+        $user = $this->actingAsUser(['is_premium' => true, 'trial_ends_at' => now()->subDay()]);
+
+        $this->get(DnaResource::getUrl('index'))->assertRedirect(
+            route('filament.app.pages.trial-expired', ['tenant' => $user->currentTeam]),
+        );
+    }
+
+    public function test_a_non_premium_tenant_403_is_not_hijacked_into_a_signup_redirect(): void
+    {
+        config(['premium.enabled' => false]);
+
+        $owner = User::factory()->withPersonalTeam()->create();
+        $team = $owner->currentTeam;
+
+        // A non-owner member who is also non-premium. TeamMembers is owner-only,
+        // so it 403s for a tenant reason — the handler keys on the exception
+        // type, not on "any 403 from a non-premium user", so this stays a 403.
+        $member = User::factory()->create(['is_premium' => false, 'current_team_id' => $team->id]);
+        $team->users()->attach($member, ['role' => 'viewer']);
+
+        $this->actingAs($member->fresh());
+        Filament::setTenant($team->fresh(), isQuiet: true);
+
+        $this->get(TeamMembers::getUrl(['tenant' => $team]))->assertStatus(403);
+    }
+}

--- a/tests/Filament/Resources/DnaMatchingResourceTest.php
+++ b/tests/Filament/Resources/DnaMatchingResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Filament\Resources;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Filament\App\Resources\DnaMatchingResource;
 use App\Models\DnaMatching;
 use App\Models\User;
@@ -50,13 +51,14 @@ class DnaMatchingResourceTest extends TestCase
         $this->assertDatabaseMissing('dna_matchings', ['id' => $dnaMatching->id]);
     }
 
-    public function test_can_access_denied_for_non_premium_user(): void
+    public function test_can_access_throws_for_non_premium_user(): void
     {
         config(['premium.enabled' => false]);
         $user = User::factory()->create(['is_premium' => false, 'trial_ends_at' => null]);
         Auth::login($user);
 
-        $this->assertFalse(DnaMatchingResource::canAccess());
+        $this->expectException(PremiumRequiredException::class);
+        DnaMatchingResource::canAccess();
     }
 
     public function test_can_access_allowed_for_trialing_premium_user(): void

--- a/tests/Filament/Resources/DnaResourceTest.php
+++ b/tests/Filament/Resources/DnaResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Filament\Resources;
 
+use App\Exceptions\PremiumRequiredException;
 use App\Filament\App\Resources\DnaResource;
 use App\Models\Dna;
 use App\Models\User;
@@ -61,13 +62,16 @@ class DnaResourceTest extends TestCase
         $this->assertFalse(DnaResource::canCreate());
     }
 
-    public function test_can_access_denied_for_non_premium_user(): void
+    public function test_can_access_throws_for_non_premium_user(): void
     {
         config(['premium.enabled' => false]);
         $user = User::factory()->create(['is_premium' => false, 'trial_ends_at' => null]);
         Auth::login($user);
 
-        $this->assertFalse(DnaResource::canAccess());
+        // The gate throws instead of returning false so the handler can redirect
+        // a non-premium user to sign-up rather than 403 (#1630).
+        $this->expectException(PremiumRequiredException::class);
+        DnaResource::canAccess();
     }
 
     public function test_can_access_allowed_for_trialing_premium_user(): void


### PR DESCRIPTION
## What

Gated premium Filament surfaces returned a bare **403** when a non-premium user reached them by direct URL. This sends them to the **sign-up path** instead (upstream #1630).

## How

- The gate on each premium surface — `DnaResource`, `DnaMatchingResource`, `SmartMatchResource`, `DuplicateCheckResource`, `DnaTriangulationPage` — now throws `PremiumRequiredException` from `canAccess()` instead of returning `false`.
- A single handler in `bootstrap/app.php` renders it as a redirect: expired trials → trial-expired page, everyone else → subscription page, tenant-aware.
- Keyed on the exception **type**, so plain tenant/team 403s (`TeamMembers`, `TreePrivacy`) stay 403.
- `canAccess()` still returns `true` for premium users, and nav never triggers the throw because `shouldRegisterNavigation()` short-circuits before Filament reaches `canAccess()` — no per-page changes needed.
- Redirect is built as a plain `RedirectResponse`: inside a Livewire request the `redirect()` helper resolves Livewire's `Redirector`, which is not a Symfony `Response` and breaks the panel's typed middleware.

## Tests

- New `PremiumGateRedirectTest`: 302 on all five surfaces, the expired-trial branch, and the tenant-403 boundary that must stay 403.
- The three existing `canAccess()`-returns-false unit tests now assert the throw.
- Full suite: 985 passed / 0 failed. Pint clean. PHPStan level 4 clean.

## Note

Branch is stacked on `feat/1621-affiliate-referrals`, so its affiliate commit (#1621) appears in this diff until that PR merges. Only the `#1630` commit is this PR's own work.