### PR TITLE
feat(subscription): clearer monthly/yearly choice, drop the stale free plan (#1635)

### DIFF
--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -181,7 +181,22 @@ class SubscriptionService
                 'interval' => $interval,
                 'amount' => $this->amountFor($interval),
                 'price' => $this->formatPrice($interval),
+                // What the plan works out to per month, so the two intervals are
+                // comparable at a glance ($2.50/mo vs $2.99/mo).
+                'per_month' => Cashier::formatAmount(
+                    (int) round($this->amountFor($interval) / ($interval === 'year' ? 12 : 1)),
+                    $this->currency(),
+                ),
             ];
+        }
+
+        // What choosing yearly actually saves against paying monthly for a year.
+        // Derived from the same amounts that are charged, never hardcoded.
+        $twelveMonths = $this->amountFor('month') * 12;
+        $saving = $twelveMonths - $this->amountFor('year');
+        if ($twelveMonths > 0 && $saving > 0) {
+            $intervals['year']['savings'] = Cashier::formatAmount($saving, $this->currency());
+            $intervals['year']['savings_percent'] = (int) round($saving / $twelveMonths * 100);
         }
 
         return [

--- a/resources/views/filament/app/pages/subscription-page.blade.php
+++ b/resources/views/filament/app/pages/subscription-page.blade.php
@@ -15,105 +15,74 @@
                 <h1 class="text-3xl font-bold mb-2">Upgrade to Premium</h1>
                 <p class="text-lg opacity-90 mb-6">Unlock powerful genealogy tools and unlimited features</p>
 
-                <div class="bg-white/10 rounded-lg p-4 inline-block">
-                    <div class="text-4xl font-bold">{{ $selected['price'] }}</div>
-                    <div class="text-sm opacity-75">per {{ $selected['interval'] }}</div>
-                </div>
-
-                @if($pricing['trial_days'] > 0)
-                    <div class="mt-6">
-                        <div class="bg-yellow-400 text-yellow-900 px-4 py-2 rounded-full inline-block font-semibold">
-                            🎉 {{ $pricing['trial_days'] }}-Day Free Trial
-                        </div>
-                    </div>
-                @endif
             </div>
         </div>
 
-        <!-- Feature Comparison -->
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            <!-- Standard Plan -->
+        {{-- One plan. There is no free tier (#1635) — the old "Standard · Free
+             forever · $0" column advertised a plan that no longer exists. --}}
+        <div class="mx-auto w-full max-w-xl">
             <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-                <div class="text-center mb-6">
-                    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Standard</h3>
-                    <p class="text-gray-500 dark:text-gray-400">Free forever</p>
-                    <div class="text-3xl font-bold text-gray-900 dark:text-white mt-2">$0</div>
-                </div>
-
-                <ul class="space-y-3">
-                    <li class="flex items-center">
-                        @svg('heroicon-o-check', 'h-5 w-5 text-green-500 mr-3')
-                        <span class="text-gray-700 dark:text-gray-300">Basic family tree</span>
-                    </li>
-                    <li class="flex items-center">
-                        @svg('heroicon-o-check', 'h-5 w-5 text-green-500 mr-3')
-                        <span class="text-gray-700 dark:text-gray-300">Standard charts</span>
-                    </li>
-                    <li class="flex items-center">
-                        @svg('heroicon-o-check', 'h-5 w-5 text-green-500 mr-3')
-                        <span class="text-gray-700 dark:text-gray-300">1 DNA kit upload</span>
-                    </li>
-                    <li class="flex items-center">
-                        @svg('heroicon-o-x-mark', 'h-5 w-5 text-red-500 mr-3')
-                        <span class="text-gray-400 line-through">Premium badge</span>
-                    </li>
-                    <li class="flex items-center">
-                        @svg('heroicon-o-x-mark', 'h-5 w-5 text-red-500 mr-3')
-                        <span class="text-gray-400 line-through">Duplicate checker</span>
-                    </li>
-                    <li class="flex items-center">
-                        @svg('heroicon-o-x-mark', 'h-5 w-5 text-red-500 mr-3')
-                        <span class="text-gray-400 line-through">Smart matching</span>
-                    </li>
-                </ul>
-            </div>
-
-            <!-- Premium Plan -->
-            <div class="bg-gradient-to-br from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/20 rounded-lg border-2 border-purple-200 dark:border-purple-700 p-6 relative">
-                <div class="absolute -top-3 left-1/2 transform -translate-x-1/2">
-                    <span class="bg-gradient-to-r from-purple-500 to-pink-500 text-white px-4 py-1 rounded-full text-sm font-semibold">
-                        Most Popular
-                    </span>
-                </div>
-
-                <div class="text-center mb-6">
+                <div class="mb-6">
                     <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Premium</h3>
-                    @if($pricing['trial_days'] > 0)
-                        <p class="text-gray-500 dark:text-gray-400">{{ $pricing['trial_days'] }}-day free trial</p>
-                    @endif
-                    <div class="text-3xl font-bold text-gray-900 dark:text-white mt-2">{{ $selected['price'] }}</div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">per {{ $selected['interval'] }}</p>
-
-                    <!-- Billing interval toggle -->
-                    <div class="mt-4 inline-flex rounded-lg border border-purple-200 dark:border-purple-700 p-1" role="group" aria-label="Billing interval">
-                        <button
-                            type="button"
-                            wire:click="$set('interval', 'month')"
-                            @class([
-                                'px-4 py-1.5 text-sm font-medium rounded-md transition',
-                                'bg-purple-600 text-white' => $this->interval === 'month',
-                                'text-gray-600 dark:text-gray-300' => $this->interval !== 'month',
-                            ])
-                            aria-pressed="{{ $this->interval === 'month' ? 'true' : 'false' }}"
-                        >
-                            Monthly · {{ $pricing['intervals']['month']['price'] }}
-                        </button>
-                        <button
-                            type="button"
-                            wire:click="$set('interval', 'year')"
-                            @class([
-                                'px-4 py-1.5 text-sm font-medium rounded-md transition',
-                                'bg-purple-600 text-white' => $this->interval === 'year',
-                                'text-gray-600 dark:text-gray-300' => $this->interval !== 'year',
-                            ])
-                            aria-pressed="{{ $this->interval === 'year' ? 'true' : 'false' }}"
-                        >
-                            Yearly · {{ $pricing['intervals']['year']['price'] }}
-                        </button>
-                    </div>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Choose how you'd like to be billed.</p>
                 </div>
 
-                <ul class="space-y-3">
+                {{-- Billing interval. Rows rather than a segmented toggle so each
+                     option can state its own per-month equivalent, what it saves
+                     and how often it bills — the facts the choice turns on. --}}
+                <div class="space-y-2" role="radiogroup" aria-label="Billing interval">
+                    @foreach ($pricing['intervals'] as $key => $option)
+                        @php $isSelected = $this->interval === $key; @endphp
+                        <button
+                            type="button"
+                            role="radio"
+                            aria-checked="{{ $isSelected ? 'true' : 'false' }}"
+                            wire:click="$set('interval', '{{ $key }}')"
+                            @class([
+                                'flex w-full items-center gap-3 rounded-lg border p-4 text-left transition',
+                                'border-primary-500 bg-primary-50 dark:bg-primary-500/10' => $isSelected,
+                                'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600' => ! $isSelected,
+                            ])
+                        >
+                            <span @class([
+                                'relative h-4 w-4 shrink-0 rounded-full border-2',
+                                'border-primary-600 bg-primary-600' => $isSelected,
+                                'border-gray-300 dark:border-gray-600' => ! $isSelected,
+                            ])>
+                                @if ($isSelected)
+                                    <span class="absolute inset-[3px] rounded-full bg-white"></span>
+                                @endif
+                            </span>
+
+                            <span class="min-w-0">
+                                <span class="flex flex-wrap items-center gap-2 font-semibold text-gray-900 dark:text-white">
+                                    {{ $key === 'year' ? 'Yearly' : 'Monthly' }}
+                                    @isset($option['savings'])
+                                        <span class="rounded-full bg-success-100 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-success-700 dark:bg-success-500/20 dark:text-success-400">
+                                            Save {{ $option['savings'] }}
+                                        </span>
+                                    @endisset
+                                </span>
+                                <span class="mt-0.5 block text-sm text-gray-500 dark:text-gray-400">
+                                    {{ $key === 'year'
+                                        ? $option['price'].' billed once a year'
+                                        : 'Billed every month' }}
+                                </span>
+                            </span>
+
+                            <span class="ml-auto shrink-0 text-right tabular-nums">
+                                <span class="block font-semibold text-gray-900 dark:text-white">{{ $option['per_month'] }}</span>
+                                <span class="block text-xs text-gray-500 dark:text-gray-400">per month</span>
+                            </span>
+                        </button>
+                    @endforeach
+                </div>
+
+                <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
+                    You'll be charged {{ $selected['price'] }} today, then every {{ $selected['interval'] }}. Cancel anytime.
+                </p>
+
+                <ul class="mt-6 space-y-3">
                     @foreach($this->getPricingData()['premium']['features'] as $feature)
                         <li class="flex items-center">
                             @svg('heroicon-o-check', 'h-5 w-5 text-green-500 mr-3')
@@ -173,7 +142,7 @@
 
                 <div class="text-center">
                     <div class="text-2xl font-bold text-purple-600 dark:text-purple-400">
-                        Standard
+                        None
                     </div>
                     <div class="text-sm text-gray-500 dark:text-gray-400">
                         Current plan
@@ -188,9 +157,9 @@
 
             <div class="space-y-4">
                 <div>
-                    <h4 class="font-medium text-gray-900 dark:text-white">What happens during the free trial?</h4>
+                    <h4 class="font-medium text-gray-900 dark:text-white">Can I switch between monthly and yearly?</h4>
                     <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                        You get full access to all premium features for {{ config('subscription.premium.trial_days', 14) }} days. No payment required upfront.
+                        Yes. Once you're subscribed you can switch billing interval from the billing portal, and we'll prorate the difference.
                     </p>
                 </div>
 

--- a/tests/Feature/Filament/SubscriptionPageTest.php
+++ b/tests/Feature/Filament/SubscriptionPageTest.php
@@ -24,6 +24,37 @@ class SubscriptionPageTest extends TestCase
         return $user;
     }
 
+    public function test_page_advertises_no_free_plan(): void
+    {
+        // The app is subscription-only (#1635): the page used to sell a
+        // "Standard · Free forever · $0" column and a free-trial FAQ.
+        config(['premium.enabled' => false]);
+        $this->actingUser();
+
+        Livewire::test(SubscriptionPage::class)
+            ->assertDontSee('Free forever')
+            ->assertDontSee('$0')
+            ->assertDontSee('What happens during the free trial?');
+    }
+
+    public function test_billing_interval_rows_show_savings_and_drive_checkout(): void
+    {
+        config([
+            'premium.enabled' => false,
+            'subscription.premium.amounts.month' => 299,
+            'subscription.premium.amounts.year' => 2999,
+        ]);
+        $this->actingUser();
+
+        Livewire::test(SubscriptionPage::class)
+            // Monthly is the default; yearly advertises what it saves.
+            ->assertSee('Save $5.89')
+            ->assertSee('$29.99 billed once a year')
+            ->assertSee('charged $2.99 today')
+            ->set('interval', 'year')
+            ->assertSee('charged $29.99 today');
+    }
+
     public function test_page_offers_subscribe_and_never_a_trial_button(): void
     {
         // The app is subscription-only (#1635): the no-card trial button is
@@ -66,8 +97,8 @@ class SubscriptionPageTest extends TestCase
                 'trial_days' => 14,
                 'require_card' => true,
                 'intervals' => [
-                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99'],
-                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99'],
+                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99', 'per_month' => '$2.99'],
+                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99', 'per_month' => '$2.50', 'savings' => '$5.89', 'savings_percent' => 16],
                 ],
                 'features' => [],
             ],
@@ -104,8 +135,8 @@ class SubscriptionPageTest extends TestCase
             'premium' => [
                 'name' => 'Premium', 'trial_days' => 14, 'require_card' => true,
                 'intervals' => [
-                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99'],
-                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99'],
+                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99', 'per_month' => '$2.99'],
+                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99', 'per_month' => '$2.50', 'savings' => '$5.89', 'savings_percent' => 16],
                 ],
                 'features' => [],
             ],

--- a/tests/Unit/Services/SubscriptionServiceTest.php
+++ b/tests/Unit/Services/SubscriptionServiceTest.php
@@ -48,6 +48,36 @@ class SubscriptionServiceTest extends TestCase
         $this->assertIsArray($pricingInfo['premium']['features']);
     }
 
+    public function test_pricing_info_derives_per_month_and_yearly_savings(): void
+    {
+        // $2.99/month vs $29.99/year: $2.50 a month, saving $5.89 (16%) against
+        // twelve monthly charges. Derived from the charged amounts, never hardcoded.
+        config([
+            'subscription.premium.amounts.month' => 299,
+            'subscription.premium.amounts.year' => 2999,
+        ]);
+
+        $intervals = $this->subscriptionService->getPricingInfo()['premium']['intervals'];
+
+        $this->assertSame('$2.99', $intervals['month']['per_month']);
+        $this->assertSame('$2.50', $intervals['year']['per_month']);
+        $this->assertSame('$5.89', $intervals['year']['savings']);
+        $this->assertSame(16, $intervals['year']['savings_percent']);
+        $this->assertArrayNotHasKey('savings', $intervals['month']);
+    }
+
+    public function test_pricing_info_omits_savings_when_yearly_saves_nothing(): void
+    {
+        config([
+            'subscription.premium.amounts.month' => 299,
+            'subscription.premium.amounts.year' => 3588,
+        ]);
+
+        $intervals = $this->subscriptionService->getPricingInfo()['premium']['intervals'];
+
+        $this->assertArrayNotHasKey('savings', $intervals['year']);
+    }
+
     public function test_check_dna_upload_limit_for_non_premium_user(): void
     {
         $user = User::factory()->create(['is_premium' => false]);


### PR DESCRIPTION
Follow-up to the subscription paywall (#1635, merged in #1643). Two problems on the subscription page, which is now the one page a non-subscriber is forced to see.

## The page still sold a plan that no longer exists

It advertised a **"Standard · Free forever · $0"** column with a feature list, reported **"Current plan: Standard"**, and answered **"What happens during the free trial?"** — none of which survive the paywall. Same contradiction the home page had, missed on this page. Now: one Premium plan, "Current plan: None", and the trial FAQ replaced with "Can I switch between monthly and yearly?".

## The monthly/yearly switch hid the fact the choice turns on

The segmented toggle read "Monthly · $2.99 / Yearly · $29.99" — the third repetition of the price on the page — and never said that yearly is $29.99 against **$35.88** billed monthly. The saving was left as arithmetic for the reader.

Replaced with selectable rows, each stating its own per-month equivalent, what it saves, and how often it bills:

```
(o) Monthly                                  $2.99
    Billed every month                   per month

( ) Yearly  [SAVE $5.89]                     $2.50
    $29.99 billed once a year            per month

You'll be charged $2.99 today, then every month. Cancel anytime.
```

`per_month`, `savings` and `savings_percent` are derived in `getPricingInfo()` from the same configured amounts that are charged, so the displayed saving cannot drift from the bill — and if yearly is ever priced at no discount, the badge disappears on its own (covered by a test).

Also dropped the "Most Popular" badge (meaningless with a single plan) and the duplicated hero price, and swapped the hardcoded purple/pink for Filament's `primary`/`success` tokens so the card follows the panel theme.

## Testing

37 passing across the subscription, billing, paywall-gate, registration, home and doctor suites; Pint and PHPStan (level 4) clean.

Worth noting: these tests caught a real defect during the change — two mocked pricing fixtures didn't supply `per_month`, so the page threw. The fixtures were misstating the service contract, the same failure mode that let the original `property_exists` checkout bug survive CI. Fixed the fixtures rather than making the view defensive.

The four switch designs were prototyped and the rows variant chosen.
