### PR TITLE
feat(subscription): make the paywall opt-in behind an env flag (#1638)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,13 @@ AFFILIATE_ENABLED=true
 # Qualified (paid) referrals required to earn one free month. Repeatable, no cap.
 AFFILIATE_REFERRALS_PER_FREE_MONTH=5
 
+# The paywall (issue #1638). On, the whole app panel requires an active
+# subscription and every registration goes straight to checkout; off, the panel is
+# open and only the per-resource premium gates apply. The code default is false so
+# a fresh checkout isn't paywalled — this file ships it on because this deployment
+# sells access. Turning it off does NOT refund or downgrade anyone.
+SUBSCRIPTION_PAYWALL_ENABLED=true
+
 # Require a card before granting premium access. When true (default), the no-card
 # trial is disabled and premium is only reachable via a card checkout (issue #1614).
 SUBSCRIPTION_REQUIRE_CARD=true

--- a/app/Console/Commands/PremiumDoctor.php
+++ b/app/Console/Commands/PremiumDoctor.php
@@ -32,6 +32,13 @@ class PremiumDoctor extends Command
         $this->info('Premium funnel configuration (#1635)');
         $this->newLine();
 
+        // 0 — asked first because it decides whether any of the rest is load-bearing.
+        // Warn-only: an open app is a valid posture, just rarely the intended one
+        // for someone running this command (#1638).
+        $this->warnCheck('paywall on (app panel requires a subscription)',
+            (bool) config('subscription.paywall_enabled'),
+            'Set SUBSCRIPTION_PAYWALL_ENABLED=true — off, the panel is open and registration skips checkout.');
+
         // 1
         $this->hard('premium.enabled is false (funnel reachable)',
             config('premium.enabled') === false,

--- a/app/Http/Middleware/EnsureSubscribed.php
+++ b/app/Http/Middleware/EnsureSubscribed.php
@@ -8,7 +8,8 @@ use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Paywall gate (upstream #1635): the whole `app` panel is subscription-only.
+ * Paywall gate (upstream #1635, made opt-in by #1638): with
+ * `subscription.paywall_enabled` on, the whole `app` panel is subscription-only.
  *
  * A non-subscriber is redirected to the subscription page from every panel
  * surface EXCEPT the ones they need in order to pay or leave. The redirect is
@@ -36,6 +37,12 @@ class EnsureSubscribed
 
     public function handle(Request $request, Closure $next): Response
     {
+        // Opt-in (#1638). Off, the panel is open and only the per-resource
+        // premium gates apply; on, this is the whole paywall.
+        if (! config('subscription.paywall_enabled')) {
+            return $next($request);
+        }
+
         if (! $request->routeIs(...self::ALLOWLIST)) {
             PremiumRequiredException::unlessPremium();
         }

--- a/app/Http/Responses/Auth/RegisterResponse.php
+++ b/app/Http/Responses/Auth/RegisterResponse.php
@@ -29,12 +29,16 @@ class RegisterResponse implements RegisterResponseContract
             return redirect('/app/new');
         }
 
-        // The app is subscription-only (#1635): every new account must subscribe
-        // before it can use anything, so send them straight to checkout — unless
-        // they already have access (e.g. an affiliate comp), in which case the
-        // app is reachable. currentTeam exists here because CreateNewUser
+        // Under the paywall (#1635, opt-in since #1638) every new account must
+        // subscribe before it can use anything, so send them straight to checkout
+        // — unless they already have access (e.g. an affiliate comp), in which
+        // case the app is reachable. currentTeam exists here because CreateNewUser
         // creates + switches a personal team during registration.
-        if (! $user->isPremium() && $user->currentTeam) {
+        //
+        // The same flag as EnsureSubscribed on purpose: a gate that redirected new
+        // accounts at a checkout they don't need, on an app they can already use,
+        // would be half a switch.
+        if (config('subscription.paywall_enabled') && ! $user->isPremium() && $user->currentTeam) {
             return redirect()->route('filament.app.pages.subscription', ['tenant' => $user->currentTeam]);
         }
 

--- a/config/subscription.php
+++ b/config/subscription.php
@@ -14,6 +14,15 @@ return [
         PREG_SPLIT_NO_EMPTY,
     ),
 
+    // The paywall (#1638): with this on, the whole app panel requires an active
+    // subscription and every new registration goes straight to checkout — the
+    // behaviour #1635 shipped. With it off, the panel is open and registration
+    // lands in the app; the per-resource premium gates still apply.
+    //
+    // Defaults to FALSE so a fresh checkout of this open-source project is not
+    // paywalled. Deployments that sell access opt in — .env.example ships it on.
+    'paywall_enabled' => (bool) env('SUBSCRIPTION_PAYWALL_ENABLED', false),
+
     'premium' => [
         // Require a card before granting premium access. When true, the no-card
         // local-trial path is unavailable and the only route to premium is a

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -47,5 +47,8 @@
              feed (#1636). Tests that want the estimate set the config themselves
              and fake the HTTP call. -->
         <env name="SUBSCRIPTION_DISPLAY_CURRENCIES" value=""/>
+        <!-- The suite exercises the paywalled posture this deployment ships
+             (#1638). Tests for the open posture turn it off themselves. -->
+        <env name="SUBSCRIPTION_PAYWALL_ENABLED" value="true"/>
     </php>
 </phpunit>

--- a/tests/Feature/Filament/PaywallGateTest.php
+++ b/tests/Feature/Filament/PaywallGateTest.php
@@ -69,4 +69,28 @@ class PaywallGateTest extends TestCase
 
         $this->get(route('filament.app.pages.dashboard', ['tenant' => $user->currentTeam]))->assertOk();
     }
+
+    public function test_the_paywall_is_opt_in_and_off_leaves_the_panel_open(): void
+    {
+        // #1638 made the gate a flag defaulting to false, so a fresh checkout of
+        // this open-source project is not paywalled. Off, the surfaces #1635
+        // closed are reachable again by any authenticated user.
+        config(['subscription.paywall_enabled' => false]);
+        $user = $this->actingAsNonSubscriber();
+
+        $this->get(route('filament.app.pages.dashboard', ['tenant' => $user->currentTeam]))->assertOk();
+        $this->get(route('filament.app.resources.people.index', ['tenant' => $user->currentTeam]))->assertOk();
+    }
+
+    public function test_the_flag_off_does_not_open_the_per_resource_premium_gates(): void
+    {
+        // The paywall and the premium tier are separate concerns: turning the
+        // paywall off opens the panel, not the DNA tools that were premium-only
+        // long before #1635 closed everything.
+        config(['subscription.paywall_enabled' => false]);
+        $user = $this->actingAsNonSubscriber();
+
+        $this->get(route('filament.app.resources.dnas.index', ['tenant' => $user->currentTeam]))
+            ->assertRedirect(route('filament.app.pages.subscription', ['tenant' => $user->currentTeam]));
+    }
 }

--- a/tests/Feature/RegistrationRedirectTest.php
+++ b/tests/Feature/RegistrationRedirectTest.php
@@ -67,4 +67,14 @@ class RegistrationRedirectTest extends TestCase
 
         return (new RegisterResponse)->toResponse($request);
     }
+
+    public function test_the_paywall_off_lands_a_new_account_in_the_app(): void
+    {
+        // #1638: the same flag as EnsureSubscribed. With the panel open, shoving a
+        // new account at a checkout it doesn't need would be half a switch.
+        config(['subscription.paywall_enabled' => false]);
+        $user = User::factory()->withPersonalTeam()->create(['is_premium' => false, 'trial_ends_at' => null]);
+
+        $this->assertStringNotContainsString('/subscription', $this->responseFor($user)->getTargetUrl());
+    }
 }


### PR DESCRIPTION
Closes #1638.

The paywall #1635 shipped is unconditional. This puts it behind `SUBSCRIPTION_PAYWALL_ENABLED`.

## Behaviour

**Flag on** — what `main` does today: the whole app panel requires an active subscription, and every registration goes straight to checkout.

**Flag off** — the panel is open to any authenticated user and registration lands in the app.

The code default is **false**, so a fresh checkout of an open-source project is not paywalled. `.env.example` ships it **on**, because this deployment sells access — so nothing changes here unless someone sets it.

## Scope of the flag

It gates **both halves** of the paywall: `EnsureSubscribed` closing the panel, and `RegisterResponse` sending new accounts to checkout. A switch that turned off one but not the other would redirect new accounts at a checkout they don't need, on an app they can already use.

It does **not** open the per-resource premium gates. The DNA tools were premium long before #1635 closed everything — the paywall and the premium tier stay separate concerns, and `test_the_flag_off_does_not_open_the_per_resource_premium_gates` holds that line.

## Notes

- **No new allowlist entries.** The issue floated exempting the dashboard and GEDCOM export; that was considered and dropped, so #1635's allowlist is unchanged — subscription page, trial-expired, tenant registration, logout.
- **`PREMIUM_ENABLED` is a different switch and was not reused.** Its meaning is inverted (`true` = everyone is premium, i.e. gate off), and `premium:doctor` treats `PREMIUM_ENABLED=false` as the correct production setting. Overloading it would have broken #1635's intent.
- **`premium:doctor` gains a warn-only check** for the new flag, asked first because it decides whether the rest of the report is load-bearing. Without it, a green doctor next to an open app is a plausible misdiagnosis.
- **`phpunit.xml` sets the flag on**, so the suite keeps exercising the posture this deployment ships. The tests for the open posture turn it off themselves.
- Turning the flag off does not refund, downgrade or otherwise touch existing subscribers.

## Verification

3 new tests. Full suite **1002 passed**, 12 skipped, 2322 assertions. Pint clean, PHPStan clean.

Revert-sensitivity checked by hand: removing the flag check from both call sites fails 2 of the 3.