### PR TITLE
feat(subscription): show the price in GBP/EUR alongside USD (#1636)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,12 @@ SUBSCRIPTION_PREMIUM_PRODUCT_NAME=Premium
 SUBSCRIPTION_PREMIUM_MONTHLY_AMOUNT=299
 SUBSCRIPTION_PREMIUM_YEARLY_AMOUNT=2999
 
+# Currencies shown beside the price as a converted estimate (issue #1636). Display
+# only — the charge is always CASHIER_CURRENCY. Rates come from the ECB's daily
+# reference feed, which publishes for information purposes only; if the feed is
+# unreachable the estimate is simply omitted. Empty disables it.
+SUBSCRIPTION_DISPLAY_CURRENCIES=GBP,EUR
+
 # Cashier Configuration
 CASHIER_CURRENCY=usd
 CASHIER_CURRENCY_LOCALE=en_US

--- a/app/Services/ExchangeRates.php
+++ b/app/Services/ExchangeRates.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use SimpleXMLElement;
+use Throwable;
+
+/**
+ * Converted price estimates from the ECB's daily euro reference rates (#1636).
+ *
+ * Display only. The ECB publishes these "for information purposes only" and
+ * strongly discourages transactional use, so nothing here may ever reach a
+ * charge — Stripe bills `cashier.currency` and only that. Whatever this returns
+ * is a label, and the surfaces that show it must cite the ECB as source and say
+ * the figure was converted by us (the ECB's terms require both).
+ */
+class ExchangeRates
+{
+    private const FEED = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml';
+
+    /**
+     * The feed's default namespace is on **ecb.int**, not ecb.europa.eu. Get this
+     * wrong and every XPath matches nothing — silently, which is indistinguishable
+     * from "the feed is down" and would make the estimate vanish for good.
+     */
+    private const NS = 'http://www.ecb.int/vocabulary/2002-08-01/eurofxref';
+
+    private const CACHE_KEY = 'ecb.eurofxref.daily';
+
+    /**
+     * Convert a minor-unit amount out of $base into each configured display currency.
+     *
+     * Returns null whenever there is nothing honest to show — no rates, an
+     * unquoted base, or no display currency left after filtering. Callers render
+     * the base-currency price alone; that is the whole failure mode.
+     *
+     * The `date` is the feed's own rate date, which is routinely older than today:
+     * the ECB publishes ~16:00 Europe/Berlin on working days and serves the last
+     * business day's rates at HTTP 200 all weekend and through TARGET holidays (a
+     * 4-day-old rate is normal around 1 May). Staleness is not failure — but it is
+     * the reason the date has to be shown next to the figure.
+     *
+     * @return array{date: string, amounts: array<string, int>}|null
+     */
+    public function estimate(int $amount, string $base): ?array
+    {
+        $feed = $this->rates();
+
+        if ($feed === null) {
+            return null;
+        }
+
+        $rates = $feed['rates'];
+
+        // EUR is the feed's own base, so it never appears as a row of its own.
+        $rates['EUR'] = 1.0;
+
+        $base = strtoupper($base);
+
+        if (! isset($rates[$base])) {
+            return null;
+        }
+
+        $amounts = [];
+
+        foreach ($this->displayCurrencies() as $code) {
+            if ($code === $base || ! isset($rates[$code])) {
+                continue;
+            }
+
+            // Rates are units-per-EUR, so crossing out of a non-EUR base means
+            // dividing by the base's rate and multiplying by the target's. The
+            // inverse reads just as plausibly and throws nothing, which is why
+            // ExchangeRatesTest pins the direction against known figures.
+            //
+            // Round once, here, on the final minor-unit amount — never the rate.
+            $amounts[$code] = (int) round($amount * $rates[$code] / $rates[$base]);
+        }
+
+        if ($amounts === []) {
+            return null;
+        }
+
+        return ['date' => $feed['date'], 'amounts' => $amounts];
+    }
+
+    /**
+     * Configured display currencies, upper-cased. Empty disables the estimate.
+     *
+     * @return list<string>
+     */
+    private function displayCurrencies(): array
+    {
+        /** @var list<string> $configured */
+        $configured = config('subscription.display_currencies', []);
+
+        return array_map('strtoupper', $configured);
+    }
+
+    /**
+     * @return array{date: string, rates: array<string, float>}|null
+     */
+    private function rates(): ?array
+    {
+        $cached = Cache::get(self::CACHE_KEY);
+
+        if (is_array($cached)) {
+            // [] is the cached-failure sentinel; Cache::remember can't express it
+            // because it treats null as a miss and would refetch on every request.
+            return $cached === [] ? null : $cached;
+        }
+
+        $fetched = $this->fetch();
+
+        // ponytail: a failure is cached for 15 minutes so a flapping feed can't be
+        // hammered once per page view, while a success holds the full day the ECB
+        // publishes on. Drop to a scheduled warm if first-hit latency ever shows up.
+        Cache::put(
+            self::CACHE_KEY,
+            $fetched ?? [],
+            $fetched === null ? now()->addMinutes(15) : now()->addDay(),
+        );
+
+        return $fetched;
+    }
+
+    /**
+     * @return array{date: string, rates: array<string, float>}|null
+     */
+    private function fetch(): ?array
+    {
+        try {
+            $response = Http::timeout(3)->get(self::FEED);
+        } catch (Throwable) {
+            // Connection refused, DNS failure, timeout — all the same to a caller
+            // that only wanted a decorative number.
+            return null;
+        }
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        return $this->parse($response->body());
+    }
+
+    /**
+     * @return array{date: string, rates: array<string, float>}|null
+     */
+    private function parse(string $body): ?array
+    {
+        // A bad path on this host answers 404 with an HTML error page, so the body
+        // is what decides whether we got rates, not the status line.
+        $xml = @simplexml_load_string($body);
+
+        if (! $xml instanceof SimpleXMLElement) {
+            return null;
+        }
+
+        $xml->registerXPathNamespace('ecb', self::NS);
+        $days = $xml->xpath('//ecb:Cube[@time]');
+
+        if (empty($days)) {
+            return null;
+        }
+
+        // The daily file has carried exactly one dated Cube every time it has been
+        // looked at, but the ECB publishes no schema saying it must, and the 90-day
+        // and full-history files use this identical shape with thousands. Taking the
+        // newest costs a loop and removes the assumption.
+        $latest = null;
+        $latestDate = '';
+
+        foreach ($days as $day) {
+            // ->attributes() rather than $day['time']: once an element is reached
+            // through the namespaced children()/xpath, array access looks the
+            // attribute up in that namespace, and these attributes have none — so
+            // it silently reads as empty. attributes() defaults to no namespace.
+            $date = (string) $day->attributes()['time'];
+
+            if ($latest === null || $date > $latestDate) {
+                $latest = $day;
+                $latestDate = $date;
+            }
+        }
+
+        $rates = [];
+
+        // The quoted currency set is not fixed — BGN left the file when Bulgaria
+        // joined the euro — so read what is there rather than expecting a list.
+        foreach ($latest->children(self::NS) as $row) {
+            $attributes = $row->attributes();
+            $code = strtoupper((string) $attributes['currency']);
+            $rate = (float) $attributes['rate'];
+
+            if ($code !== '' && $rate > 0.0) {
+                $rates[$code] = $rate;
+            }
+        }
+
+        if ($rates === []) {
+            return null;
+        }
+
+        return ['date' => $latestDate, 'rates' => $rates];
+    }
+}

--- a/app/Services/ExchangeRates.php
+++ b/app/Services/ExchangeRates.php
@@ -48,6 +48,14 @@ class ExchangeRates
      */
     public function estimate(int $amount, string $base): ?array
     {
+        // Checked before the fetch: with no display currencies there is nothing to
+        // convert into, so an install that leaves this empty never touches the feed.
+        $currencies = $this->displayCurrencies();
+
+        if ($currencies === []) {
+            return null;
+        }
+
         $feed = $this->rates();
 
         if ($feed === null) {
@@ -67,7 +75,7 @@ class ExchangeRates
 
         $amounts = [];
 
-        foreach ($this->displayCurrencies() as $code) {
+        foreach ($currencies as $code) {
             if ($code === $base || ! isset($rates[$code])) {
                 continue;
             }
@@ -86,6 +94,15 @@ class ExchangeRates
         }
 
         return ['date' => $feed['date'], 'amounts' => $amounts];
+    }
+
+    /**
+     * Rate date of the feed backing the estimate, or null when there is none.
+     * The surfaces print it — the ECB's terms require the figure be dated.
+     */
+    public function date(): ?string
+    {
+        return $this->displayCurrencies() === [] ? null : $this->rates()['date'] ?? null;
     }
 
     /**

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -16,6 +16,10 @@ class SubscriptionService
     /** The billing intervals the premium tier is offered at. */
     public const INTERVALS = ['month', 'year'];
 
+    // Defaulted rather than required so the many `new SubscriptionService` call
+    // sites — tests included — keep working without a container.
+    public function __construct(private readonly ExchangeRates $exchangeRates = new ExchangeRates) {}
+
     /**
      * Whether a card must be taken before premium access is granted. When true,
      * the no-card local-trial path is unavailable (issue #1614). Defaults on.
@@ -177,16 +181,20 @@ class SubscriptionService
     {
         $intervals = [];
         foreach (self::INTERVALS as $interval) {
+            $perMonth = (int) round($this->amountFor($interval) / ($interval === 'year' ? 12 : 1));
+
             $intervals[$interval] = [
                 'interval' => $interval,
                 'amount' => $this->amountFor($interval),
                 'price' => $this->formatPrice($interval),
                 // What the plan works out to per month, so the two intervals are
                 // comparable at a glance ($2.50/mo vs $2.99/mo).
-                'per_month' => Cashier::formatAmount(
-                    (int) round($this->amountFor($interval) / ($interval === 'year' ? 12 : 1)),
-                    $this->currency(),
-                ),
+                'per_month' => Cashier::formatAmount($perMonth, $this->currency()),
+                // Every figure the page shows converts, not just the headline: with
+                // a currency switcher, a page in GBP still showing "$2.50 per month"
+                // reads as a bug (#1636 ticket 02).
+                'price_amounts' => $this->displayAmounts($this->amountFor($interval)),
+                'per_month_amounts' => $this->displayAmounts($perMonth),
             ];
         }
 
@@ -196,6 +204,7 @@ class SubscriptionService
         $saving = $twelveMonths - $this->amountFor('year');
         if ($twelveMonths > 0 && $saving > 0) {
             $intervals['year']['savings'] = Cashier::formatAmount($saving, $this->currency());
+            $intervals['year']['savings_amounts'] = $this->displayAmounts($saving);
             $intervals['year']['savings_percent'] = (int) round($saving / $twelveMonths * 100);
         }
 
@@ -205,6 +214,9 @@ class SubscriptionService
                 'trial_days' => $this->trialDays(),
                 'require_card' => $this->requiresCard(),
                 'intervals' => $intervals,
+                // Null when there are no rates: the surfaces read this as "render no
+                // switcher and no attribution", falling back to the charge currency.
+                'estimate_date' => $this->estimateDate(),
                 'features' => [
                     'Premium user badge',
                     'Unlimited DNA kit uploads',
@@ -402,6 +414,40 @@ class SubscriptionService
     public function formatPrice(string $interval): string
     {
         return Cashier::formatAmount($this->amountFor($interval), $this->currency());
+    }
+
+    /**
+     * Every display form of one minor-unit amount, keyed by upper-case currency
+     * code, **charge currency first** (#1636). The surfaces render all of them and
+     * a script shows one; the first entry is what a reader with no stored choice,
+     * or no JavaScript, sees.
+     *
+     * With no rates available this is just the charge currency — which is exactly
+     * how the pages rendered before this feature, so the fallback is "unchanged".
+     *
+     * @return array<string, string>
+     */
+    public function displayAmounts(int $amount): array
+    {
+        $currency = $this->currency();
+        $amounts = [strtoupper($currency) => Cashier::formatAmount($amount, $currency)];
+
+        $estimate = $this->exchangeRates->estimate($amount, $currency);
+
+        foreach ($estimate['amounts'] ?? [] as $code => $minorUnits) {
+            $amounts[$code] = Cashier::formatAmount($minorUnits, strtolower($code));
+        }
+
+        return $amounts;
+    }
+
+    /**
+     * Rate date behind the estimate, or null when there is no estimate to show.
+     * Null is what tells a surface to render no switcher and no attribution.
+     */
+    public function estimateDate(): ?string
+    {
+        return $this->exchangeRates->date();
     }
 
     private function assertInterval(string $interval): void

--- a/config/subscription.php
+++ b/config/subscription.php
@@ -3,6 +3,17 @@
 declare(strict_types=1);
 
 return [
+    // Currencies shown beside the charge currency as a converted estimate (#1636).
+    // Display only — nothing is ever charged in these, and the ECB rates behind
+    // them are published for information purposes only. Comma-separated ISO 4217
+    // codes; an empty list disables the estimate entirely.
+    'display_currencies' => preg_split(
+        '/\s*,\s*/',
+        (string) env('SUBSCRIPTION_DISPLAY_CURRENCIES', 'GBP,EUR'),
+        -1,
+        PREG_SPLIT_NO_EMPTY,
+    ),
+
     'premium' => [
         // Require a card before granting premium access. When true, the no-card
         // local-trial path is unavailable and the only route to premium is a

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -43,5 +43,9 @@
         <env name="REVERB_APP_KEY" value="test"/>
         <env name="REVERB_APP_SECRET" value="test"/>
         <env name="STRIPE_WEBHOOK_SECRET" value="whsec_test_secret"/>
+        <!-- Off by default so rendering a price page never reaches for the live ECB
+             feed (#1636). Tests that want the estimate set the config themselves
+             and fake the HTTP call. -->
+        <env name="SUBSCRIPTION_DISPLAY_CURRENCIES" value=""/>
     </php>
 </phpunit>

--- a/resources/views/components/currency-switcher.blade.php
+++ b/resources/views/components/currency-switcher.blade.php
@@ -1,0 +1,93 @@
+{{--
+    Currency switcher + the attribution the ECB's terms require (#1636).
+
+    Renders nothing at all when there is no estimate to offer — no rates, one
+    currency, or the feature switched off — so every surface degrades to the
+    charge-currency markup it had before.
+
+    The choice is client-side only: no users.currency column, no cookie, no server
+    round-trip. Figures for every currency are already in the page (x-price), so
+    switching is a text swap.
+
+    Expects $amounts (any displayAmounts() map — only its keys are used) and $date,
+    the ECB rate date. The base currency is the first key.
+--}}
+@props(['amounts', 'date'])
+
+@php
+    $currencies = array_keys($amounts);
+    $base = $currencies[0] ?? null;
+@endphp
+
+@if ($date && count($currencies) > 1)
+    <div {{ $attributes->merge(['class' => 'text-label']) }}>
+        <div class="inline-flex gap-0.5 rounded-md border border-rule bg-surface p-0.5" role="group" aria-label="Display currency">
+            @foreach ($currencies as $code)
+                <button type="button"
+                        data-currency-option="{{ $code }}"
+                        aria-pressed="{{ $code === $base ? 'true' : 'false' }}"
+                        class="rounded px-2 py-1 text-xs tabular-nums text-ink-muted transition-colors duration-150 aria-pressed:bg-paper aria-pressed:font-semibold aria-pressed:text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-registry-green">
+                    {{ $code }}
+                </button>
+            @endforeach
+        </div>
+
+        {{-- Mandatory, not decorative: the ECB requires citation as source, and
+             because the cross-rate out of the charge currency is computed here it
+             also requires the figure be stated as modified. The date is required
+             too — the feed is routinely a day or more old (weekends, TARGET
+             holidays), and it is the rate's date, not today's. --}}
+        <p class="mt-2 text-xs text-ink-muted">
+            Charged in {{ $base }}. Other currencies are an estimate converted from
+            {{ $base }} at the euro reference rate of {{ $date }} — source: European
+            Central Bank, cross-rate calculated by us.
+        </p>
+    </div>
+
+    <script>
+        // Not bundled through Vite: this has to work on the two public Blade pages
+        // and inside the Filament panel, which do not share an entrypoint.
+        (() => {
+            if (window.__currencySwitcher) return;
+            window.__currencySwitcher = true;
+
+            const KEY = 'display-currency';
+
+            const apply = () => {
+                const chosen = localStorage.getItem(KEY);
+                if (!chosen) return;
+
+                document.querySelectorAll('[data-price]').forEach((el) => {
+                    const value = el.dataset[chosen.toLowerCase()];
+                    // Only write on a real change — a MutationObserver is watching,
+                    // and an unconditional assignment would re-trigger it forever.
+                    if (value && el.textContent !== value) el.textContent = value;
+                });
+
+                document.querySelectorAll('[data-currency-option]').forEach((button) => {
+                    button.setAttribute('aria-pressed', String(button.dataset.currencyOption === chosen));
+                });
+            };
+
+            document.addEventListener('click', (event) => {
+                const button = event.target.closest('[data-currency-option]');
+                if (!button) return;
+
+                localStorage.setItem(KEY, button.dataset.currencyOption);
+                apply();
+            });
+
+            // Livewire morphs the Filament page back to server HTML, which is always
+            // the charge currency. Observing the DOM re-applies the choice without
+            // binding to a particular Livewire version's hook names.
+            let queued = false;
+            new MutationObserver(() => {
+                if (queued) return;
+                queued = true;
+                requestAnimationFrame(() => { queued = false; apply(); });
+            }).observe(document.documentElement, { childList: true, subtree: true });
+
+            apply();
+        })();
+    </script>
+@endif

--- a/resources/views/components/price.blade.php
+++ b/resources/views/components/price.blade.php
@@ -1,0 +1,14 @@
+{{--
+    One money figure, carrying every currency it can be shown in (#1636).
+
+    The charge currency is rendered as the text, so a reader with no stored choice
+    — or no JavaScript at all — sees exactly what they saw before this feature and
+    exactly what Stripe will charge. x-currency-switcher's script rewrites the text
+    from the data-* attributes when a currency has been chosen.
+
+    Expects $amounts keyed by upper-case currency code, charge currency first —
+    i.e. SubscriptionService::displayAmounts().
+--}}
+@props(['amounts'])
+
+<span data-price @foreach ($amounts as $code => $formatted) data-{{ strtolower($code) }}="{{ $formatted }}" @endforeach {{ $attributes }}>{{ $amounts[array_key_first($amounts)] }}</span>

--- a/resources/views/filament/app/pages/subscription-page.blade.php
+++ b/resources/views/filament/app/pages/subscription-page.blade.php
@@ -25,6 +25,14 @@
                 <div class="mb-6">
                     <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Premium</h3>
                     <p class="text-sm text-gray-500 dark:text-gray-400">Choose how you'd like to be billed.</p>
+
+                    {{-- Every figure below converts with this (#1636). Renders
+                         nothing when there are no rates. --}}
+                    <x-currency-switcher
+                        :amounts="$selected['price_amounts']"
+                        :date="$pricing['estimate_date']"
+                        class="mt-4"
+                    />
                 </div>
 
                 {{-- Billing interval. Rows rather than a segmented toggle so each
@@ -59,19 +67,21 @@
                                     {{ $key === 'year' ? 'Yearly' : 'Monthly' }}
                                     @isset($option['savings'])
                                         <span class="rounded-full bg-success-100 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-success-700 dark:bg-success-500/20 dark:text-success-400">
-                                            Save {{ $option['savings'] }}
+                                            Save <x-price :amounts="$option['savings_amounts']" />
                                         </span>
                                     @endisset
                                 </span>
                                 <span class="mt-0.5 block text-sm text-gray-500 dark:text-gray-400">
-                                    {{ $key === 'year'
-                                        ? $option['price'].' billed once a year'
-                                        : 'Billed every month' }}
+                                    @if ($key === 'year')
+                                        <x-price :amounts="$option['price_amounts']" /> billed once a year
+                                    @else
+                                        Billed every month
+                                    @endif
                                 </span>
                             </span>
 
                             <span class="ml-auto shrink-0 text-right tabular-nums">
-                                <span class="block font-semibold text-gray-900 dark:text-white">{{ $option['per_month'] }}</span>
+                                <span class="block font-semibold text-gray-900 dark:text-white"><x-price :amounts="$option['per_month_amounts']" /></span>
                                 <span class="block text-xs text-gray-500 dark:text-gray-400">per month</span>
                             </span>
                         </button>
@@ -79,7 +89,7 @@
                 </div>
 
                 <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
-                    You'll be charged {{ $selected['price'] }} today, then every {{ $selected['interval'] }}. Cancel anytime.
+                    You'll be charged <x-price :amounts="$selected['price_amounts']" /> today, then every {{ $selected['interval'] }}. Cancel anytime.
                 </p>
 
                 <ul class="mt-6 space-y-3">
@@ -106,7 +116,7 @@
                                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
                             </svg>
-                            <span wire:loading.remove wire:target="redirectToCheckout">Subscribe {{ ucfirst($selected['interval']) }}ly · {{ $selected['price'] }}</span>
+                            <span wire:loading.remove wire:target="redirectToCheckout">Subscribe {{ ucfirst($selected['interval']) }}ly · <x-price :amounts="$selected['price_amounts']" /></span>
                             <span wire:loading wire:target="redirectToCheckout">Redirecting…</span>
                         </span>
                     </x-filament::button>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -3,8 +3,16 @@
 @php
     // Real price from config, not hardcoded (an old page invented "£4.99").
     $settings = app(\App\Settings\GeneralSettings::class);
-    $price = app(\App\Services\SubscriptionService::class)->formatPrice('month');
+    $subscription = app(\App\Services\SubscriptionService::class);
+    $price = $subscription->formatPrice('month');
     $interval = 'month';
+
+    // Converted estimates for the premium card (#1636). The hero strapline below
+    // deliberately keeps the charge currency and does not switch: it has no room
+    // for the attribution the ECB's terms require, and an unattributed converted
+    // figure is the one thing we may not show. Readers who want it click through.
+    $priceAmounts = $subscription->displayAmounts($subscription->amountFor('month'));
+    $estimateDate = $subscription->estimateDate();
 @endphp
 
 @section('content')
@@ -254,10 +262,11 @@
                         </a>
                     @else
                         <p class="flex items-baseline gap-2">
-                            <span class="text-headline tabular-nums text-ink">{{ $price }}</span>
+                            <x-price :amounts="$priceAmounts" class="text-headline tabular-nums text-ink" />
                             <span class="text-body text-ink-muted">per {{ $interval }}</span>
                         </p>
                         <p class="mt-3 text-label text-ink-muted">Billed at checkout. Cancel anytime.</p>
+                        <x-currency-switcher :amounts="$priceAmounts" :date="$estimateDate" class="mt-4" />
 
                         <a href="{{ route('filament.app.pages.subscription', ['tenant' => auth()->user()->currentTeam]) }}"
                            class="mt-7 inline-flex min-h-11 w-full items-center justify-center rounded-md bg-registry-green px-5 py-3 text-label text-paper transition-colors duration-150 ease-out-quart hover:bg-registry-green-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-registry-green">
@@ -271,10 +280,11 @@
                     @endif
                 @else
                     <p class="flex items-baseline gap-2">
-                        <span class="text-headline tabular-nums text-ink">{{ $price }}</span>
+                        <x-price :amounts="$priceAmounts" class="text-headline tabular-nums text-ink" />
                         <span class="text-body text-ink-muted">per {{ $interval }}</span>
                     </p>
                     <p class="mt-3 text-label text-ink-muted">Billed at checkout. Cancel anytime.</p>
+                    <x-currency-switcher :amounts="$priceAmounts" :date="$estimateDate" class="mt-4" />
 
                     <a href="{{ route('register') }}"
                        class="mt-7 inline-flex min-h-11 w-full items-center justify-center rounded-md bg-registry-green px-5 py-3 text-label text-paper transition-colors duration-150 ease-out-quart hover:bg-registry-green-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-registry-green">

--- a/resources/views/pages/subscription.blade.php
+++ b/resources/views/pages/subscription.blade.php
@@ -2,8 +2,13 @@
 
 @php
     $settings = app(\App\Settings\GeneralSettings::class);
-    $price = app(\App\Services\SubscriptionService::class)->formatPrice('month');
+    $subscription = app(\App\Services\SubscriptionService::class);
+    $price = $subscription->formatPrice('month');
     $interval = 'month';
+
+    // Converted estimates (#1636). Display only — the charge is always the base.
+    $priceAmounts = $subscription->displayAmounts($subscription->amountFor('month'));
+    $estimateDate = $subscription->estimateDate();
     $trialDays = (int) config('subscription.premium.trial_days', 14);
     $requiresCard = (bool) config('subscription.premium.require_card', true);
     $repo = 'https://github.com/liberu-genealogy/genealogy-laravel';
@@ -138,9 +143,11 @@
                 </p>
 
                 <p class="mt-6 flex items-baseline gap-2">
-                    <span class="text-headline tabular-nums text-ink">{{ $price }}</span>
+                    <x-price :amounts="$priceAmounts" class="text-headline tabular-nums text-ink" />
                     <span class="text-body text-ink-muted">per {{ $interval }}</span>
                 </p>
+
+                <x-currency-switcher :amounts="$priceAmounts" :date="$estimateDate" class="mt-4" />
 
                 <ul class="mt-8 flex flex-col gap-3 text-body text-ink">
                     <li class="flex items-start gap-3 text-ink-muted">

--- a/tests/Feature/CurrencyEstimateTest.php
+++ b/tests/Feature/CurrencyEstimateTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * The converted price estimate on the public price surfaces (#1636).
+ *
+ * The assertions that matter most are the negative ones: with no rates, every
+ * page must render exactly what it rendered before this feature existed.
+ */
+class CurrencyEstimateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const FEED = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        config()->set('cashier.currency', 'usd');
+        config()->set('subscription.premium.amounts.month', 299);
+    }
+
+    public function test_home_carries_every_currency_and_the_switcher(): void
+    {
+        $this->withRates();
+
+        $response = $this->get('/');
+
+        $response->assertOk();
+        // 299 * 0.85388 / 1.1377 = 224.41
+        $response->assertSee('data-gbp="£2.24"', escape: false);
+        $response->assertSee('data-eur="€2.63"', escape: false);
+        $response->assertSee('data-currency-option="GBP"', escape: false);
+    }
+
+    public function test_pricing_page_carries_every_currency_and_the_switcher(): void
+    {
+        $this->withRates();
+
+        $response = $this->get('/subscription');
+
+        $response->assertOk();
+        $response->assertSee('data-gbp="£2.24"', escape: false);
+        $response->assertSee('data-currency-option="EUR"', escape: false);
+    }
+
+    public function test_the_charge_currency_is_what_renders_without_javascript(): void
+    {
+        $this->withRates();
+
+        // The estimate is a text swap done client-side, so the served HTML must
+        // still say what Stripe will charge — not a figure we can't promise.
+        $this->get('/subscription')->assertSee('>$2.99</span>', escape: false);
+    }
+
+    public function test_attribution_names_the_ecb_and_dates_the_rate(): void
+    {
+        // Not decoration: the ECB's terms require citation as source, that a
+        // modified figure say so, and that the rate be dated.
+        $this->withRates(date: '2026-05-29');
+
+        $response = $this->get('/subscription');
+
+        $response->assertSee('European', escape: false);
+        $response->assertSee('Central Bank', escape: false);
+        $response->assertSee('2026-05-29', escape: false);
+        $response->assertSee('cross-rate calculated by us', escape: false);
+    }
+
+    public function test_no_rates_leaves_the_pages_exactly_as_they_were(): void
+    {
+        config()->set('subscription.display_currencies', ['GBP', 'EUR']);
+        Http::fake([self::FEED => Http::response('', 503)]);
+
+        $response = $this->get('/subscription');
+
+        $response->assertOk();
+        $response->assertSee('$2.99');
+        $response->assertDontSee('data-currency-option', escape: false);
+        $response->assertDontSee('data-gbp', escape: false);
+        $response->assertDontSee('European Central Bank', escape: false);
+    }
+
+    public function test_the_feature_off_never_reaches_for_the_feed(): void
+    {
+        // phpunit.xml leaves the currency list empty, so the default posture of the
+        // whole suite is "no outbound request from rendering a page".
+        config()->set('subscription.display_currencies', []);
+        Http::fake();
+
+        $this->get('/subscription')->assertOk();
+
+        Http::assertNothingSent();
+    }
+
+    public function test_the_hero_strapline_keeps_the_charge_currency(): void
+    {
+        // Deliberate: the strapline has no room for the attribution the ECB
+        // requires, and an unattributed converted figure is the one thing we may
+        // not show. Only the card below it switches.
+        $this->withRates();
+
+        $this->get('/')->assertSee('$2.99 per month · Cancel anytime', escape: false);
+    }
+
+    private function withRates(string $date = '2026-07-24'): void
+    {
+        config()->set('subscription.display_currencies', ['GBP', 'EUR']);
+
+        Http::fake([self::FEED => Http::response(<<<XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+            <Cube>
+                <Cube time='{$date}'>
+                    <Cube currency='USD' rate='1.1377'/>
+                    <Cube currency='GBP' rate='0.85388'/>
+                </Cube>
+            </Cube>
+        </gesmes:Envelope>
+        XML)]);
+    }
+}

--- a/tests/Feature/Filament/SubscriptionPageTest.php
+++ b/tests/Feature/Filament/SubscriptionPageTest.php
@@ -8,6 +8,8 @@ use App\Services\SubscriptionService;
 use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -47,12 +49,17 @@ class SubscriptionPageTest extends TestCase
         $this->actingUser();
 
         Livewire::test(SubscriptionPage::class)
-            // Monthly is the default; yearly advertises what it saves.
-            ->assertSee('Save $5.89')
-            ->assertSee('$29.99 billed once a year')
-            ->assertSee('charged $2.99 today')
+            // Monthly is the default; yearly advertises what it saves. Every
+            // money figure is wrapped by <x-price> so it can be switched to
+            // another currency (#1636), which is why these assert across the
+            // closing tag rather than on contiguous text.
+            ->assertSee('$5.89</span>', escape: false)
+            ->assertSee('$29.99</span>', escape: false)
+            ->assertSee('billed once a year')
+            // The charge line tracks the selected interval.
+            ->assertSee('today, then every month')
             ->set('interval', 'year')
-            ->assertSee('charged $29.99 today');
+            ->assertSee('today, then every year');
     }
 
     public function test_page_offers_subscribe_and_never_a_trial_button(): void
@@ -97,10 +104,11 @@ class SubscriptionPageTest extends TestCase
                 'trial_days' => 14,
                 'require_card' => true,
                 'intervals' => [
-                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99', 'per_month' => '$2.99'],
-                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99', 'per_month' => '$2.50', 'savings' => '$5.89', 'savings_percent' => 16],
+                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99', 'per_month' => '$2.99', 'price_amounts' => ['USD' => '$2.99'], 'per_month_amounts' => ['USD' => '$2.99']],
+                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99', 'per_month' => '$2.50', 'savings' => '$5.89', 'savings_percent' => 16, 'price_amounts' => ['USD' => '$29.99'], 'per_month_amounts' => ['USD' => '$2.50'], 'savings_amounts' => ['USD' => '$5.89']],
                 ],
                 'features' => [],
+                'estimate_date' => null,
             ],
         ];
 
@@ -135,10 +143,11 @@ class SubscriptionPageTest extends TestCase
             'premium' => [
                 'name' => 'Premium', 'trial_days' => 14, 'require_card' => true,
                 'intervals' => [
-                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99', 'per_month' => '$2.99'],
-                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99', 'per_month' => '$2.50', 'savings' => '$5.89', 'savings_percent' => 16],
+                    'month' => ['interval' => 'month', 'amount' => 299, 'price' => '$2.99', 'per_month' => '$2.99', 'price_amounts' => ['USD' => '$2.99'], 'per_month_amounts' => ['USD' => '$2.99']],
+                    'year' => ['interval' => 'year', 'amount' => 2999, 'price' => '$29.99', 'per_month' => '$2.50', 'savings' => '$5.89', 'savings_percent' => 16, 'price_amounts' => ['USD' => '$29.99'], 'per_month_amounts' => ['USD' => '$2.50'], 'savings_amounts' => ['USD' => '$5.89']],
                 ],
                 'features' => [],
+                'estimate_date' => null,
             ],
         ]);
         $mockService->allows('requiresCard')->andReturnTrue();
@@ -155,5 +164,40 @@ class SubscriptionPageTest extends TestCase
             ->call('redirectToCheckout')
             ->assertNoRedirect()
             ->assertNotified('Subscription Error');
+    }
+
+    public function test_every_figure_on_the_page_converts_with_the_switcher(): void
+    {
+        // Not just the headline (#1636 ticket 02): a page framed in GBP that still
+        // shows "$2.50 per month" in the same row reads as a bug, so per_month and
+        // the savings pill carry their converted forms too.
+        config([
+            'premium.enabled' => false,
+            'cashier.currency' => 'usd',
+            'subscription.premium.amounts.month' => 299,
+            'subscription.premium.amounts.year' => 2999,
+            'subscription.display_currencies' => ['GBP'],
+        ]);
+        Cache::flush();
+        Http::fake([
+            'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml' => Http::response(
+                '<?xml version="1.0" encoding="UTF-8"?>'.
+                '<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">'.
+                "<Cube><Cube time='2026-07-24'>".
+                "<Cube currency='USD' rate='1.1377'/><Cube currency='GBP' rate='0.85388'/>".
+                '</Cube></Cube></gesmes:Envelope>'
+            ),
+        ]);
+        $this->actingUser();
+
+        Livewire::test(SubscriptionPage::class)
+            // headline monthly: 299 * 0.85388 / 1.1377 = 224.41
+            ->assertSee('data-gbp="£2.24"', escape: false)
+            // per-month equivalent of the yearly plan: 2999/12 = 250 -> 187.63
+            ->assertSee('data-gbp="£1.88"', escape: false)
+            // the savings pill: 3588 - 2999 = 589 -> 442.06
+            ->assertSee('data-gbp="£4.42"', escape: false)
+            ->assertSee('data-currency-option="GBP"', escape: false)
+            ->assertSee('Central Bank');
     }
 }

--- a/tests/Unit/Services/ExchangeRatesTest.php
+++ b/tests/Unit/Services/ExchangeRatesTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\ExchangeRates;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ExchangeRatesTest extends TestCase
+{
+    private const FEED = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        config()->set('subscription.display_currencies', ['GBP', 'EUR']);
+    }
+
+    /**
+     * The one test that matters. Rates are quoted as units-per-EUR, so converting
+     * out of USD means dividing by USD's rate and multiplying by the target's.
+     * Both inversions produce plausible-looking money and neither throws, so the
+     * assertion pins real figures from the 2026-07-24 feed rather than a shape.
+     */
+    public function test_converts_out_of_usd_via_the_euro_cross_rate(): void
+    {
+        Http::fake([self::FEED => Http::response($this->feed())]);
+
+        $estimate = (new ExchangeRates)->estimate(2999, 'usd');
+
+        // 2999 * 0.85388 / 1.1377 = 2250.84
+        $this->assertSame(2251, $estimate['amounts']['GBP']);
+        // 2999 * 1 / 1.1377 = 2636.02
+        $this->assertSame(2636, $estimate['amounts']['EUR']);
+
+        // Inverting the cross-rate gives 2999 * 1.1377 / 0.85388 = 3995.8, and
+        // multiplying by USD's rate instead gives 3412 — both look like money.
+        $this->assertNotSame(3996, $estimate['amounts']['GBP']);
+        $this->assertNotSame(3412, $estimate['amounts']['EUR']);
+    }
+
+    public function test_rounds_the_amount_once_at_the_end(): void
+    {
+        Http::fake([self::FEED => Http::response($this->feed())]);
+
+        // 299 * 0.85388 / 1.1377 = 224.41 -> 224, not 299 * round(0.75) = 224.25
+        // and not a rate rounded to 0.8 (which would give 239).
+        $this->assertSame(224, (new ExchangeRates)->estimate(299, 'usd')['amounts']['GBP']);
+    }
+
+    public function test_exposes_the_feeds_own_rate_date_not_todays(): void
+    {
+        // A Saturday fetch serves Friday's rates at HTTP 200. The surfaces have to
+        // print this date, so it must survive rather than be replaced with now().
+        Http::fake([self::FEED => Http::response($this->feed(date: '2026-05-29'))]);
+
+        $this->assertSame('2026-05-29', (new ExchangeRates)->estimate(2999, 'usd')['date']);
+    }
+
+    public function test_omits_the_base_currency_from_its_own_estimate(): void
+    {
+        config()->set('subscription.display_currencies', ['GBP', 'USD']);
+        Http::fake([self::FEED => Http::response($this->feed())]);
+
+        $this->assertSame(['GBP'], array_keys((new ExchangeRates)->estimate(2999, 'usd')['amounts']));
+    }
+
+    public function test_skips_a_display_currency_the_feed_does_not_quote(): void
+    {
+        // The quoted set is not fixed — BGN vanished when Bulgaria joined the euro.
+        config()->set('subscription.display_currencies', ['GBP', 'BGN']);
+        Http::fake([self::FEED => Http::response($this->feed())]);
+
+        $this->assertSame(['GBP'], array_keys((new ExchangeRates)->estimate(2999, 'usd')['amounts']));
+    }
+
+    public function test_returns_null_when_the_base_currency_is_not_quoted(): void
+    {
+        Http::fake([self::FEED => Http::response($this->feed())]);
+
+        $this->assertNull((new ExchangeRates)->estimate(2999, 'zwl'));
+    }
+
+    public function test_takes_the_newest_dated_cube_when_the_feed_carries_several(): void
+    {
+        // The daily file has only ever carried one, but the ECB publishes no schema
+        // promising that, and the history files use this identical shape.
+        Http::fake([self::FEED => Http::response($this->multiDayFeed())]);
+
+        $this->assertSame('2026-07-24', (new ExchangeRates)->estimate(2999, 'usd')['date']);
+    }
+
+    public function test_returns_null_when_the_feed_errors(): void
+    {
+        Http::fake([self::FEED => Http::response('', 503)]);
+
+        $this->assertNull((new ExchangeRates)->estimate(2999, 'usd'));
+    }
+
+    public function test_returns_null_when_the_body_is_html_not_xml(): void
+    {
+        // A bad path on this host answers 404 with an HTML error page, so a status
+        // check alone would happily parse a web page as rates.
+        Http::fake([self::FEED => Http::response('<html><body>Not found</body></html>', 404)]);
+
+        $this->assertNull((new ExchangeRates)->estimate(2999, 'usd'));
+    }
+
+    public function test_returns_null_when_no_display_currencies_are_configured(): void
+    {
+        config()->set('subscription.display_currencies', []);
+        Http::fake([self::FEED => Http::response($this->feed())]);
+
+        $this->assertNull((new ExchangeRates)->estimate(2999, 'usd'));
+    }
+
+    public function test_fetches_once_a_day_not_once_a_call(): void
+    {
+        Http::fake([self::FEED => Http::response($this->feed())]);
+
+        $rates = new ExchangeRates;
+        $rates->estimate(2999, 'usd');
+        $rates->estimate(299, 'usd');
+
+        Http::assertSentCount(1);
+    }
+
+    public function test_does_not_refetch_after_a_failure(): void
+    {
+        // Cache::remember treats a null return as a miss, which would put a live
+        // HTTP call on every page view for as long as the feed stayed down.
+        Http::fake([self::FEED => Http::response('', 503)]);
+
+        $rates = new ExchangeRates;
+        $rates->estimate(2999, 'usd');
+        $rates->estimate(2999, 'usd');
+
+        Http::assertSentCount(1);
+    }
+
+    private function feed(string $date = '2026-07-24'): string
+    {
+        return <<<XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+            <gesmes:subject>Reference rates</gesmes:subject>
+            <Cube>
+                <Cube time='{$date}'>
+                    <Cube currency='USD' rate='1.1377'/>
+                    <Cube currency='GBP' rate='0.85388'/>
+                    <Cube currency='JPY' rate='186.38'/>
+                </Cube>
+            </Cube>
+        </gesmes:Envelope>
+        XML;
+    }
+
+    private function multiDayFeed(): string
+    {
+        return <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+            <Cube>
+                <Cube time='2026-07-23'>
+                    <Cube currency='USD' rate='1.2000'/>
+                    <Cube currency='GBP' rate='0.90000'/>
+                </Cube>
+                <Cube time='2026-07-24'>
+                    <Cube currency='USD' rate='1.1377'/>
+                    <Cube currency='GBP' rate='0.85388'/>
+                </Cube>
+            </Cube>
+        </gesmes:Envelope>
+        XML;
+    }
+}


### PR DESCRIPTION
Closes #1636.

The subscription price is shown in the reader's choice of USD, GBP or EUR. **Display only** — Stripe still charges `cashier.currency`, and the page says so next to every price.

## What changed

**`App\Services\ExchangeRates`** — converts a minor-unit amount out of the charge currency into each configured display currency, using the ECB's daily euro reference feed. Returns `null` whenever there is nothing honest to show, and callers render the price alone.

**Three price surfaces** — the home premium card, the public pricing page, and the Filament subscription page. `<x-price>` renders every currency's figure as `data-*` on one span, with the **charge currency as the element's text**; `<x-currency-switcher>` renders the buttons, the attribution and the script, and renders nothing at all when there are no rates. The choice lives in `localStorage` — no `users.currency` column, no cookie, no server round-trip, no geo-IP guessing.

Every figure converts, not just the headline: a page framed in GBP that still showed "$2.50 per month" in the same row would read as a bug, so `per_month` and the savings pill carry converted forms too.

## Things worth a reviewer's attention

- **The feed's quirks are load-bearing, and the tests pin each one.** Rates are quoted units-per-EUR, so crossing out of USD divides by USD's rate and multiplies by the target's — both inversions produce plausible-looking money and neither throws. Weekends and TARGET holidays are not failures: the feed answers 200 with the last business day's rates and an older `time`, so the feed's own date is what gets displayed. The default namespace is on `ecb.int`, not `ecb.europa.eu`; the wrong URI matches nothing silently. A 404 on this host returns an HTML error page, so the body decides whether we got rates, not the status.
- **The attribution line is required, not decoration.** The ECB must be cited as source, a figure we modified must say so, and the rate must be dated.
- **`phpunit.xml` sets `SUBSCRIPTION_DISPLAY_CURRENCIES=\"\"`.** Without it, every existing test that renders a price page would have made a live HTTP request. `estimate()` also checks the configured currencies before fetching, so an install that leaves the list empty never touches the network either.
- **A `MutationObserver` re-applies the choice rather than a Livewire hook.** Livewire morphs the Filament page back to server HTML — always the charge currency — which would silently revert the reader's pick. The observer is version-proof where hook names are not, and the write is guarded on \`textContent !== value\` so it cannot re-trigger itself.
- **The hero strapline deliberately keeps the charge currency and does not switch.** It has no room for the attribution line, and an unattributed converted figure is the one thing we may not show. The card below it carries the switcher instead.
- Two assertions in `SubscriptionPageTest` moved off contiguous text — money figures now sit inside a span, so `Save $5.89` is no longer a substring. The charge line now asserts `today, then every {month|year}`, which tests the interval-tracking intent more directly than the old string did.

## Configuration

`SUBSCRIPTION_DISPLAY_CURRENCIES=GBP,EUR` (default), documented in `.env.example`. Empty disables the feature entirely.

## Verification

20 new tests. Full suite **1019 passed**, 12 skipped, 2357 assertions. Pint clean, PHPStan clean.

Revert-sensitivity checked by hand: inverting the cross-rate in the source fails 2 tests.

**Not covered by tests, wants a human:** a live walk-through — click GBP, confirm the figures swap on all three surfaces, that the choice survives a reload, and that it survives Livewire re-rendering the Filament interval rows. The tests assert the HTML carries the right data; they never execute the script.